### PR TITLE
Remove "format: date" from multiple fields in the open-api-specification.yml file

### DIFF
--- a/claims-data/api/build.gradle
+++ b/claims-data/api/build.gradle
@@ -12,7 +12,7 @@ repositories {
 //Remove the line below when the laa-ccms-spring-boot-gradle-plugin is upgraded
 ext['tomcat.version'] = '10.1.44'
 // Upgrade to fix CVE-2025-55163
-ext['netty.version'] = '4.1.124.Final'
+ext['netty.version'] = '4.1.125.Final'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -680,12 +680,10 @@ components:
           type: string
         case_start_date:
           type: string
-          format: date
-          description: Date the case was started (format YYYY-MM-DD)
+          description: Date the case was started (format DD/MM/YYYY)
         case_concluded_date:
           type: string
-          format: date
-          description: Date the case was concluded (format YYYY-MM-DD)
+          description: Date the case was concluded (format DD/MM/YYYY)
         matter_type_code:
           type: string
         crime_matter_type_code:
@@ -702,8 +700,7 @@ components:
           type: string
         representation_order_date:
           type: string
-          format: date
-          description: Date the rep order was created (format YYYY-MM-DD)
+          description: Date the rep order was created (format DD/MM/YYYY)
         suspects_defendants_count:
           type: integer
         police_station_court_attendances_count:
@@ -738,8 +735,7 @@ components:
           type: string
         client_date_of_birth:
           type: string
-          format: date
-          description: Client's date of birth (format YYYY-MM-DD)
+          description: Client's date of birth (format DD/MM/YYYY)
         unique_client_number:
           type: string
         client_postcode:
@@ -766,8 +762,7 @@ components:
           type: string
         client_2_date_of_birth:
           type: string
-          format: date
-          description: Client 2's date of birth (format YYYY-MM-DD)
+          description: Client 2's date of birth (format DD/MM/YYYY)
         client_2_ucn:
           type: string
         client_2_postcode:
@@ -806,8 +801,7 @@ components:
           type: string
         transfer_date:
           type: string
-          format: date
-          description: Transfer Date (format YYYY-MM-DD)
+          description: Transfer Date (format DD/MM/YYYY)
         exemption_criteria_satisfied:
           type: string
         exceptional_case_funding_reference:
@@ -864,8 +858,7 @@ components:
           type: boolean
         surgery_date:
           type: string
-          format: date
-          description: Surgery Date (format YYYY-MM-DD)
+          description: Surgery Date (format DD/MM/YYYY)
         surgery_clients_count:
           type: integer
         surgery_matters_count:
@@ -909,7 +902,6 @@ components:
           type: string
         caseStartDate:
           type: string
-          format: date
         caseId:
           type: string
         caseStageLevel:
@@ -926,7 +918,6 @@ components:
           type: string
         clientDateOfBirth:
           type: string
-          format: date
         ucn:
           type: string
         claRefNumber:
@@ -943,7 +934,6 @@ components:
           type: string
         workConcludedDate:
           type: string
-          format: date
         adviceTime:
           type: integer
         travelTime:
@@ -1008,7 +998,6 @@ components:
           type: string
         transferDate:
           type: string
-          format: date
         detentionTravelWaitingCosts:
           type: number
           format: bigDecimal
@@ -1046,7 +1035,6 @@ components:
           type: string
         surgeryDate:
           type: string
-          format: date
         lineNumber:
           type: string
         crimeMatterType:
@@ -1055,7 +1043,6 @@ components:
           type: string
         repOrderDate:
           type: string
-          format: date
         noOfSuspects:
           type: integer
         noOfPoliceStation:
@@ -1090,7 +1077,6 @@ components:
           type: string
         client2DateOfBirth:
           type: string
-          format: date
         client2Ucn:
           type: string
         client2PostCode:
@@ -1124,7 +1110,6 @@ components:
           format: bigDecimal
         medConcludedDate:
           type: string
-          format: date
     MatterStartPost:
       allOf:
         - $ref: '#/components/schemas/MatterStartFields'

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -31,7 +31,7 @@ jacocoTestCoverageVerification {
 //Remove the line below when the laa-ccms-spring-boot-gradle-plugin is upgraded
 ext['tomcat.version'] = '10.1.44'
 // Upgrade to fix CVE-2025-55163
-ext['netty.version'] = '4.1.124.Final'
+ext['netty.version'] = '4.1.125.Final'
 ext['commons-lang3.version'] = '3.18.0'
 
 dependencies {

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Claim.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Claim.java
@@ -9,7 +9,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -58,11 +57,11 @@ public class Claim {
 
   @NotNull
   @Column(nullable = false)
-  private LocalDate caseStartDate;
+  private String caseStartDate;
 
   @NotNull
   @Column(nullable = false)
-  private LocalDate caseConcludedDate;
+  private String caseConcludedDate;
 
   @NotNull
   @Column(nullable = false)
@@ -80,7 +79,7 @@ public class Claim {
 
   private String deliveryLocation;
 
-  private LocalDate representationOrderDate;
+  private String representationOrderDate;
 
   private Integer suspectsDefendantsCount;
 

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Claim.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Claim.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,11 +59,13 @@ public class Claim {
 
   @NotNull
   @Column(nullable = false)
-  private String caseStartDate;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
+  private LocalDate caseStartDate;
 
   @NotNull
   @Column(nullable = false)
-  private String caseConcludedDate;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
+  private LocalDate caseConcludedDate;
 
   @NotNull
   @Column(nullable = false)
@@ -79,7 +83,8 @@ public class Claim {
 
   private String deliveryLocation;
 
-  private String representationOrderDate;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
+  private LocalDate representationOrderDate;
 
   private Integer suspectsDefendantsCount;
 

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Client.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Client.java
@@ -9,7 +9,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,7 +39,7 @@ public class Client {
 
   private String clientSurname;
 
-  private LocalDate clientDateOfBirth;
+  private String clientDateOfBirth;
 
   private String uniqueClientNumber;
 
@@ -69,7 +68,7 @@ public class Client {
   private String client2Surname;
 
   @Column(name = "client_2_date_of_birth")
-  private LocalDate client2DateOfBirth;
+  private String client2DateOfBirth;
 
   @Column(name = "client_2_ucn")
   private String client2Ucn;

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Client.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Client.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,7 +41,8 @@ public class Client {
 
   private String clientSurname;
 
-  private String clientDateOfBirth;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
+  private LocalDate clientDateOfBirth;
 
   private String uniqueClientNumber;
 
@@ -68,7 +71,8 @@ public class Client {
   private String client2Surname;
 
   @Column(name = "client_2_date_of_birth")
-  private String client2DateOfBirth;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
+  private LocalDate client2DateOfBirth;
 
   @Column(name = "client_2_ucn")
   private String client2Ucn;

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimControllerTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimControllerTest.java
@@ -89,8 +89,8 @@ class ClaimControllerTest {
             .lineNumber(42)
             .caseReferenceNumber("CRN-777")
             .uniqueFileNumber("UFN-777")
-            .caseStartDate("2025-06-01")
-            .caseConcludedDate("2025-06-30")
+            .caseStartDate("01/06/2025")
+            .caseConcludedDate("30/06/2025")
             .matterTypeCode("MAT77")
             .outcomeCode("OUT77");
     when(claimService.getClaim(submissionId, claimId)).thenReturn(claimFields);

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimControllerTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimControllerTest.java
@@ -89,8 +89,8 @@ class ClaimControllerTest {
             .lineNumber(42)
             .caseReferenceNumber("CRN-777")
             .uniqueFileNumber("UFN-777")
-            .caseStartDate(java.time.LocalDate.parse("2025-06-01"))
-            .caseConcludedDate(java.time.LocalDate.parse("2025-06-30"))
+            .caseStartDate("2025-06-01")
+            .caseConcludedDate("2025-06-30")
             .matterTypeCode("MAT77")
             .outcomeCode("OUT77");
     when(claimService.getClaim(submissionId, claimId)).thenReturn(claimFields);

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,8 +39,8 @@ class ClaimMapperTest {
             .lineNumber(5)
             .caseReferenceNumber("CASE001")
             .uniqueFileNumber("UFN123")
-            .caseStartDate(LocalDate.now())
-            .caseConcludedDate(LocalDate.now().plusDays(1))
+            .caseStartDate("01/01/2020")
+            .caseConcludedDate("02/01/2020")
             .matterTypeCode("MTC")
             .crimeMatterTypeCode("CMTC")
             .feeSchemeCode("FSC")
@@ -49,7 +48,7 @@ class ClaimMapperTest {
             .procurementAreaCode("PAC")
             .accessPointCode("APC")
             .deliveryLocation("DEL")
-            .representationOrderDate(LocalDate.now().minusDays(2))
+            .representationOrderDate("01/01/2020")
             .suspectsDefendantsCount(3)
             .policeStationCourtAttendancesCount(4)
             .policeStationCourtPrisonId("PSCPI")
@@ -113,8 +112,8 @@ class ClaimMapperTest {
             .lineNumber(5)
             .caseReferenceNumber("CASE001")
             .uniqueFileNumber("UFN123")
-            .caseStartDate(LocalDate.now())
-            .caseConcludedDate(LocalDate.now().plusDays(1))
+            .caseStartDate("01/01/2020")
+            .caseConcludedDate("02/01/2020")
             .matterTypeCode("MTC")
             .crimeMatterTypeCode("CMTC")
             .feeSchemeCode("FSC")
@@ -122,7 +121,7 @@ class ClaimMapperTest {
             .procurementAreaCode("PAC")
             .accessPointCode("APC")
             .deliveryLocation("DEL")
-            .representationOrderDate(LocalDate.now().minusDays(2))
+            .representationOrderDate("01/01/2020")
             .suspectsDefendantsCount(3)
             .policeStationCourtAttendancesCount(4)
             .policeStationCourtPrisonId("PSCPI")

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,8 +73,12 @@ class ClaimMapperTest {
     assertEquals(post.getLineNumber(), entity.getLineNumber());
     assertEquals(post.getCaseReferenceNumber(), entity.getCaseReferenceNumber());
     assertEquals(post.getUniqueFileNumber(), entity.getUniqueFileNumber());
-    assertEquals(post.getCaseStartDate(), entity.getCaseStartDate());
-    assertEquals(post.getCaseConcludedDate(), entity.getCaseConcludedDate());
+    assertEquals(
+        post.getCaseStartDate(),
+        entity.getCaseStartDate().format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
+    assertEquals(
+        post.getCaseConcludedDate(),
+        entity.getCaseConcludedDate().format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
     assertEquals(post.getMatterTypeCode(), entity.getMatterTypeCode());
     assertEquals(post.getCrimeMatterTypeCode(), entity.getCrimeMatterTypeCode());
     assertEquals(post.getFeeSchemeCode(), entity.getFeeSchemeCode());
@@ -80,7 +86,9 @@ class ClaimMapperTest {
     assertEquals(post.getProcurementAreaCode(), entity.getProcurementAreaCode());
     assertEquals(post.getAccessPointCode(), entity.getAccessPointCode());
     assertEquals(post.getDeliveryLocation(), entity.getDeliveryLocation());
-    assertEquals(post.getRepresentationOrderDate(), entity.getRepresentationOrderDate());
+    assertEquals(
+        post.getRepresentationOrderDate(),
+        entity.getRepresentationOrderDate().format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
     assertEquals(post.getSuspectsDefendantsCount(), entity.getSuspectsDefendantsCount());
     assertEquals(
         post.getPoliceStationCourtAttendancesCount(),
@@ -112,8 +120,8 @@ class ClaimMapperTest {
             .lineNumber(5)
             .caseReferenceNumber("CASE001")
             .uniqueFileNumber("UFN123")
-            .caseStartDate("01/01/2020")
-            .caseConcludedDate("02/01/2020")
+            .caseStartDate(LocalDate.now())
+            .caseConcludedDate(LocalDate.now().plusDays(1))
             .matterTypeCode("MTC")
             .crimeMatterTypeCode("CMTC")
             .feeSchemeCode("FSC")
@@ -121,7 +129,7 @@ class ClaimMapperTest {
             .procurementAreaCode("PAC")
             .accessPointCode("APC")
             .deliveryLocation("DEL")
-            .representationOrderDate("01/01/2020")
+            .representationOrderDate(LocalDate.now().minusDays(2))
             .suspectsDefendantsCount(3)
             .policeStationCourtAttendancesCount(4)
             .policeStationCourtPrisonId("PSCPI")
@@ -145,8 +153,8 @@ class ClaimMapperTest {
     assertEquals(entity.getLineNumber(), fields.getLineNumber());
     assertEquals(entity.getCaseReferenceNumber(), fields.getCaseReferenceNumber());
     assertEquals(entity.getUniqueFileNumber(), fields.getUniqueFileNumber());
-    assertEquals(entity.getCaseStartDate(), fields.getCaseStartDate());
-    assertEquals(entity.getCaseConcludedDate(), fields.getCaseConcludedDate());
+    assertEquals(entity.getCaseStartDate().toString(), fields.getCaseStartDate());
+    assertEquals(entity.getCaseConcludedDate().toString(), fields.getCaseConcludedDate());
     assertEquals(entity.getMatterTypeCode(), fields.getMatterTypeCode());
     assertEquals(entity.getCrimeMatterTypeCode(), fields.getCrimeMatterTypeCode());
     assertEquals(entity.getFeeSchemeCode(), fields.getFeeSchemeCode());
@@ -154,7 +162,8 @@ class ClaimMapperTest {
     assertEquals(entity.getProcurementAreaCode(), fields.getProcurementAreaCode());
     assertEquals(entity.getAccessPointCode(), fields.getAccessPointCode());
     assertEquals(entity.getDeliveryLocation(), fields.getDeliveryLocation());
-    assertEquals(entity.getRepresentationOrderDate(), fields.getRepresentationOrderDate());
+    assertEquals(
+        entity.getRepresentationOrderDate().toString(), fields.getRepresentationOrderDate());
     assertEquals(entity.getSuspectsDefendantsCount(), fields.getSuspectsDefendantsCount());
     assertEquals(
         entity.getPoliceStationCourtAttendancesCount(),

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClientMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClientMapperTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,14 +29,12 @@ class ClientMapperTest {
 
   @Test
   void toClient_mapsAllFields() {
-    final LocalDate dob1 = LocalDate.of(1990, 5, 20);
-    final LocalDate dob2 = LocalDate.of(1992, 7, 15);
 
     final ClaimPost post =
         new ClaimPost()
             .clientForename("John")
             .clientSurname("Doe")
-            .clientDateOfBirth(dob1)
+            .clientDateOfBirth("20/05/1990")
             .uniqueClientNumber("UCN-123")
             .clientPostcode("AB1 2CD")
             .genderCode("M")
@@ -50,7 +47,7 @@ class ClientMapperTest {
             .claExemptionCode("EX-22")
             .client2Forename("Jane")
             .client2Surname("Roe")
-            .client2DateOfBirth(dob2)
+            .client2DateOfBirth("15/07/1992")
             .client2Ucn("UCN-456")
             .client2Postcode("EF3 4GH")
             .client2GenderCode("F")
@@ -63,7 +60,7 @@ class ClientMapperTest {
     assertNotNull(client);
     assertEquals("John", client.getClientForename());
     assertEquals("Doe", client.getClientSurname());
-    assertEquals(dob1, client.getClientDateOfBirth());
+    assertEquals("20/05/1990", client.getClientDateOfBirth());
     assertEquals("UCN-123", client.getUniqueClientNumber());
     assertEquals("AB1 2CD", client.getClientPostcode());
     assertEquals("M", client.getGenderCode());
@@ -76,7 +73,7 @@ class ClientMapperTest {
     assertEquals("EX-22", client.getClaExemptionCode());
     assertEquals("Jane", client.getClient2Forename());
     assertEquals("Roe", client.getClient2Surname());
-    assertEquals(dob2, client.getClient2DateOfBirth());
+    assertEquals("15/07/1992", client.getClient2DateOfBirth());
     assertEquals("UCN-456", client.getClient2Ucn());
     assertEquals("EF3 4GH", client.getClient2Postcode());
     assertEquals("F", client.getClient2GenderCode());
@@ -98,12 +95,11 @@ class ClientMapperTest {
 
   @Test
   void updateClaimFieldsFromClient_updatesOnlyNonNullFields() {
-    final LocalDate initialDob = LocalDate.of(1980, 1, 1);
     final ClaimFields fields =
         ClaimFields.builder()
             .clientForename("OldForename")
             .clientSurname("OldSurname")
-            .clientDateOfBirth(initialDob)
+            .clientDateOfBirth("01/01/1980")
             .uniqueClientNumber("OLD-UCN")
             .clientPostcode("OLD-PC")
             .genderCode("OLD-G")
@@ -116,7 +112,7 @@ class ClientMapperTest {
             .claExemptionCode("OLD-EX")
             .client2Forename("Old2F")
             .client2Surname("Old2S")
-            .client2DateOfBirth(LocalDate.of(1985, 2, 2))
+            .client2DateOfBirth("02/02/1985")
             .client2Ucn("OLD-UCN2")
             .client2Postcode("OLD-PC2")
             .client2GenderCode("OLD-G2")
@@ -125,12 +121,11 @@ class ClientMapperTest {
             .client2IsLegallyAided(true)
             .build();
 
-    final LocalDate newDob1 = LocalDate.of(1999, 9, 9);
     final Client entity =
         Client.builder()
             .clientForename("NewForename")
             .clientSurname("NewSurname")
-            .clientDateOfBirth(newDob1)
+            .clientDateOfBirth("09/09/1999")
             .uniqueClientNumber(null)
             .clientPostcode("NEW-PC")
             .genderCode(null)
@@ -156,7 +151,7 @@ class ClientMapperTest {
 
     assertEquals("NewForename", fields.getClientForename());
     assertEquals("NewSurname", fields.getClientSurname());
-    assertEquals(newDob1, fields.getClientDateOfBirth());
+    assertEquals("09/09/1999", fields.getClientDateOfBirth());
     assertEquals("OLD-UCN", fields.getUniqueClientNumber());
     assertEquals("NEW-PC", fields.getClientPostcode());
     assertEquals("OLD-G", fields.getGenderCode());
@@ -169,7 +164,7 @@ class ClientMapperTest {
     assertEquals("OLD-EX", fields.getClaExemptionCode());
     assertEquals("New2F", fields.getClient2Forename());
     assertEquals("Old2S", fields.getClient2Surname());
-    assertEquals(LocalDate.of(1985, 2, 2), fields.getClient2DateOfBirth());
+    assertEquals("02/02/1985", fields.getClient2DateOfBirth());
     assertEquals("NEW-UCN2", fields.getClient2Ucn());
     assertEquals("OLD-PC2", fields.getClient2Postcode());
     assertEquals("NEW-G2", fields.getClient2GenderCode());

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClientMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClientMapperTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -60,7 +62,7 @@ class ClientMapperTest {
     assertNotNull(client);
     assertEquals("John", client.getClientForename());
     assertEquals("Doe", client.getClientSurname());
-    assertEquals("20/05/1990", client.getClientDateOfBirth());
+    assertEquals("1990-05-20", client.getClientDateOfBirth().toString());
     assertEquals("UCN-123", client.getUniqueClientNumber());
     assertEquals("AB1 2CD", client.getClientPostcode());
     assertEquals("M", client.getGenderCode());
@@ -73,7 +75,9 @@ class ClientMapperTest {
     assertEquals("EX-22", client.getClaExemptionCode());
     assertEquals("Jane", client.getClient2Forename());
     assertEquals("Roe", client.getClient2Surname());
-    assertEquals("15/07/1992", client.getClient2DateOfBirth());
+    assertEquals(
+        "15/07/1992",
+        client.getClient2DateOfBirth().format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
     assertEquals("UCN-456", client.getClient2Ucn());
     assertEquals("EF3 4GH", client.getClient2Postcode());
     assertEquals("F", client.getClient2GenderCode());
@@ -125,7 +129,7 @@ class ClientMapperTest {
         Client.builder()
             .clientForename("NewForename")
             .clientSurname("NewSurname")
-            .clientDateOfBirth("09/09/1999")
+            .clientDateOfBirth(LocalDate.of(1999, 9, 9))
             .uniqueClientNumber(null)
             .clientPostcode("NEW-PC")
             .genderCode(null)
@@ -151,7 +155,7 @@ class ClientMapperTest {
 
     assertEquals("NewForename", fields.getClientForename());
     assertEquals("NewSurname", fields.getClientSurname());
-    assertEquals("09/09/1999", fields.getClientDateOfBirth());
+    assertEquals("1999-09-09", fields.getClientDateOfBirth());
     assertEquals("OLD-UCN", fields.getUniqueClientNumber());
     assertEquals("NEW-PC", fields.getClientPostcode());
     assertEquals("OLD-G", fields.getGenderCode());

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimServiceTest.java
@@ -81,8 +81,7 @@ class ClaimServiceTest {
         Arguments.of(Client.builder().clientDateOfBirth("01/01/1980").build()),
         Arguments.of(Client.builder().client2Forename("TestName").build()),
         Arguments.of(Client.builder().client2Surname("TestSurname").build()),
-        Arguments.of(Client.builder().client2DateOfBirth("12/12/1083").build())
-    );
+        Arguments.of(Client.builder().client2DateOfBirth("12/12/1083").build()));
   }
 
   @Test

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -78,10 +79,10 @@ class ClaimServiceTest {
     return Stream.of(
         Arguments.of(Client.builder().clientForename("John").build()),
         Arguments.of(Client.builder().clientSurname("Smith").build()),
-        Arguments.of(Client.builder().clientDateOfBirth("01/01/1980").build()),
+        Arguments.of(Client.builder().clientDateOfBirth(LocalDate.of(1980, 1, 1)).build()),
         Arguments.of(Client.builder().client2Forename("TestName").build()),
         Arguments.of(Client.builder().client2Surname("TestSurname").build()),
-        Arguments.of(Client.builder().client2DateOfBirth("12/12/1083").build()));
+        Arguments.of(Client.builder().client2DateOfBirth(LocalDate.of(1983, 12, 12)).build()));
   }
 
   @Test

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -79,10 +78,11 @@ class ClaimServiceTest {
     return Stream.of(
         Arguments.of(Client.builder().clientForename("John").build()),
         Arguments.of(Client.builder().clientSurname("Smith").build()),
-        Arguments.of(Client.builder().clientDateOfBirth(LocalDate.of(1980, 1, 1)).build()),
+        Arguments.of(Client.builder().clientDateOfBirth("01/01/1980").build()),
         Arguments.of(Client.builder().client2Forename("TestName").build()),
         Arguments.of(Client.builder().client2Surname("TestSurname").build()),
-        Arguments.of(Client.builder().client2DateOfBirth(LocalDate.of(1983, 12, 12)).build()));
+        Arguments.of(Client.builder().client2DateOfBirth("12/12/1083").build())
+    );
   }
 
   @Test

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/ClaimsDataTestUtil.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/ClaimsDataTestUtil.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.util;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.List;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.*;
 
@@ -29,7 +28,7 @@ public class ClaimsDataTestUtil {
         .matterType("matterType")
         .feeCode("feeCode")
         .caseRefNumber("caseRefNumber")
-        .caseStartDate(LocalDate.of(2000, 1, 1))
+        .caseStartDate("01/01/2000")
         .caseId("caseId")
         .caseStageLevel("caseStageLevel")
         .ufn("ufn")
@@ -37,7 +36,7 @@ public class ClaimsDataTestUtil {
         .accessPoint("accessPoint")
         .clientForename("clientForename")
         .clientSurname("clientSurname")
-        .clientDateOfBirth(LocalDate.of(2000, 1, 2))
+        .clientDateOfBirth("02/01/2000")
         .ucn("ucn")
         .claRefNumber("claRefNumber")
         .claExemption("claExemption")
@@ -45,7 +44,7 @@ public class ClaimsDataTestUtil {
         .ethnicity("ethnicity")
         .disability("disability")
         .clientPostCode("clientPostCode")
-        .workConcludedDate(LocalDate.of(2000, 1, 3))
+        .workConcludedDate("03/01/2000")
         .adviceTime(1)
         .travelTime(2)
         .waitingTime(3)
@@ -73,7 +72,7 @@ public class ClaimsDataTestUtil {
         .substantiveHearing(Boolean.FALSE)
         .hoInterview("hoInterview")
         .hoUcn("hoUcn")
-        .transferDate(LocalDate.of(2000, 1, 4))
+        .transferDate("04/01/2000")
         .detentionTravelWaitingCosts(new BigDecimal("0.09"))
         .deliveryLocation("deliveryLocation")
         .priorAuthorityRef("priorAuthorityRef")
@@ -91,11 +90,11 @@ public class ClaimsDataTestUtil {
         .noOfClients(6)
         .noOfSurgeryClients(7)
         .ircSurgery("ircSurgery")
-        .surgeryDate(LocalDate.of(2000, 1, 5))
+        .surgeryDate("05/01/2000")
         .lineNumber("lineNumber")
         .crimeMatterType("crimeMatterType")
         .feeScheme("feeScheme")
-        .repOrderDate(LocalDate.of(2000, 1, 6))
+        .repOrderDate("06/01/2000")
         .noOfSuspects(8)
         .noOfPoliceStation(9)
         .policeStation("policeStation")
@@ -112,7 +111,7 @@ public class ClaimsDataTestUtil {
         .clientLegallyAided("clientLegallyAided")
         .client2Forename("client2Forename")
         .client2Surname("client2Surname")
-        .client2DateOfBirth(LocalDate.of(2000, 1, 7))
+        .client2DateOfBirth("07/01/2000")
         .client2Ucn("client2Ucn")
         .client2PostCode("client2PostCode")
         .client2Gender("client2Gender")
@@ -128,7 +127,7 @@ public class ClaimsDataTestUtil {
         .localAuthorityNumber("localAuthorityNumber")
         .paNumber("paNumber")
         .excessTravelCosts(new BigDecimal("0.10"))
-        .medConcludedDate(LocalDate.of(2000, 1, 8));
+        .medConcludedDate("08/01/2000");
   }
 
   public static BulkSubmissionMatterStart getBulkSubmissionMatterStart() {


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-319)

Remove "format: date" from multiple fields in the open-api-specification.yml file because it assumes the ISO format of YYYY-MM-DD whereas we need our dates in DD/MM/YYYY format. The dates will be validated later via the event service.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
