### PR TITLE
quickfix: helm use --set-string instead of --set

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -67,7 +67,7 @@ runs:
           --namespace ${KUBE_NAMESPACE} \
           --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
           --set image.tag="${GIT_SHA}" \
-          --set ingress.annotations."nginx\.ingress\.kubernetes\.io/whitelist-source-range"="$ALLOW_LIST" \
+          --set-string ingress.annotations."nginx\.ingress\.kubernetes\.io/whitelist-source-range"="$ALLOW_LIST" \
           --set spring.profile="main" \
           --values ${VALUES_FILE} \
           --install \

--- a/.github/actions/deploy_branch/action.yml
+++ b/.github/actions/deploy_branch/action.yml
@@ -99,7 +99,7 @@ runs:
           --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
           --set image.tag="${GIT_SHA}" \
           --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$identifier" \
-          --set ingress.annotations."nginx\.ingress\.kubernetes\.io/whitelist-source-range"="$ALLOW_LIST" \
+          --set-string ingress.annotations."nginx\.ingress\.kubernetes\.io/whitelist-source-range"="$ALLOW_LIST" \
           --set ingress.hosts="{$release_host}" \
           --set spring.profile="$SPRING_PROFILE" \
           --values ${VALUES_FILE} \


### PR DESCRIPTION
## What

Error: `failed parsing --set data: value name nested level is greater than maximum supported nested level of 30`

Helm still interpret the --set value as nested too deeply — especially when the value contains a large number of comma-separated IPs

The --set-string flag treats the value as a literal string, avoiding complex type inference and nesting

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
