### PR TITLE
Adds submitted to SubmissionFields and total_value to ClaimFields

### DIFF
--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -507,6 +507,9 @@ components:
         number_of_claims:
           type: integer
           description: Number of claims in this submission.
+        submitted:
+          type: date
+          description: Date the submission was submitted
 
     ClaimPost:
       allOf:

--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -595,6 +595,8 @@ components:
           type: string
         referral_source:
           type: string
+        total_value:
+          type: number
         client_forename:
           type: string
         client_surname:

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapper.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapper.java
@@ -1,5 +1,8 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.mapper;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -36,7 +39,19 @@ public interface SubmissionMapper {
    * @return mapped {@link SubmissionFields}
    */
   @Mapping(target = "submissionId", source = "id")
+  @Mapping(target = "submitted", source = "createdOn")
   SubmissionFields toSubmissionFields(Submission submission);
+
+  /**
+   * Converts an instant to a LocalDate.
+   *
+   * @param instant the instant to convert
+   * @return the converted LocalDate
+   */
+  default LocalDate mapInstantToLocalDate(Instant instant) {
+    return instant != null ? instant.atZone(ZoneId.systemDefault()).toLocalDate() : null;
+  }
+
 
   /**
    * Update a {@link Submission} entity from a {@link SubmissionPatch}.

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
@@ -166,6 +166,7 @@ class ClaimMapperTest {
     assertEquals(entity.getMediationTimeMinutes(), fields.getMediationTimeMinutes());
     assertEquals(entity.getOutreachLocation(), fields.getOutreachLocation());
     assertEquals(entity.getReferralSource(), fields.getReferralSource());
+    assertEquals(entity.getTotalValue(), fields.getTotalValue());
   }
 
   @Test

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapperTest.java
@@ -2,6 +2,8 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,7 +17,9 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionPost;
 
 @ExtendWith(MockitoExtension.class)
 class SubmissionMapperTest {
-  @InjectMocks private SubmissionMapper submissionMapper = new SubmissionMapperImpl();
+
+  @InjectMocks
+  private SubmissionMapper submissionMapper = new SubmissionMapperImpl();
 
   @Spy
   private GlobalStringMapper globalStringMapper = new GlobalStringMapperImpl();
@@ -25,13 +29,13 @@ class SubmissionMapperTest {
     UUID id = UUID.randomUUID();
     UUID bulkId = UUID.randomUUID();
     SubmissionPost post = new SubmissionPost()
-                              .submissionId(id)
-                              .bulkSubmissionId(bulkId)
-                              .officeAccountNumber("12345")
-                              .submissionPeriod("2025-07")
-                              .areaOfLaw("crime")
-                              .isNilSubmission(false)
-                              .numberOfClaims(1);
+        .submissionId(id)
+        .bulkSubmissionId(bulkId)
+        .officeAccountNumber("12345")
+        .submissionPeriod("2025-07")
+        .areaOfLaw("crime")
+        .isNilSubmission(false)
+        .numberOfClaims(1);
 
     Submission result = submissionMapper.toSubmission(post);
 
@@ -56,17 +60,21 @@ class SubmissionMapperTest {
             .areaOfLaw("crime")
             .isNilSubmission(false)
             .numberOfClaims(2)
+            .createdOn(LocalDate.of(2025, 5, 20).atStartOfDay(ZoneId.systemDefault()).toInstant())
             .build();
 
     SubmissionFields result = submissionMapper.toSubmissionFields(submission);
 
     assertThat(result.getSubmissionId()).isEqualTo(id);
     assertThat(result.getOfficeAccountNumber()).isEqualTo("12345");
+    assertThat(result.getSubmissionPeriod()).isEqualTo("2025-07");
+    assertThat(result.getSubmitted()).isEqualTo(LocalDate.of(2025, 5, 20));
   }
 
   @Test
   void shouldUpdateSubmissionFromPatch() {
-    Submission submission = Submission.builder().scheduleNumber("123").isNilSubmission(false).build();
+    Submission submission =
+        Submission.builder().scheduleNumber("123").isNilSubmission(false).build();
     SubmissionPatch patch = new SubmissionPatch().scheduleNumber("456").isNilSubmission(true);
 
     submissionMapper.updateSubmissionFromPatch(patch, submission);


### PR DESCRIPTION
## What

- Added `total_value` to the `ClaimFields` object. 
- Added `submitted` to the `SubmissionFields` object.

This is required for work as part of [CCMSPUI-808](https://dsdmoj.atlassian.net/browse/CCMSPUI-808)

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[CCMSPUI-808]: https://dsdmoj.atlassian.net/browse/CCMSPUI-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ