### PR TITLE
DSTEW-565: Fix v19 Flyway migration

### DIFF
--- a/claims-data/service/src/main/resources/db/migration/V20__fix_v19_provider_user_id_migration_error.sql
+++ b/claims-data/service/src/main/resources/db/migration/V20__fix_v19_provider_user_id_migration_error.sql
@@ -1,0 +1,42 @@
+-- V20: Fix the error from V19 migration
+-- V19 failed because it tried to add a NOT NULL column to a table with existing data
+-- This migration cleans up and properly adds the provider_user_id column
+
+-- Step 1: Remove the failed V19 migration from flyway history
+-- This allows migrations to continue past the failure
+DELETE FROM flyway_schema_history WHERE version = '19';
+
+-- Step 2: Check if column exists and handle appropriately
+-- Only add the column if it doesn't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_schema = 'claims' 
+        AND table_name = 'submission' 
+        AND column_name = 'provider_user_id'
+    ) THEN
+        -- Column doesn't exist, safe to add it
+        ALTER TABLE submission ADD COLUMN provider_user_id TEXT;
+    ELSE
+        -- Column exists but might be NOT NULL (causing the original error)
+        -- Make it nullable first so we can populate it safely
+        ALTER TABLE submission ALTER COLUMN provider_user_id DROP NOT NULL;
+    END IF;
+END $$;
+
+-- Step 4: Populate the column with data from bulk_submission
+UPDATE submission s
+SET provider_user_id = (
+    SELECT bs.created_by_user_id
+    FROM bulk_submission bs
+    WHERE bs.id = s.bulk_submission_id
+);
+
+-- Step 5: Handle any rows where bulk_submission_id doesn't match
+UPDATE submission 
+SET provider_user_id = 'unknown_user' 
+WHERE provider_user_id IS NULL;
+
+-- Step 6: Now make the column NOT NULL (safe because all rows have values)
+ALTER TABLE submission ALTER COLUMN provider_user_id SET NOT NULL;


### PR DESCRIPTION
## What

Describe what you did and why.
Add v20 migration to fix uat (main) CrashLoopBackOff status that seems to have been caused by V19:

- migration V19 tries to add a NOT NULL column provider_user_id to the submission table
- the column is added first with NOT NULL constraint
- then it tries to populate the column with data from bulk_submission table
- postgre fails because we cannot add a NOT NULL column to a table that already has data

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
