### PR TITLE
Enhance GET /api/v0/claims to include calculated_fee_details fields

### DIFF
--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -240,7 +240,6 @@ paths:
             type: string
             format: date
           description: Filter submissions submitted up to this date (inclusive)
-
       responses:
         '200':
           description: returns a list of paginated claim submissions
@@ -777,7 +776,7 @@ components:
 
     claim_post:
       allOf:
-        - $ref: '#/components/schemas/claim_response'
+        - $ref: '#/components/schemas/claim_base'
       required:
         - status
         - line_number
@@ -785,14 +784,12 @@ components:
     ClaimPatch:
       allOf:
         - $ref: '#/components/schemas/claim_response'
-      type: object
-      properties:
-        fee_calculation_response:
-          $ref: '#/components/schemas/fee_calculation_patch'
-        validation_messages:
-          type: array
-          items:
-            $ref: '#/components/schemas/validation_message_patch'
+        - type: object
+          properties:
+            validation_messages:
+              type: array
+              items:
+                $ref: '#/components/schemas/validation_message_patch'
     claim_status:
       type: string
       enum:
@@ -811,7 +808,7 @@ components:
           type: 'array'
           items:
             $ref: '#/components/schemas/claim_response'
-    claim_response:
+    claim_base:
       type: object
       description: Claim details
       properties:
@@ -1026,6 +1023,13 @@ components:
           description: "Number of Home Office Interviews"
         local_authority_number:
           type: string
+    claim_response:
+      allOf:
+        - $ref: '#/components/schemas/claim_base'
+        - type: object
+          properties:
+            fee_calculation_response:
+              $ref: '#/components/schemas/fee_calculation_patch'
     fee_calculation_patch:
       type: object
       description: Fee calculation response from the Fee Scheme Platform

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/BulkSubmissionControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/BulkSubmissionControllerIntegrationTest.java
@@ -63,8 +63,7 @@ public class BulkSubmissionControllerIntegrationTest extends AbstractIntegration
 
   @BeforeAll
   void setup() {
-    submissionRepository.deleteAll();
-    bulkSubmissionRepository.deleteAll();
+    clearIntegrationData();
 
     // create the queue if it doesn't exist
     sqsClient.createQueue(builder -> builder.queueName(queueName));

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimControllerIntegrationTest.java
@@ -57,6 +57,19 @@ public class ClaimControllerIntegrationTest extends AbstractIntegrationTest {
     String responseBody = result.getResponse().getContentAsString();
     var claimResponse = OBJECT_MAPPER.readValue(responseBody, ClaimResponse.class);
     assertThat(claimResponse.getId()).isEqualTo(CLAIM_1_ID.toString());
+    assertThat(claimResponse.getClientForename()).isEqualTo("Alice");
+    assertThat(claimResponse.getAdviceTime()).isEqualTo(120);
+    assertThat(claimResponse.getTravelTime()).isEqualTo(45);
+    assertThat(claimResponse.getIsLondonRate()).isTrue();
+
+    var feeCalculationResponse = claimResponse.getFeeCalculationResponse();
+    assertThat(feeCalculationResponse).isNotNull();
+    assertThat(feeCalculationResponse.getFeeCode()).isEqualTo("CALC-FEE-1");
+    assertThat(feeCalculationResponse.getTotalAmount()).isEqualByComparingTo("125");
+    assertThat(feeCalculationResponse.getVatIndicator()).isTrue();
+    assertThat(feeCalculationResponse.getBoltOnDetails()).isNotNull();
+    assertThat(feeCalculationResponse.getBoltOnDetails().getBoltOnTotalFeeAmount())
+        .isEqualByComparingTo("12");
   }
 
   @Test

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/MatterStartsControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/MatterStartsControllerIntegrationTest.java
@@ -38,7 +38,7 @@ public class MatterStartsControllerIntegrationTest extends AbstractIntegrationTe
 
   @BeforeEach
   void setup() {
-    matterStartRepository.deleteAll();
+    clearIntegrationData();
     submission = getSubmissionTestData();
   }
 

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/SubmissionControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/SubmissionControllerIntegrationTest.java
@@ -80,12 +80,7 @@ public class SubmissionControllerIntegrationTest extends AbstractIntegrationTest
   @AfterEach
   void close() {
     // delete everything from DB
-    clientRepository.deleteAll();
-    claimRepository.deleteAll();
-    matterStartRepository.deleteAll();
-    validationMessageLogRepository.deleteAll();
-    submissionRepository.deleteAll();
-    bulkSubmissionRepository.deleteAll();
+    clearIntegrationData();
   }
 
   @Test

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/CalculatedFeeDetailRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/CalculatedFeeDetailRepositoryIntegrationTest.java
@@ -1,0 +1,41 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.CalculatedFeeDetail;
+import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CalculatedFeeDetailRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+  @Test
+  void findByClaimId_returnsCalculatedFeeDetail() {
+    var submission = getSubmissionTestData();
+    createClaimsTestData(submission);
+
+    var result = calculatedFeeDetailRepository.findByClaimId(CLAIM_1_ID);
+
+    assertThat(result).isPresent();
+    CalculatedFeeDetail feeDetail = result.get();
+    assertThat(feeDetail.getClaim().getId()).isEqualTo(CLAIM_1_ID);
+    assertThat(feeDetail.getFeeCode()).isEqualTo("CALC-FEE-1");
+    assertThat(feeDetail.getTotalAmount()).isEqualByComparingTo("125");
+    assertThat(feeDetail.getBoltOnCmrhTelephoneCount()).isEqualTo(2);
+  }
+
+  @Test
+  void findByClaimId_whenUnknown_returnsEmpty() {
+    var submission = getSubmissionTestData();
+    createClaimsTestData(submission);
+
+    UUID unknownClaimId = Uuid7.timeBasedUuid();
+    var result = calculatedFeeDetailRepository.findByClaimId(unknownClaimId);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimRepositoryIntegrationTest.java
@@ -67,11 +67,7 @@ public class ClaimRepositoryIntegrationTest extends AbstractIntegrationTest {
    */
   @BeforeEach
   public void setup() {
-    validationMessageLogRepository.deleteAll();
-    clientRepository.deleteAll();
-    claimRepository.deleteAll();
-    submissionRepository.deleteAll();
-    bulkSubmissionRepository.deleteAll();
+    clearIntegrationData();
 
     var bulkSubmission =
         BulkSubmission.builder()

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimSummaryFeeRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimSummaryFeeRepositoryIntegrationTest.java
@@ -1,0 +1,53 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_2_ID;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
+import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ClaimSummaryFeeRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+  @Test
+  void findByClaimId_returnsSummaryFee() {
+    var submission = getSubmissionTestData();
+    createClaimsTestData(submission);
+
+    var result = claimSummaryFeeRepository.findByClaimId(CLAIM_1_ID);
+
+    assertThat(result).isPresent();
+    ClaimSummaryFee summaryFee = result.get();
+    assertThat(summaryFee.getClaim().getId()).isEqualTo(CLAIM_1_ID);
+    assertThat(summaryFee.getAdviceTime()).isEqualTo(120);
+    assertThat(summaryFee.getMeetingsAttendedCode()).isEqualTo("MEET-A");
+  }
+
+  @Test
+  void findByClaim_returnsSummaryFee() {
+    var submission = getSubmissionTestData();
+    createClaimsTestData(submission);
+
+    var claim = claimRepository.findById(CLAIM_2_ID).orElseThrow();
+    var result = claimSummaryFeeRepository.findByClaim(claim);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getAdviceTypeCode()).isEqualTo("ADV-002");
+  }
+
+  @Test
+  void findByClaimId_whenUnknown_returnsEmpty() {
+    var submission = getSubmissionTestData();
+    createClaimsTestData(submission);
+
+    UUID unknownClaimId = Uuid7.timeBasedUuid();
+    var result = claimSummaryFeeRepository.findByClaimId(unknownClaimId);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -59,11 +59,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
    */
   @BeforeEach
   public void setup() {
-    validationMessageLogRepository.deleteAll();
-    clientRepository.deleteAll();
-    claimRepository.deleteAll();
-    submissionRepository.deleteAll();
-    bulkSubmissionRepository.deleteAll();
+    clearIntegrationData();
 
     var bulkSubmission =
         BulkSubmission.builder()

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapper.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapper.java
@@ -4,12 +4,14 @@ import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.CalculatedFeeDetail;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ValidationMessageLog;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.BoltOnPatch;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPost;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
@@ -117,4 +119,34 @@ public interface ClaimMapper {
   @Mapping(target = "escapeCaseFlag", source = "response.boltOnDetails.escapeCaseFlag")
   @Mapping(target = "schemeId", source = "response.boltOnDetails.schemeId")
   CalculatedFeeDetail toCalculatedFeeDetail(FeeCalculationPatch response);
+
+  @Mapping(target = "id", ignore = true)
+  @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+  void updateClaimResponseFromClaimSummaryFee(
+      ClaimSummaryFee entity, @MappingTarget ClaimResponse claim);
+
+  @Mapping(
+      target = "feeCalculationResponse",
+      source = "entity",
+      qualifiedByName = "updateFeeCalculationResponseFromCalculatedFeeDetail")
+  @BeanMapping(
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+      ignoreByDefault = true)
+  void updateClaimResponseFromCalculatedFeeDetail(
+      CalculatedFeeDetail entity, @MappingTarget ClaimResponse claim);
+
+  @Named("updateFeeCalculationResponseFromCalculatedFeeDetail")
+  @Mapping(target = "claimId", source = "claim.id")
+  @Mapping(
+      target = "boltOnDetails",
+      source = "entity",
+      qualifiedByName = "updateBoltOnDetailsFromCalculatedFeeDetail")
+  @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+  void updateFeeCalculationResponseFromCalculatedFeeDetail(
+      CalculatedFeeDetail entity, @MappingTarget FeeCalculationPatch feeCalculationResponse);
+
+  @Named("updateBoltOnDetailsFromCalculatedFeeDetail")
+  @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+  void updateBoltOnDetailsFromCalculatedFeeDetail(
+      CalculatedFeeDetail entity, @MappingTarget BoltOnPatch boltOnDetails);
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/CalculatedFeeDetailRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/CalculatedFeeDetailRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,4 +8,6 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.entity.CalculatedFeeDetail;
 
 /** Repository for handling CRUD operations on calculated fee detail records. */
 @Repository
-public interface CalculatedFeeDetailRepository extends JpaRepository<CalculatedFeeDetail, UUID> {}
+public interface CalculatedFeeDetailRepository extends JpaRepository<CalculatedFeeDetail, UUID> {
+  Optional<CalculatedFeeDetail> findByClaimId(UUID claimId);
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimSummaryFeeRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimSummaryFeeRepository.java
@@ -10,5 +10,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
 /** Repository for handling CRUD operations on claim summary fee records. */
 @Repository
 public interface ClaimSummaryFeeRepository extends JpaRepository<ClaimSummaryFee, UUID> {
+  Optional<ClaimSummaryFee> findByClaimId(UUID claimId);
+
   Optional<ClaimSummaryFee> findByClaim(Claim claim);
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimService.java
@@ -117,6 +117,15 @@ public class ClaimService
     clientRepository
         .findByClaimId(claimId)
         .ifPresent(client -> clientMapper.updateClaimResponseFromClient(client, response));
+    claimSummaryFeeRepository
+        .findByClaimId(claimId)
+        .ifPresent(fee -> claimMapper.updateClaimResponseFromClaimSummaryFee(fee, response));
+    calculatedFeeDetailRepository
+        .findByClaimId(claimId)
+        .ifPresent(
+            feeDetail ->
+                claimMapper.updateClaimResponseFromCalculatedFeeDetail(feeDetail, response));
+
     return response;
   }
 
@@ -237,6 +246,24 @@ public class ClaimService
                 claimStatuses),
             pageable);
 
-    return claimResultSetMapper.toClaimResultSet(page);
+    ClaimResultSet response = claimResultSetMapper.toClaimResultSet(page);
+    for (ClaimResponse claimResponse : response.getContent()) {
+      if (claimResponse.getId() != null) {
+        clientRepository
+            .findByClaimId(UUID.fromString(claimResponse.getId()))
+            .ifPresent(client -> clientMapper.updateClaimResponseFromClient(client, claimResponse));
+        claimSummaryFeeRepository
+            .findByClaimId(UUID.fromString(claimResponse.getId()))
+            .ifPresent(
+                fee -> claimMapper.updateClaimResponseFromClaimSummaryFee(fee, claimResponse));
+        calculatedFeeDetailRepository
+            .findByClaimId(UUID.fromString(claimResponse.getId()))
+            .ifPresent(
+                feeDetail ->
+                    claimMapper.updateClaimResponseFromCalculatedFeeDetail(
+                        feeDetail, claimResponse));
+      }
+    }
+    return response;
   }
 }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
@@ -373,6 +373,205 @@ class ClaimMapperTest {
     assertThat(calculatedFeeDetail.getSchemeId()).isEqualTo(boltOnPatch.getSchemeId());
   }
 
+  @Test
+  void updateClaimResponseFromClaimSummaryFee_mapsFields() {
+    final ClaimSummaryFee summaryFee = new ClaimSummaryFee();
+    summaryFee.setAdviceTime(10);
+    summaryFee.setTravelTime(20);
+    summaryFee.setWaitingTime(30);
+    summaryFee.setNetProfitCostsAmount(new BigDecimal("123.45"));
+    summaryFee.setNetDisbursementAmount(new BigDecimal("67.89"));
+    summaryFee.setNetCounselCostsAmount(new BigDecimal("10.11"));
+    summaryFee.setDisbursementsVatAmount(new BigDecimal("12.34"));
+    summaryFee.setTravelWaitingCostsAmount(new BigDecimal("15.67"));
+    summaryFee.setNetWaitingCostsAmount(new BigDecimal("18.90"));
+    summaryFee.setIsVatApplicable(Boolean.TRUE);
+    summaryFee.setIsToleranceApplicable(Boolean.FALSE);
+    summaryFee.setPriorAuthorityReference("PA-123");
+    summaryFee.setIsLondonRate(Boolean.TRUE);
+    summaryFee.setAdjournedHearingFeeAmount(5);
+    summaryFee.setIsAdditionalTravelPayment(Boolean.FALSE);
+    summaryFee.setCostsDamagesRecoveredAmount(new BigDecimal("21.00"));
+    summaryFee.setMeetingsAttendedCode("MEET1");
+    summaryFee.setDetentionTravelWaitingCostsAmount(new BigDecimal("22.00"));
+    summaryFee.setJrFormFillingAmount(new BigDecimal("23.00"));
+    summaryFee.setIsEligibleClient(Boolean.TRUE);
+    summaryFee.setCourtLocationCode("COURT01");
+    summaryFee.setAdviceTypeCode("ADVICE01");
+    summaryFee.setMedicalReportsCount(3);
+    summaryFee.setIsIrcSurgery(Boolean.TRUE);
+    summaryFee.setSurgeryDate(LocalDate.of(2025, 1, 2));
+    summaryFee.setSurgeryClientsCount(4);
+    summaryFee.setSurgeryMattersCount(5);
+    summaryFee.setCmrhOralCount(6);
+    summaryFee.setCmrhTelephoneCount(7);
+    summaryFee.setAitHearingCentreCode("AITHC01");
+    summaryFee.setIsSubstantiveHearing(Boolean.FALSE);
+    summaryFee.setHoInterview(8);
+    summaryFee.setLocalAuthorityNumber("LA-001");
+
+    final ClaimResponse claimResponse = new ClaimResponse();
+
+    mapper.updateClaimResponseFromClaimSummaryFee(summaryFee, claimResponse);
+
+    assertThat(claimResponse.getAdviceTime()).isEqualTo(10);
+    assertThat(claimResponse.getTravelTime()).isEqualTo(20);
+    assertThat(claimResponse.getWaitingTime()).isEqualTo(30);
+    assertThat(claimResponse.getNetProfitCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("123.45"));
+    assertThat(claimResponse.getNetDisbursementAmount())
+        .isEqualByComparingTo(new BigDecimal("67.89"));
+    assertThat(claimResponse.getNetCounselCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("10.11"));
+    assertThat(claimResponse.getDisbursementsVatAmount())
+        .isEqualByComparingTo(new BigDecimal("12.34"));
+    assertThat(claimResponse.getTravelWaitingCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("15.67"));
+    assertThat(claimResponse.getNetWaitingCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("18.90"));
+    assertThat(claimResponse.getIsVatApplicable()).isTrue();
+    assertThat(claimResponse.getIsToleranceApplicable()).isFalse();
+    assertThat(claimResponse.getPriorAuthorityReference()).isEqualTo("PA-123");
+    assertThat(claimResponse.getIsLondonRate()).isTrue();
+    assertThat(claimResponse.getAdjournedHearingFeeAmount()).isEqualTo(5);
+    assertThat(claimResponse.getIsAdditionalTravelPayment()).isFalse();
+    assertThat(claimResponse.getDetentionTravelWaitingCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("22.00"));
+    assertThat(claimResponse.getSurgeryDate()).isEqualTo("2025-01-02");
+    assertThat(claimResponse.getIsSubstantiveHearing()).isFalse();
+    assertThat(claimResponse.getLocalAuthorityNumber()).isEqualTo("LA-001");
+    assertThat(claimResponse.getMeetingsAttendedCode()).isEqualTo("MEET1");
+  }
+
+  @Test
+  void updateClaimResponseFromCalculatedFeeDetail_createsNestedResponseWhenMissing() {
+    final CalculatedFeeDetail feeDetail = new CalculatedFeeDetail();
+    final Claim claim = Claim.builder().id(Uuid7.timeBasedUuid()).build();
+    feeDetail.setClaim(claim);
+    feeDetail.setFeeCode("FEE001");
+    feeDetail.setFeeCodeDescription("Fee description");
+    feeDetail.setFeeType(FeeCalculationType.DISBURSEMENT_ONLY);
+    feeDetail.setCategoryOfLaw("LAW");
+    feeDetail.setTotalAmount(new BigDecimal("100.00"));
+    feeDetail.setVatIndicator(Boolean.TRUE);
+    feeDetail.setVatRateApplied(new BigDecimal("20.00"));
+    feeDetail.setCalculatedVatAmount(new BigDecimal("20.00"));
+    feeDetail.setDisbursementAmount(new BigDecimal("10.00"));
+    feeDetail.setRequestedNetDisbursementAmount(new BigDecimal("9.00"));
+    feeDetail.setDisbursementVatAmount(new BigDecimal("1.00"));
+    feeDetail.setHourlyTotalAmount(new BigDecimal("50.00"));
+    feeDetail.setFixedFeeAmount(new BigDecimal("30.00"));
+    feeDetail.setNetProfitCostsAmount(new BigDecimal("40.00"));
+    feeDetail.setRequestedNetProfitCostsAmount(new BigDecimal("35.00"));
+    feeDetail.setNetCostOfCounselAmount(new BigDecimal("25.00"));
+    feeDetail.setNetTravelCostsAmount(new BigDecimal("15.00"));
+    feeDetail.setNetWaitingCostsAmount(new BigDecimal("5.00"));
+    feeDetail.setDetentionAndWaitingCostsAmount(new BigDecimal("3.00"));
+    feeDetail.setJrFormFillingAmount(new BigDecimal("2.00"));
+    feeDetail.setTravelAndWaitingCostsAmount(new BigDecimal("4.00"));
+    feeDetail.setBoltOnTotalFeeAmount(new BigDecimal("6.00"));
+    feeDetail.setBoltOnAdjournedHearingCount(1);
+    feeDetail.setBoltOnAdjournedHearingFee(new BigDecimal("1.50"));
+    feeDetail.setBoltOnCmrhTelephoneCount(2);
+    feeDetail.setBoltOnCmrhTelephoneFee(new BigDecimal("2.50"));
+    feeDetail.setBoltOnCmrhOralCount(3);
+    feeDetail.setBoltOnCmrhOralFee(new BigDecimal("3.50"));
+    feeDetail.setBoltOnHomeOfficeInterviewCount(4);
+    feeDetail.setBoltOnHomeOfficeInterviewFee(new BigDecimal("4.50"));
+    feeDetail.setEscapeCaseFlag(Boolean.TRUE);
+    feeDetail.setSchemeId("SCHEME-01");
+
+    final ClaimResponse claimResponse = new ClaimResponse();
+
+    mapper.updateClaimResponseFromCalculatedFeeDetail(feeDetail, claimResponse);
+
+    final FeeCalculationPatch feeCalculationResponse = claimResponse.getFeeCalculationResponse();
+    assertNotNull(feeCalculationResponse);
+    assertThat(feeCalculationResponse.getClaimId()).isEqualTo(claim.getId());
+    assertThat(feeCalculationResponse.getFeeCode()).isEqualTo("FEE001");
+    assertThat(feeCalculationResponse.getFeeCodeDescription()).isEqualTo("Fee description");
+    assertThat(feeCalculationResponse.getFeeType()).isEqualTo(FeeCalculationType.DISBURSEMENT_ONLY);
+    assertThat(feeCalculationResponse.getCategoryOfLaw()).isEqualTo("LAW");
+    assertThat(feeCalculationResponse.getTotalAmount())
+        .isEqualByComparingTo(new BigDecimal("100.00"));
+    assertThat(feeCalculationResponse.getVatIndicator()).isTrue();
+    assertThat(feeCalculationResponse.getVatRateApplied())
+        .isEqualByComparingTo(new BigDecimal("20.00"));
+    assertThat(feeCalculationResponse.getCalculatedVatAmount())
+        .isEqualByComparingTo(new BigDecimal("20.00"));
+    assertThat(feeCalculationResponse.getDisbursementAmount())
+        .isEqualByComparingTo(new BigDecimal("10.00"));
+    assertThat(feeCalculationResponse.getRequestedNetDisbursementAmount())
+        .isEqualByComparingTo(new BigDecimal("9.00"));
+    assertThat(feeCalculationResponse.getDisbursementVatAmount())
+        .isEqualByComparingTo(new BigDecimal("1.00"));
+    assertThat(feeCalculationResponse.getHourlyTotalAmount())
+        .isEqualByComparingTo(new BigDecimal("50.00"));
+    assertThat(feeCalculationResponse.getFixedFeeAmount())
+        .isEqualByComparingTo(new BigDecimal("30.00"));
+    assertThat(feeCalculationResponse.getNetProfitCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("40.00"));
+    assertThat(feeCalculationResponse.getRequestedNetProfitCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("35.00"));
+    assertThat(feeCalculationResponse.getNetCostOfCounselAmount())
+        .isEqualByComparingTo(new BigDecimal("25.00"));
+    assertThat(feeCalculationResponse.getNetTravelCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("15.00"));
+    assertThat(feeCalculationResponse.getNetWaitingCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("5.00"));
+    assertThat(feeCalculationResponse.getDetentionAndWaitingCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("3.00"));
+    assertThat(feeCalculationResponse.getJrFormFillingAmount())
+        .isEqualByComparingTo(new BigDecimal("2.00"));
+    assertThat(feeCalculationResponse.getTravelAndWaitingCostsAmount())
+        .isEqualByComparingTo(new BigDecimal("4.00"));
+
+    final BoltOnPatch boltOnDetails = feeCalculationResponse.getBoltOnDetails();
+    assertNotNull(boltOnDetails);
+    assertThat(boltOnDetails.getBoltOnTotalFeeAmount())
+        .isEqualByComparingTo(new BigDecimal("6.00"));
+    assertThat(boltOnDetails.getBoltOnAdjournedHearingCount()).isEqualTo(1);
+    assertThat(boltOnDetails.getBoltOnAdjournedHearingFee())
+        .isEqualByComparingTo(new BigDecimal("1.50"));
+    assertThat(boltOnDetails.getBoltOnCmrhTelephoneCount()).isEqualTo(2);
+    assertThat(boltOnDetails.getBoltOnCmrhTelephoneFee())
+        .isEqualByComparingTo(new BigDecimal("2.50"));
+    assertThat(boltOnDetails.getBoltOnCmrhOralCount()).isEqualTo(3);
+    assertThat(boltOnDetails.getBoltOnCmrhOralFee()).isEqualByComparingTo(new BigDecimal("3.50"));
+    assertThat(boltOnDetails.getBoltOnHomeOfficeInterviewCount()).isEqualTo(4);
+    assertThat(boltOnDetails.getBoltOnHomeOfficeInterviewFee())
+        .isEqualByComparingTo(new BigDecimal("4.50"));
+    assertThat(boltOnDetails.getEscapeCaseFlag()).isTrue();
+    assertThat(boltOnDetails.getSchemeId()).isEqualTo("SCHEME-01");
+  }
+
+  @Test
+  void updateClaimResponseFromCalculatedFeeDetail_reusesExistingNestedObjects() {
+    final CalculatedFeeDetail feeDetail = new CalculatedFeeDetail();
+    final Claim claim = Claim.builder().id(Uuid7.timeBasedUuid()).build();
+    feeDetail.setClaim(claim);
+    feeDetail.setFeeCode("NEW-CODE");
+    feeDetail.setBoltOnTotalFeeAmount(new BigDecimal("12.34"));
+    feeDetail.setSchemeId("NEW-SCHEME");
+
+    final FeeCalculationPatch existingResponse = new FeeCalculationPatch().feeCode("OLD-CODE");
+    final BoltOnPatch existingBoltOn = new BoltOnPatch().schemeId("OLD-SCHEME");
+    existingResponse.setBoltOnDetails(existingBoltOn);
+
+    final ClaimResponse claimResponse =
+        new ClaimResponse().feeCalculationResponse(existingResponse);
+
+    mapper.updateClaimResponseFromCalculatedFeeDetail(feeDetail, claimResponse);
+
+    assertThat(claimResponse.getFeeCalculationResponse()).isSameAs(existingResponse);
+    assertThat(claimResponse.getFeeCalculationResponse().getBoltOnDetails())
+        .isSameAs(existingBoltOn);
+    assertThat(existingResponse.getFeeCode()).isEqualTo("NEW-CODE");
+    assertThat(existingBoltOn.getSchemeId()).isEqualTo("NEW-SCHEME");
+    assertThat(existingBoltOn.getBoltOnTotalFeeAmount())
+        .isEqualByComparingTo(new BigDecimal("12.34"));
+  }
+
   private static BoltOnPatch getBoltOnPatch() {
     final BoltOnPatch boltOnPatch = new BoltOnPatch();
     boltOnPatch.boltOnTotalFeeAmount(new BigDecimal("345.07"));


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-582)

The GET /api/v0/claims endpoint currently returns claim data without the associated calculated fee details. We need to include this information in the response to provide a complete view of each claim's fee calculation.

User Story:
As a user searching for claims,
I want to see the calculated fee details for each claim in the search results,
so that I can quickly review fee calculations without having to open each claim individually.


[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-558)

Update GET /api/v0/claims search endpoint to return complete claim data including client, case, fee summary, and calculated fee details, matching the response structure of GET /api/v0/submissions/{submission-id}/claims/{claim-id}

The GET /api/v0/claims search endpoint currently returns only base claim data from the claim table and nulls out all related entity fields (client, case, fee details). This forces the Event Client application to make individual calls to GET /api/v0/submissions/{submission-id}/claims/{claim-id} for each claim in the search results to retrieve complete claim information.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
