### PR TITLE
Fix: OpenAPI generator unknown format

### DIFF
--- a/claims-data/api/build.gradle
+++ b/claims-data/api/build.gradle
@@ -32,6 +32,17 @@ openApiGenerate {
     apiPackage = "uk.gov.justice.laa.dstew.payments.claimsdata.api"
     invokerPackage = "uk.gov.justice.laa.dstew.payments.claimsdata.invoker"
     modelPackage = "uk.gov.justice.laa.dstew.payments.claimsdata.model"
+    
+    // Handle custom format: bigDecimal by mapping it to BigDecimal
+    // This prevents the "Unknown format" warnings
+    typeMappings = [
+            "number+bigDecimal": "BigDecimal"
+    ]
+    
+    importMappings = [
+            "BigDecimal": "java.math.BigDecimal"
+    ]
+    
     configOptions = [
             generateBuilders    : "true",
             interfaceOnly       : "true", // This will only generate interfaces, not implementations


### PR DESCRIPTION
## What

The OpenAPI generator (Task :claims-data:api:openApiGenerate) doesn't recognize bigDecimal as a standard format. Use *Mappings instead.

**Warning**:
- Unknown `format` bigDecimal detected for type `number`. Defaulting to `number`

**Fix**:
- "number+bigDecimal": "BigDecimal" tells the generator to map any type: number with format: bigDecimal to the BigDecimal type
- "BigDecimal": "java.math.BigDecimal" ensures the proper import is added

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
