### PR TITLE
patch/DSTEW-287/fix-migration-script-v11

### DIFF
--- a/claims-data/service/src/main/resources/db/migration/V10__remove_number_of_matter_starts_from_matter_start_table.sql
+++ b/claims-data/service/src/main/resources/db/migration/V10__remove_number_of_matter_starts_from_matter_start_table.sql
@@ -1,2 +1,0 @@
-ALTER TABLE matter_start
-DROP COLUMN IF EXISTS number_of_matter_starts;

--- a/claims-data/service/src/main/resources/db/migration/V11__remove_number_of_matter_starts_from_matter_start_table.sql
+++ b/claims-data/service/src/main/resources/db/migration/V11__remove_number_of_matter_starts_from_matter_start_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE matter_start
+DROP COLUMN IF EXISTS number_of_matter_starts;


### PR DESCRIPTION
- Renamed V10 migration script to V11 (drop number_of_matter_starts on matter_start table). This is to fix the conflict noticed on deployed UAT against V10 migration.

## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-287)

We noticed we went out of synch with db migrations being deployed. This is to fix the conflict of a duplicated V10 by creating a new V11.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
