### PR TITLE
Fix: Add missing env variable

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -54,6 +54,7 @@ runs:
       shell: bash
       env:
         ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+        ECR_REGION: ${{ inputs.ecr-region }}
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         GIT_SHA: ${{ github.sha }}
         KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
@@ -64,6 +65,7 @@ runs:
           --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
           --set image.tag="${GIT_SHA}" \
           --set spring.profile="main" \
+          --set aws.region="${ECR_REGION}" \
           --values ${VALUES_FILE} \
           --install \
           --wait --timeout=10m


### PR DESCRIPTION
## What

Add `ECR_REGION` variable to deploy action as the the deploy action failed on staging and therefore production.

UAT used the deploy_branch action therefore this was already ok.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
