### PR TITLE
[DSTEW-1188] - Add release plugin and add snapshot value

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -45,14 +45,6 @@ jobs:
       - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'
 
-      - name: Create tag
-        run: |
-          git config --global user.email "github-actions-bot[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions-bot[bot]"
-          ./gradlew release -Prelease.useAutomaticVersion=true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Publish api models package
         run: |
           version=$(git rev-parse --short HEAD)
@@ -163,6 +155,31 @@ jobs:
           args: --docker --severity-threshold=high
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+  release-version:
+    if: github.ref == 'refs/heads/main'   # extra safeguard: only main
+    name: Bump version + Tag
+    runs-on: ubuntu-latest
+    needs:
+      - build-test                       # ensures build/test pass before release
+    permissions:
+      contents: write                     # required for committing and pushing tags
+    steps:
+      - name: Checkout main with full history
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure Git
+        run: |
+          git config user.email "github-actions-bot[bot]@users.noreply.github.com"
+          git config user.name "github-actions-bot[bot]"
+
+      - name: Run Gradle Release (version + tag only)
+        run: ./gradlew release -Prelease.useAutomaticVersion=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-push-docker:
     name: build and push docker image

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'
 
+      - name: Create tag
+        run: |
+          git config --global user.email "github-actions-bot[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions-bot[bot]"
+          ./gradlew release -Prelease.useAutomaticVersion=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish api models package
         run: |
           version=$(git rev-parse --short HEAD)

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,11 @@ WORKDIR /opt/laa-data-claims-api/claims-data/
 
 # --- Stage for copying from the internal builder stage ---
 FROM base AS build-internal
-ONBUILD COPY --from=builder /build/claims-data/service/build/libs/service-*.jar app.jar
+ONBUILD COPY --from=builder /build/claims-data/service/build/libs/service-*-SNAPSHOT.jar app.jar
 
 # --- Stage for copying from the local filesystem (CI/Manual) ---
 FROM base AS build-external
-ONBUILD COPY claims-data/service/build/libs/service-1.0.0.jar app.jar
+ONBUILD COPY claims-data/service/build/libs/service-1.0.0-SNAPSHOT.jar app.jar
 
 # --- Final Stage ---
 ARG BUILD_SOURCE

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'net.researchgate.release' version '3.1.0'
+}
+
 subprojects {
     group = 'uk.gov.justice.laa.datastewardship.payments'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0
+version=1.0.0-SNAPSHOT
 group=uk.gov.justice.laa
 org.gradle.configuration-cache=false


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1188)

This PR adds the ResearchGate Gradle Release Plugin (net.researchgate.release v3.1.0) and updates the project version to use the -SNAPSHOT suffix.

**What was done**
- Added net.researchgate.release plugin (v3.1.0) to the Gradle build
- Updated gradle.properties to use a -SNAPSHOT version
- Aligned the project with a standard release/versioning workflow

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
