### PR TITLE
DSTEW-1396 - Added Assessed Total Amount to multi parameter submissio…

### DIFF
--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepositoryIntegrationTest.java
@@ -110,7 +110,7 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   @Test
   @DisplayName("Should return assessed total for one assessed claim")
   void shouldReturnAssessedTotalForOneAssessedClaim() {
-    AssessedClaim claim = createAssessedClaim();
+    ClaimWithFee claim = createClaimWithFee();
     saveAssessment(claim, "12.34", TENTH_APRIL_2024);
 
     assertAssessedTotal("12.34");
@@ -119,8 +119,8 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   @Test
   @DisplayName("Should sum latest assessments across multiple claims")
   void shouldSumLatestAssessmentsAcrossMultipleClaims() {
-    AssessedClaim claim1 = createAssessedClaim();
-    AssessedClaim claim2 = createAssessedClaim();
+    ClaimWithFee claim1 = createClaimWithFee();
+    ClaimWithFee claim2 = createClaimWithFee();
 
     saveAssessment(claim1, "10.00", TENTH_APRIL_2024);
     saveAssessment(claim2, "5.25", ELEVENTH_APRIL_2024);
@@ -131,7 +131,7 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   @Test
   @DisplayName("Should only count the latest assessment for the same claim")
   void shouldOnlyCountLatestAssessmentForSameClaim() {
-    AssessedClaim claim = createAssessedClaim();
+    ClaimWithFee claim = createClaimWithFee();
 
     saveAssessment(claim, "10.00", TENTH_APRIL_2024);
     saveAssessment(claim, "7.50", TWELFTH_APRIL_2024);
@@ -142,8 +142,8 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   @Test
   @DisplayName("Should sum latest assessment per claim when any claim has multiple assessments")
   void shouldSumLatestAssessmentPerClaimWhenOneClaimHasMultipleAssessments() {
-    AssessedClaim claim1 = createAssessedClaim();
-    AssessedClaim claim2 = createAssessedClaim();
+    ClaimWithFee claim1 = createClaimWithFee();
+    ClaimWithFee claim2 = createClaimWithFee();
 
     saveAssessment(claim1, "10.00", TENTH_APRIL_2024);
     saveAssessment(claim1, "12.00", TWELFTH_APRIL_2024);
@@ -158,8 +158,8 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   @Test
   @DisplayName("Should return zero when latest assessments sum to zero")
   void shouldReturnZeroWhenLatestAssessmentsSumToZero() {
-    AssessedClaim claim1 = createAssessedClaim();
-    AssessedClaim claim2 = createAssessedClaim();
+    ClaimWithFee claim1 = createClaimWithFee();
+    ClaimWithFee claim2 = createClaimWithFee();
 
     saveAssessment(claim1, "10.00", TENTH_APRIL_2024);
     saveAssessment(claim2, "-10.00", ELEVENTH_APRIL_2024);
@@ -172,8 +172,8 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   void shouldReturnAssessedTotalsForMultipleSubmissions() {
     Submission submission2 = createSubmission("office2");
 
-    AssessedClaim submission1Claim = createAssessedClaim();
-    AssessedClaim submission2Claim = createAssessedClaim(submission2);
+    ClaimWithFee submission1Claim = createClaimWithFee();
+    ClaimWithFee submission2Claim = createClaimWithFee(submission2);
 
     saveAssessment(submission1Claim, "10.00", TENTH_APRIL_2024);
     saveAssessment(submission2Claim, "25.50", TENTH_APRIL_2024);
@@ -198,8 +198,8 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   void shouldOnlyCountLatestAssessmentPerClaimAcrossSubmissions() {
     Submission submission2 = createSubmission("office2");
 
-    AssessedClaim submission1Claim = createAssessedClaim();
-    AssessedClaim submission2Claim = createAssessedClaim(submission2);
+    ClaimWithFee submission1Claim = createClaimWithFee();
+    ClaimWithFee submission2Claim = createClaimWithFee(submission2);
 
     saveAssessment(submission1Claim, "10.00", TENTH_APRIL_2024);
     saveAssessment(submission1Claim, "15.00", TWELFTH_APRIL_2024); // latest for submission 1
@@ -227,7 +227,7 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   void shouldNotReturnSubmissionsWithNoAssessmentsInBulkQueryResults() {
     Submission submission2 = createSubmission("office2");
 
-    AssessedClaim submission1Claim = createAssessedClaim();
+    ClaimWithFee submission1Claim = createClaimWithFee();
     saveAssessment(submission1Claim, "10.00", TENTH_APRIL_2024);
 
     Map<UUID, BigDecimal> totals =
@@ -253,15 +253,15 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
     Submission submission3 = createSubmission("office3");
 
     // submission 1 has assessments on two claims
-    AssessedClaim submission1Claim1 = createAssessedClaim();
-    AssessedClaim submission1Claim2 = createAssessedClaim();
+    ClaimWithFee submission1Claim1 = createClaimWithFee();
+    ClaimWithFee submission1Claim2 = createClaimWithFee();
 
     saveAssessment(submission1Claim1, "10.00", TENTH_APRIL_2024);
     saveAssessment(submission1Claim1, "15.00", TWELFTH_APRIL_2024); // latest for claim 1
     saveAssessment(submission1Claim2, "7.50", ELEVENTH_APRIL_2024);
 
     // submission 2 has one assessed claim with multiple assessments
-    AssessedClaim submission2Claim = createAssessedClaim(submission2);
+    ClaimWithFee submission2Claim = createClaimWithFee(submission2);
 
     saveAssessment(submission2Claim, "20.00", TENTH_APRIL_2024);
     saveAssessment(submission2Claim, "5.00", ELEVENTH_APRIL_2024); // latest for submission 2
@@ -317,11 +317,11 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
     return submissionRepository.saveAndFlush(newSubmission);
   }
 
-  private AssessedClaim createAssessedClaim() {
-    return createAssessedClaim(submission);
+  private ClaimWithFee createClaimWithFee() {
+    return createClaimWithFee(submission);
   }
 
-  private AssessedClaim createAssessedClaim(Submission forSubmission) {
+  private ClaimWithFee createClaimWithFee(Submission forSubmission) {
     Claim claim =
         claimRepository.saveAndFlush(
             Claim.builder()
@@ -342,16 +342,16 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
                 .claim(claim)
                 .build());
 
-    return AssessedClaim.builder().claim(claim).claimSummaryFee(claimSummaryFee).build();
+    return ClaimWithFee.builder().claim(claim).claimSummaryFee(claimSummaryFee).build();
   }
 
   private void saveAssessment(
-      AssessedClaim assessedClaim, String assessedTotalInclVat, Instant createdOn) {
+      ClaimWithFee claimWithFee, String assessedTotalInclVat, Instant createdOn) {
     Assessment assessment =
         Assessment.builder()
             .id(UUID.randomUUID())
-            .claim(assessedClaim.claim())
-            .claimSummaryFee(assessedClaim.claimSummaryFee())
+            .claim(claimWithFee.claim())
+            .claimSummaryFee(claimWithFee.claimSummaryFee())
             .assessedTotalVat(BigDecimal.ZERO)
             .assessedTotalInclVat(new BigDecimal(assessedTotalInclVat))
             .allowedTotalVat(BigDecimal.ZERO)
@@ -367,5 +367,5 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   }
 
   @Builder
-  private record AssessedClaim(Claim claim, ClaimSummaryFee claimSummaryFee) {}
+  private record ClaimWithFee(Claim claim, ClaimSummaryFee claimSummaryFee) {}
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepositoryIntegrationTest.java
@@ -10,7 +10,9 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,9 +36,9 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetBulkSubmission200Re
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionStatus;
 
 /**
- * Integration tests for {@link AssessmentRepository#getAssessedTotalAmount(UUID)}.
+ * Integration tests for assessed total aggregation queries.
  *
- * <p>These tests verify that the assessed total amount for a submission is calculated as the sum of
+ * <p>These tests verify that assessed total amounts for submissions are calculated as the sum of
  * {@code assessedTotalInclVat} from the latest assessment for each claim in the submission.
  *
  * <p>The scenarios covered include:
@@ -47,6 +49,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionStatus;
  *   <li>summing assessed totals across multiple claims
  *   <li>counting only the most recent assessment when a claim has multiple assessments
  *   <li>returning zero when the latest assessments sum to zero
+ *   <li>returning grouped assessed totals for multiple submissions
  * </ul>
  */
 @Slf4j
@@ -76,7 +79,6 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
             .createdOn(TENTH_APRIL_2024)
             .updatedOn(TENTH_APRIL_2024)
             .build();
-
     bulkSubmissionRepository.saveAndFlush(bulkSubmission);
 
     submission =
@@ -96,7 +98,6 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
             .providerUserId(bulkSubmission.getCreatedByUserId())
             .createdOn(TENTH_APRIL_2024)
             .build();
-
     submissionRepository.saveAndFlush(submission);
   }
 
@@ -110,7 +111,6 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   @DisplayName("Should return assessed total for one assessed claim")
   void shouldReturnAssessedTotalForOneAssessedClaim() {
     AssessedClaim claim = createAssessedClaim();
-
     saveAssessment(claim, "12.34", TENTH_APRIL_2024);
 
     assertAssessedTotal("12.34");
@@ -147,9 +147,11 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
 
     saveAssessment(claim1, "10.00", TENTH_APRIL_2024);
     saveAssessment(claim1, "12.00", TWELFTH_APRIL_2024);
+
     saveAssessment(claim2, "15.00", TENTH_APRIL_2024);
     saveAssessment(claim2, "33.00", ELEVENTH_APRIL_2024);
     saveAssessment(claim2, "5.00", TWELFTH_APRIL_2024);
+
     assertAssessedTotal("17.00");
   }
 
@@ -165,77 +167,28 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
     assertAssessedTotal("0.00");
   }
 
-  private void assertAssessedTotal(String expected) {
-    BigDecimal result = assessmentRepository.getAssessedTotalAmount(submission.getId());
-    assertThat(result).isEqualByComparingTo(expected);
-  }
-
   @Test
   @DisplayName("Should return assessed totals for multiple submissions")
   void shouldReturnAssessedTotalsForMultipleSubmissions() {
-    // Second submission
-    Submission submission2 =
-        Submission.builder()
-            .id(UUID.randomUUID())
-            .bulkSubmissionId(submission.getBulkSubmissionId())
-            .officeAccountNumber("office2")
-            .submissionPeriod("JAN-25")
-            .areaOfLaw(AreaOfLaw.LEGAL_HELP)
-            .status(SubmissionStatus.CREATED)
-            .createdByUserId(USER_ID)
-            .providerUserId(submission.getProviderUserId())
-            .createdOn(TENTH_APRIL_2024)
-            .build();
+    Submission submission2 = createSubmission("office2");
 
-    submissionRepository.saveAndFlush(submission2);
+    AssessedClaim submission1Claim = createAssessedClaim();
+    AssessedClaim submission2Claim = createAssessedClaim(submission2);
 
-    // Submission 1 assessments
-    AssessedClaim s1Claim1 = createAssessedClaim();
-    saveAssessment(s1Claim1, "10.00", TENTH_APRIL_2024);
+    saveAssessment(submission1Claim, "10.00", TENTH_APRIL_2024);
+    saveAssessment(submission2Claim, "25.50", TENTH_APRIL_2024);
 
-    // Submission 2 assessments
-    Claim claimForSubmission2 =
-        claimRepository.saveAndFlush(
-            Claim.builder()
-                .id(UUID.randomUUID())
-                .submission(submission2)
-                .hasAssessment(true)
-                .matterTypeCode("MTC-444")
-                .status(ClaimStatus.READY_TO_PROCESS)
-                .lineNumber(1)
-                .createdByUserId(USER_ID)
-                .build());
-
-    ClaimSummaryFee feeForSubmission2 =
-        claimSummaryFeeRepository.saveAndFlush(
-            ClaimSummaryFee.builder()
-                .id(UUID.randomUUID())
-                .claim(claimForSubmission2)
-                .createdByUserId(USER_ID)
-                .build());
-
-    saveAssessment(
-        AssessedClaim.builder()
-            .claim(claimForSubmission2)
-            .claimSummaryFee(feeForSubmission2)
-            .build(),
-        "25.50",
-        TENTH_APRIL_2024);
-
-    // Execute
-    var results =
-        assessmentRepository.getAssessedTotalAmounts(
-            List.of(submission.getId(), submission2.getId()));
-
-    // Convert to Map for easy assertion
-    var totals =
-        results.stream()
+    Map<UUID, BigDecimal> totals =
+        assessmentRepository
+            .getAssessedTotalAmounts(List.of(submission.getId(), submission2.getId()))
+            .stream()
             .collect(
-                java.util.stream.Collectors.toMap(
-                    r -> (UUID) r.getSubmissionId(), r -> (BigDecimal) r.getTotal()));
+                Collectors.toMap(
+                    AssessmentRepository.AssessedTotalAmountProjection::getSubmissionId,
+                    AssessmentRepository.AssessedTotalAmountProjection::getTotal));
 
-    // Assert
     assertThat(totals)
+        .hasSize(2)
         .containsEntry(submission.getId(), new BigDecimal("10.00"))
         .containsEntry(submission2.getId(), new BigDecimal("25.50"));
   }
@@ -243,14 +196,98 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   @Test
   @DisplayName("Should only count the latest assessment per claim across submissions")
   void shouldOnlyCountLatestAssessmentPerClaimAcrossSubmissions() {
-    AssessedClaim claim1 = createAssessedClaim();
-    saveAssessment(claim1, "10.00", TENTH_APRIL_2024);
-    saveAssessment(claim1, "15.00", TWELFTH_APRIL_2024); // latest
+    Submission submission2 = createSubmission("office2");
 
-    var results = assessmentRepository.getAssessedTotalAmounts(List.of(submission.getId()));
+    AssessedClaim submission1Claim = createAssessedClaim();
+    AssessedClaim submission2Claim = createAssessedClaim(submission2);
 
-    assertThat(results).hasSize(1);
-    assertThat((BigDecimal) results.getFirst().getTotal()).isEqualByComparingTo("15.00");
+    saveAssessment(submission1Claim, "10.00", TENTH_APRIL_2024);
+    saveAssessment(submission1Claim, "15.00", TWELFTH_APRIL_2024); // latest for submission 1
+
+    saveAssessment(submission2Claim, "20.00", TENTH_APRIL_2024);
+    saveAssessment(submission2Claim, "5.00", ELEVENTH_APRIL_2024); // latest for submission 2
+
+    Map<UUID, BigDecimal> totals =
+        assessmentRepository
+            .getAssessedTotalAmounts(List.of(submission.getId(), submission2.getId()))
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    AssessmentRepository.AssessedTotalAmountProjection::getSubmissionId,
+                    AssessmentRepository.AssessedTotalAmountProjection::getTotal));
+
+    assertThat(totals)
+        .hasSize(2)
+        .containsEntry(submission.getId(), new BigDecimal("15.00"))
+        .containsEntry(submission2.getId(), new BigDecimal("5.00"));
+  }
+
+  @Test
+  @DisplayName("Should not return submissions with no assessments in bulk query results")
+  void shouldNotReturnSubmissionsWithNoAssessmentsInBulkQueryResults() {
+    Submission submission2 = createSubmission("office2");
+
+    AssessedClaim submission1Claim = createAssessedClaim();
+    saveAssessment(submission1Claim, "10.00", TENTH_APRIL_2024);
+
+    Map<UUID, BigDecimal> totals =
+        assessmentRepository
+            .getAssessedTotalAmounts(List.of(submission.getId(), submission2.getId()))
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    AssessmentRepository.AssessedTotalAmountProjection::getSubmissionId,
+                    AssessmentRepository.AssessedTotalAmountProjection::getTotal));
+
+    assertThat(totals)
+        .hasSize(1)
+        .containsEntry(submission.getId(), new BigDecimal("10.00"))
+        .doesNotContainKey(submission2.getId());
+  }
+
+  @Test
+  @DisplayName(
+      "Should return only submissions with assessments and use latest assessment per claim")
+  void shouldReturnOnlySubmissionsWithAssessmentsAndUseLatestAssessmentPerClaim() {
+    Submission submission2 = createSubmission("office2");
+    Submission submission3 = createSubmission("office3");
+
+    // submission 1 has assessments on two claims
+    AssessedClaim submission1Claim1 = createAssessedClaim();
+    AssessedClaim submission1Claim2 = createAssessedClaim();
+
+    saveAssessment(submission1Claim1, "10.00", TENTH_APRIL_2024);
+    saveAssessment(submission1Claim1, "15.00", TWELFTH_APRIL_2024); // latest for claim 1
+    saveAssessment(submission1Claim2, "7.50", ELEVENTH_APRIL_2024);
+
+    // submission 2 has one assessed claim with multiple assessments
+    AssessedClaim submission2Claim = createAssessedClaim(submission2);
+
+    saveAssessment(submission2Claim, "20.00", TENTH_APRIL_2024);
+    saveAssessment(submission2Claim, "5.00", ELEVENTH_APRIL_2024); // latest for submission 2
+
+    // submission 3 has no assessments
+
+    Map<UUID, BigDecimal> totals =
+        assessmentRepository
+            .getAssessedTotalAmounts(
+                List.of(submission.getId(), submission2.getId(), submission3.getId()))
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    AssessmentRepository.AssessedTotalAmountProjection::getSubmissionId,
+                    AssessmentRepository.AssessedTotalAmountProjection::getTotal));
+
+    assertThat(totals)
+        .hasSize(2)
+        .containsEntry(submission.getId(), new BigDecimal("22.50"))
+        .containsEntry(submission2.getId(), new BigDecimal("5.00"))
+        .doesNotContainKey(submission3.getId());
+  }
+
+  private void assertAssessedTotal(String expected) {
+    BigDecimal result = assessmentRepository.getAssessedTotalAmount(submission.getId());
+    assertThat(result).isEqualByComparingTo(expected);
   }
 
   private void assertAssessedTotalIsNull() {
@@ -258,12 +295,38 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
     assertThat(result).isNull();
   }
 
+  private Submission createSubmission(String officeAccountNumber) {
+    Submission newSubmission =
+        Submission.builder()
+            .id(UUID.randomUUID())
+            .bulkSubmissionId(submission.getBulkSubmissionId())
+            .officeAccountNumber(officeAccountNumber)
+            .submissionPeriod("JAN-25")
+            .areaOfLaw(AreaOfLaw.LEGAL_HELP)
+            .status(SubmissionStatus.CREATED)
+            .crimeLowerScheduleNumber(officeAccountNumber + "/CRIME")
+            .legalHelpSubmissionReference(officeAccountNumber + "/LEGAL")
+            .mediationSubmissionReference(officeAccountNumber + "/MEDIATION")
+            .isNilSubmission(false)
+            .numberOfClaims(2)
+            .createdByUserId(USER_ID)
+            .providerUserId(submission.getProviderUserId())
+            .createdOn(TENTH_APRIL_2024)
+            .build();
+
+    return submissionRepository.saveAndFlush(newSubmission);
+  }
+
   private AssessedClaim createAssessedClaim() {
+    return createAssessedClaim(submission);
+  }
+
+  private AssessedClaim createAssessedClaim(Submission forSubmission) {
     Claim claim =
         claimRepository.saveAndFlush(
             Claim.builder()
                 .id(UUID.randomUUID())
-                .submission(submission)
+                .submission(forSubmission)
                 .hasAssessment(true)
                 .matterTypeCode("MTC-333")
                 .status(ClaimStatus.READY_TO_PROCESS)
@@ -284,7 +347,6 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
 
   private void saveAssessment(
       AssessedClaim assessedClaim, String assessedTotalInclVat, Instant createdOn) {
-
     Assessment assessment =
         Assessment.builder()
             .id(UUID.randomUUID())

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepositoryIntegrationTest.java
@@ -230,7 +230,9 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
     // Convert to Map for easy assertion
     var totals =
         results.stream()
-            .collect(java.util.stream.Collectors.toMap(r -> (UUID) r[0], r -> (BigDecimal) r[1]));
+            .collect(
+                java.util.stream.Collectors.toMap(
+                    r -> (UUID) r.getSubmissionId(), r -> (BigDecimal) r.getTotal()));
 
     // Assert
     assertThat(totals)
@@ -248,7 +250,7 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
     var results = assessmentRepository.getAssessedTotalAmounts(List.of(submission.getId()));
 
     assertThat(results).hasSize(1);
-    assertThat((BigDecimal) results.getFirst()[1]).isEqualByComparingTo("15.00");
+    assertThat((BigDecimal) results.getFirst().getTotal()).isEqualByComparingTo("15.00");
   }
 
   private void assertAssessedTotalIsNull() {

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepositoryIntegrationTest.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
@@ -167,6 +168,87 @@ class AssessmentRepositoryIntegrationTest extends AbstractIntegrationTest {
   private void assertAssessedTotal(String expected) {
     BigDecimal result = assessmentRepository.getAssessedTotalAmount(submission.getId());
     assertThat(result).isEqualByComparingTo(expected);
+  }
+
+  @Test
+  @DisplayName("Should return assessed totals for multiple submissions")
+  void shouldReturnAssessedTotalsForMultipleSubmissions() {
+    // Second submission
+    Submission submission2 =
+        Submission.builder()
+            .id(UUID.randomUUID())
+            .bulkSubmissionId(submission.getBulkSubmissionId())
+            .officeAccountNumber("office2")
+            .submissionPeriod("JAN-25")
+            .areaOfLaw(AreaOfLaw.LEGAL_HELP)
+            .status(SubmissionStatus.CREATED)
+            .createdByUserId(USER_ID)
+            .providerUserId(submission.getProviderUserId())
+            .createdOn(TENTH_APRIL_2024)
+            .build();
+
+    submissionRepository.saveAndFlush(submission2);
+
+    // Submission 1 assessments
+    AssessedClaim s1Claim1 = createAssessedClaim();
+    saveAssessment(s1Claim1, "10.00", TENTH_APRIL_2024);
+
+    // Submission 2 assessments
+    Claim claimForSubmission2 =
+        claimRepository.saveAndFlush(
+            Claim.builder()
+                .id(UUID.randomUUID())
+                .submission(submission2)
+                .hasAssessment(true)
+                .matterTypeCode("MTC-444")
+                .status(ClaimStatus.READY_TO_PROCESS)
+                .lineNumber(1)
+                .createdByUserId(USER_ID)
+                .build());
+
+    ClaimSummaryFee feeForSubmission2 =
+        claimSummaryFeeRepository.saveAndFlush(
+            ClaimSummaryFee.builder()
+                .id(UUID.randomUUID())
+                .claim(claimForSubmission2)
+                .createdByUserId(USER_ID)
+                .build());
+
+    saveAssessment(
+        AssessedClaim.builder()
+            .claim(claimForSubmission2)
+            .claimSummaryFee(feeForSubmission2)
+            .build(),
+        "25.50",
+        TENTH_APRIL_2024);
+
+    // Execute
+    var results =
+        assessmentRepository.getAssessedTotalAmounts(
+            List.of(submission.getId(), submission2.getId()));
+
+    // Convert to Map for easy assertion
+    var totals =
+        results.stream()
+            .collect(java.util.stream.Collectors.toMap(r -> (UUID) r[0], r -> (BigDecimal) r[1]));
+
+    // Assert
+    assertThat(totals)
+        .containsEntry(submission.getId(), new BigDecimal("10.00"))
+        .containsEntry(submission2.getId(), new BigDecimal("25.50"));
+  }
+
+  @Test
+  @DisplayName("Should only count the latest assessment per claim across submissions")
+  void shouldOnlyCountLatestAssessmentPerClaimAcrossSubmissions() {
+    AssessedClaim claim1 = createAssessedClaim();
+    saveAssessment(claim1, "10.00", TENTH_APRIL_2024);
+    saveAssessment(claim1, "15.00", TWELFTH_APRIL_2024); // latest
+
+    var results = assessmentRepository.getAssessedTotalAmounts(List.of(submission.getId()));
+
+    assertThat(results).hasSize(1);
+    assertThat((BigDecimal) results.getFirst()[1]).isEqualByComparingTo("15.00");
   }
 
   private void assertAssessedTotalIsNull() {

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.repository;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -20,14 +21,28 @@ public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
 
   @Query(
       """
-      SELECT SUM(a.assessedTotalInclVat)
+          SELECT SUM(a.assessedTotalInclVat)
+          FROM Assessment a
+          WHERE a.claim.submission.id = :submissionId
+            AND a.createdOn = (
+                SELECT MAX(a2.createdOn)
+                FROM Assessment a2
+                WHERE a2.claim = a.claim
+            )
+          """)
+  BigDecimal getAssessedTotalAmount(@Param("submissionId") UUID submissionId);
+
+  @Query(
+      """
+      SELECT a.claim.submission.id, SUM(a.assessedTotalInclVat)
       FROM Assessment a
-      WHERE a.claim.submission.id = :submissionId
+      WHERE a.claim.submission.id IN :submissionIds
         AND a.createdOn = (
             SELECT MAX(a2.createdOn)
             FROM Assessment a2
             WHERE a2.claim = a.claim
         )
+      GROUP BY a.claim.submission.id
       """)
-  BigDecimal getAssessedTotalAmount(@Param("submissionId") UUID submissionId);
+  List<Object[]> getAssessedTotalAmounts(@Param("submissionIds") List<UUID> submissionIds);
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
@@ -15,6 +15,12 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
 /** Repository for accessing {@link Assessment} entities. */
 @Repository
 public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
+  interface AssessedTotalAmountProjection {
+    UUID getSubmissionId();
+
+    BigDecimal getTotal();
+  }
+
   Optional<Assessment> findByIdAndClaimId(UUID assessmentId, UUID claimId);
 
   Page<Assessment> findByClaimId(UUID claimId, Pageable pageable);
@@ -34,7 +40,7 @@ public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
 
   @Query(
       """
-      SELECT a.claim.submission.id, SUM(a.assessedTotalInclVat)
+      SELECT a.claim.submission.id AS submissionId, SUM(a.assessedTotalInclVat) AS total
       FROM Assessment a
       WHERE a.claim.submission.id IN :submissionIds
         AND a.createdOn = (
@@ -44,5 +50,6 @@ public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
         )
       GROUP BY a.claim.submission.id
       """)
-  List<Object[]> getAssessedTotalAmounts(@Param("submissionIds") List<UUID> submissionIds);
+  List<AssessedTotalAmountProjection> getAssessedTotalAmounts(
+      @Param("submissionIds") List<UUID> submissionIds);
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
@@ -15,16 +15,59 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
 /** Repository for accessing {@link Assessment} entities. */
 @Repository
 public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
+
+  /**
+   * Projection for assessed total amounts grouped by submission.
+   *
+   * <p>Used by {@link #getAssessedTotalAmounts(List)} to return the assessed total amount for each
+   * submission without loading full entity data.
+   */
   interface AssessedTotalAmountProjection {
+
+    /**
+     * Returns the identifier of the submission.
+     *
+     * @return the submission ID
+     */
     UUID getSubmissionId();
 
+    /**
+     * Returns the assessed total amount for the submission.
+     *
+     * @return the summed assessed total amount
+     */
     BigDecimal getTotal();
   }
 
+  /**
+   * Finds an assessment by its identifier and associated claim identifier.
+   *
+   * @param assessmentId the unique identifier of the assessment
+   * @param claimId the unique identifier of the claim
+   * @return an {@link Optional} containing the matching assessment, or empty if none found
+   */
   Optional<Assessment> findByIdAndClaimId(UUID assessmentId, UUID claimId);
 
+  /**
+   * Returns a paginated list of assessments for the given claim.
+   *
+   * @param claimId the unique identifier of the claim
+   * @param pageable pagination information
+   * @return a page of assessments associated with the claim
+   */
   Page<Assessment> findByClaimId(UUID claimId, Pageable pageable);
 
+  /**
+   * Returns the assessed total amount for the given submission.
+   *
+   * <p>This is calculated as the sum of {@code assessedTotalInclVat} from the latest assessment for
+   * each claim belonging to the submission. If no assessments exist for any claim in the
+   * submission, this method returns {@code null}.
+   *
+   * @param submissionId the unique identifier of the submission
+   * @return the summed assessed total amount for the submission, or {@code null} if no assessments
+   *     exist
+   */
   @Query(
       """
           SELECT SUM(a.assessedTotalInclVat)
@@ -38,18 +81,30 @@ public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
           """)
   BigDecimal getAssessedTotalAmount(@Param("submissionId") UUID submissionId);
 
+  /**
+   * Returns assessed total amounts for the given submissions.
+   *
+   * <p>For each submission ID provided, this query returns the sum of {@code assessedTotalInclVat}
+   * from the latest assessment for each claim belonging to that submission. Results are grouped by
+   * submission ID.
+   *
+   * <p>Submissions with no assessments are not included in the returned list.
+   *
+   * @param submissionIds the unique identifiers of the submissions
+   * @return a list of projections containing submission IDs and their assessed total amounts
+   */
   @Query(
       """
-      SELECT a.claim.submission.id AS submissionId, SUM(a.assessedTotalInclVat) AS total
-      FROM Assessment a
-      WHERE a.claim.submission.id IN :submissionIds
-        AND a.createdOn = (
-            SELECT MAX(a2.createdOn)
-            FROM Assessment a2
-            WHERE a2.claim = a.claim
-        )
-      GROUP BY a.claim.submission.id
-      """)
+          SELECT a.claim.submission.id AS submissionId, SUM(a.assessedTotalInclVat) AS total
+          FROM Assessment a
+          WHERE a.claim.submission.id IN :submissionIds
+            AND a.createdOn = (
+                SELECT MAX(a2.createdOn)
+                FROM Assessment a2
+                WHERE a2.claim = a.claim
+            )
+          GROUP BY a.claim.submission.id
+          """)
   List<AssessedTotalAmountProjection> getAssessedTotalAmounts(
       @Param("submissionIds") List<UUID> submissionIds);
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
@@ -24,7 +25,9 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.repository.AssessmentReposit
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimRepository;
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 
-/** Service containing business logic for handling assessments. */
+/**
+ * Service containing business logic for handling assessments.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -96,7 +99,7 @@ public class AssessmentService {
    * {@code claimId}. If no matching assessment is found, an {@link AssessmentNotFoundException} is
    * thrown.
    *
-   * @param claimId the unique identifier of the claim
+   * @param claimId      the unique identifier of the claim
    * @param assessmentId the unique identifier of the assessment
    * @return an {@link AssessmentGet} DTO containing assessment details
    * @throws AssessmentNotFoundException if the assessment does not exist for the given claim
@@ -128,7 +131,7 @@ public class AssessmentService {
    *
    * @param claimId the unique identifier of the claim; must not be {@code null}.
    * @return an {@link AssessmentResultSet} containing all assessments for the claim.
-   * @throws IllegalArgumentException if {@code claimId} is {@code null}.
+   * @throws IllegalArgumentException    if {@code claimId} is {@code null}.
    * @throws AssessmentNotFoundException if no assessments exist for the given claim ID.
    */
   @Transactional(readOnly = true)
@@ -146,9 +149,9 @@ public class AssessmentService {
    * monetary fields are set to zero and common fields are populated using the provided arguments.
    *
    * @param assessmentReason the reason for creating the void assessment
-   * @param claim the associated {@link Claim} instance
-   * @param claimSummaryFee the related {@link ClaimSummaryFee} instance
-   * @param createdByUserId the UUID of the user creating the assessment
+   * @param claim            the associated {@link Claim} instance
+   * @param claimSummaryFee  the related {@link ClaimSummaryFee} instance
+   * @param createdByUserId  the UUID of the user creating the assessment
    * @return a new {@link Assessment} of type VOID
    */
   public Assessment createVoidAssessment(
@@ -198,12 +201,12 @@ public class AssessmentService {
   /**
    * Populates common fields in the given {@link Assessment} based on the provided parameters.
    *
-   * @param assessment the {@link Assessment} to be updated
-   * @param claim the associated {@link Claim} instance
-   * @param claimSummaryFee the related {@link ClaimSummaryFee} instance
-   * @param createdByUserId the ID of the user creating the assessment
+   * @param assessment       the {@link Assessment} to be updated
+   * @param claim            the associated {@link Claim} instance
+   * @param claimSummaryFee  the related {@link ClaimSummaryFee} instance
+   * @param createdByUserId  the ID of the user creating the assessment
    * @param assessmentReason the reason for the assessment
-   * @param assessmentType the type of the assessment (e.g., VOID)
+   * @param assessmentType   the type of the assessment (e.g., VOID)
    */
   protected void setCommonFields(
       Assessment assessment,
@@ -232,14 +235,22 @@ public class AssessmentService {
    *
    * @param submissionId the unique identifier of the submission
    * @return the summed assessed total amount for the submission, or {@code null} if no assessments
-   *     exist ``
+   * exist ``
    */
   public BigDecimal getAssessedTotalAmount(UUID submissionId) {
     return assessmentRepository.getAssessedTotalAmount(submissionId);
   }
 
   public Map<UUID, BigDecimal> getAssessedTotalAmounts(List<UUID> submissionIds) {
-    return assessmentRepository.getAssessedTotalAmounts(submissionIds).stream()
-        .collect(Collectors.toMap(row -> (UUID) row[0], row -> (BigDecimal) row[1]));
+    if (CollectionUtils.isEmpty(submissionIds)) {
+      return Map.of();
+    }
+
+    return assessmentRepository.getAssessedTotalAmounts(submissionIds)
+        .stream()
+        .collect(Collectors.toMap(
+            AssessmentRepository.AssessedTotalAmountProjection::getSubmissionId,
+            AssessmentRepository.AssessedTotalAmountProjection::getTotal
+        ));
   }
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
@@ -2,7 +2,10 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.service;
 
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -233,5 +236,10 @@ public class AssessmentService {
    */
   public BigDecimal getAssessedTotalAmount(UUID submissionId) {
     return assessmentRepository.getAssessedTotalAmount(submissionId);
+  }
+
+  public Map<UUID, BigDecimal> getAssessedTotalAmounts(List<UUID> submissionIds) {
+    return assessmentRepository.getAssessedTotalAmounts(submissionIds).stream()
+        .collect(Collectors.toMap(row -> (UUID) row[0], row -> (BigDecimal) row[1]));
   }
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
@@ -25,9 +25,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.repository.AssessmentReposit
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimRepository;
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 
-/**
- * Service containing business logic for handling assessments.
- */
+/** Service containing business logic for handling assessments. */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -99,7 +97,7 @@ public class AssessmentService {
    * {@code claimId}. If no matching assessment is found, an {@link AssessmentNotFoundException} is
    * thrown.
    *
-   * @param claimId      the unique identifier of the claim
+   * @param claimId the unique identifier of the claim
    * @param assessmentId the unique identifier of the assessment
    * @return an {@link AssessmentGet} DTO containing assessment details
    * @throws AssessmentNotFoundException if the assessment does not exist for the given claim
@@ -131,7 +129,7 @@ public class AssessmentService {
    *
    * @param claimId the unique identifier of the claim; must not be {@code null}.
    * @return an {@link AssessmentResultSet} containing all assessments for the claim.
-   * @throws IllegalArgumentException    if {@code claimId} is {@code null}.
+   * @throws IllegalArgumentException if {@code claimId} is {@code null}.
    * @throws AssessmentNotFoundException if no assessments exist for the given claim ID.
    */
   @Transactional(readOnly = true)
@@ -149,9 +147,9 @@ public class AssessmentService {
    * monetary fields are set to zero and common fields are populated using the provided arguments.
    *
    * @param assessmentReason the reason for creating the void assessment
-   * @param claim            the associated {@link Claim} instance
-   * @param claimSummaryFee  the related {@link ClaimSummaryFee} instance
-   * @param createdByUserId  the UUID of the user creating the assessment
+   * @param claim the associated {@link Claim} instance
+   * @param claimSummaryFee the related {@link ClaimSummaryFee} instance
+   * @param createdByUserId the UUID of the user creating the assessment
    * @return a new {@link Assessment} of type VOID
    */
   public Assessment createVoidAssessment(
@@ -201,12 +199,12 @@ public class AssessmentService {
   /**
    * Populates common fields in the given {@link Assessment} based on the provided parameters.
    *
-   * @param assessment       the {@link Assessment} to be updated
-   * @param claim            the associated {@link Claim} instance
-   * @param claimSummaryFee  the related {@link ClaimSummaryFee} instance
-   * @param createdByUserId  the ID of the user creating the assessment
+   * @param assessment the {@link Assessment} to be updated
+   * @param claim the associated {@link Claim} instance
+   * @param claimSummaryFee the related {@link ClaimSummaryFee} instance
+   * @param createdByUserId the ID of the user creating the assessment
    * @param assessmentReason the reason for the assessment
-   * @param assessmentType   the type of the assessment (e.g., VOID)
+   * @param assessmentType the type of the assessment (e.g., VOID)
    */
   protected void setCommonFields(
       Assessment assessment,
@@ -235,22 +233,36 @@ public class AssessmentService {
    *
    * @param submissionId the unique identifier of the submission
    * @return the summed assessed total amount for the submission, or {@code null} if no assessments
-   * exist ``
+   *     exist ``
    */
   public BigDecimal getAssessedTotalAmount(UUID submissionId) {
     return assessmentRepository.getAssessedTotalAmount(submissionId);
   }
 
+  /**
+   * Returns assessed total amounts for the given submissions.
+   *
+   * <p>For each submission ID provided, this method retrieves the summed {@code
+   * assessedTotalInclVat} from the latest assessment for each claim belonging to that submission.
+   * If the input list is {@code null} or empty, this method returns an empty map.
+   *
+   * <p>The returned map is keyed by submission ID, with each value representing the assessed total
+   * amount for that submission. Submissions with no assessments will not be present in the returned
+   * map.
+   *
+   * @param submissionIds the unique identifiers of the submissions
+   * @return a map of submission IDs to assessed total amounts, or an empty map if the input is
+   *     {@code null} or empty
+   */
   public Map<UUID, BigDecimal> getAssessedTotalAmounts(List<UUID> submissionIds) {
     if (CollectionUtils.isEmpty(submissionIds)) {
       return Map.of();
     }
 
-    return assessmentRepository.getAssessedTotalAmounts(submissionIds)
-        .stream()
-        .collect(Collectors.toMap(
-            AssessmentRepository.AssessedTotalAmountProjection::getSubmissionId,
-            AssessmentRepository.AssessedTotalAmountProjection::getTotal
-        ));
+    return assessmentRepository.getAssessedTotalAmounts(submissionIds).stream()
+        .collect(
+            Collectors.toMap(
+                AssessmentRepository.AssessedTotalAmountProjection::getSubmissionId,
+                AssessmentRepository.AssessedTotalAmountProjection::getTotal));
   }
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -35,9 +35,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.service.lookup.AbstractEntit
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.BigDecimalUtils;
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.TransactionalPublisher;
 
-/**
- * Service containing business logic for handling submissions.
- */
+/** Service containing business logic for handling submissions. */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -121,7 +119,7 @@ public class SubmissionService
   /**
    * Partially update a submission.
    *
-   * @param id              the submission id
+   * @param id the submission id
    * @param submissionPatch patch object containing updated fields
    */
   @Transactional
@@ -158,16 +156,16 @@ public class SubmissionService
    * Returns all the existing submissions filtered by some parameters and paginated in a {@link
    * SubmissionsResultSet}.
    *
-   * @param offices            a mandatory list of office codes to filter submissions by
-   * @param submissionId       an optional identifier to filter submissions by
-   * @param submittedDateFrom  an optional end date to filter submissions created on or after this
-   *                           date
-   * @param submittedDateTo    an optional end date to filter submissions created on or before this
-   *                           date
+   * @param offices a mandatory list of office codes to filter submissions by
+   * @param submissionId an optional identifier to filter submissions by
+   * @param submittedDateFrom an optional end date to filter submissions created on or after this
+   *     date
+   * @param submittedDateTo an optional end date to filter submissions created on or before this
+   *     date
    * @param submissionStatuses an optional list of submission statuses to filter submissions by
-   * @param pageable           a pageable object to yield the paginated submission results
+   * @param pageable a pageable object to yield the paginated submission results
    * @return the paginated result set with all submissions that satisfy the filtering criteria
-   * above.
+   *     above.
    */
   @Transactional(readOnly = true)
   public SubmissionsResultSet getSubmissionsResultSet(
@@ -195,27 +193,24 @@ public class SubmissionService
                 .and(SubmissionSpecification.submissionStatusIn(submissionStatuses)),
             pageable);
 
-    List<UUID> submissionIds =
-        page.getContent().stream()
-            .map(Submission::getId)
-            .toList();
+    List<UUID> submissionIds = page.getContent().stream().map(Submission::getId).toList();
 
     Map<UUID, BigDecimal> assessedTotalAmounts =
         submissionIds.isEmpty()
             ? Map.of()
             : assessmentService.getAssessedTotalAmounts(submissionIds);
 
-    SubmissionsResultSet resultSet =
-        submissionsResultSetMapper.toSubmissionsResultSet(page);
+    SubmissionsResultSet resultSet = submissionsResultSetMapper.toSubmissionsResultSet(page);
 
-    resultSet.getContent().forEach(submissionBase -> {
-      BigDecimal assessedTotal =
-          assessedTotalAmounts.get(submissionBase.getSubmissionId());
+    resultSet
+        .getContent()
+        .forEach(
+            submissionBase -> {
+              BigDecimal assessedTotal = assessedTotalAmounts.get(submissionBase.getSubmissionId());
 
-      submissionBase.setAssessedTotalAmount(
-          BigDecimalUtils.scaleNullable(assessedTotal, DECIMAL_PLACES)
-      );
-    });
+              submissionBase.setAssessedTotalAmount(
+                  BigDecimalUtils.scaleNullable(assessedTotal, DECIMAL_PLACES));
+            });
 
     return resultSet;
   }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -193,14 +193,15 @@ public class SubmissionService
                 .and(SubmissionSpecification.submissionStatusIn(submissionStatuses)),
             pageable);
 
+    SubmissionsResultSet resultSet = submissionsResultSetMapper.toSubmissionsResultSet(page);
     List<UUID> submissionIds = page.getContent().stream().map(Submission::getId).toList();
 
-    Map<UUID, BigDecimal> assessedTotalAmounts =
-        submissionIds.isEmpty()
-            ? Map.of()
-            : assessmentService.getAssessedTotalAmounts(submissionIds);
+    if (submissionIds.isEmpty()) {
+      return resultSet;
+    }
 
-    SubmissionsResultSet resultSet = submissionsResultSetMapper.toSubmissionsResultSet(page);
+    Map<UUID, BigDecimal> assessedTotalAmounts =
+        assessmentService.getAssessedTotalAmounts(submissionIds);
 
     resultSet
         .getContent()

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -1,9 +1,11 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.service;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
@@ -191,6 +193,20 @@ public class SubmissionService
                 .and(SubmissionSpecification.submissionStatusIn(submissionStatuses)),
             pageable);
 
-    return submissionsResultSetMapper.toSubmissionsResultSet(page);
+    List<UUID> submissionIds = page.getContent().stream().map(Submission::getId).toList();
+
+    Map<UUID, BigDecimal> assessedTotalAmounts =
+        assessmentService.getAssessedTotalAmounts(submissionIds);
+
+    SubmissionsResultSet resultSet = submissionsResultSetMapper.toSubmissionsResultSet(page);
+    resultSet
+        .getContent()
+        .forEach(
+            submissionBase -> {
+              BigDecimal assessedTotal = assessedTotalAmounts.get(submissionBase.getSubmissionId());
+              submissionBase.setAssessedTotalAmount(
+                  BigDecimalUtils.scaleNullable(assessedTotal, DECIMAL_PLACES));
+            });
+    return resultSet;
   }
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -35,7 +35,9 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.service.lookup.AbstractEntit
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.BigDecimalUtils;
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.TransactionalPublisher;
 
-/** Service containing business logic for handling submissions. */
+/**
+ * Service containing business logic for handling submissions.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -119,7 +121,7 @@ public class SubmissionService
   /**
    * Partially update a submission.
    *
-   * @param id the submission id
+   * @param id              the submission id
    * @param submissionPatch patch object containing updated fields
    */
   @Transactional
@@ -156,16 +158,16 @@ public class SubmissionService
    * Returns all the existing submissions filtered by some parameters and paginated in a {@link
    * SubmissionsResultSet}.
    *
-   * @param offices a mandatory list of office codes to filter submissions by
-   * @param submissionId an optional identifier to filter submissions by
-   * @param submittedDateFrom an optional end date to filter submissions created on or after this
-   *     date
-   * @param submittedDateTo an optional end date to filter submissions created on or before this
-   *     date
+   * @param offices            a mandatory list of office codes to filter submissions by
+   * @param submissionId       an optional identifier to filter submissions by
+   * @param submittedDateFrom  an optional end date to filter submissions created on or after this
+   *                           date
+   * @param submittedDateTo    an optional end date to filter submissions created on or before this
+   *                           date
    * @param submissionStatuses an optional list of submission statuses to filter submissions by
-   * @param pageable a pageable object to yield the paginated submission results
+   * @param pageable           a pageable object to yield the paginated submission results
    * @return the paginated result set with all submissions that satisfy the filtering criteria
-   *     above.
+   * above.
    */
   @Transactional(readOnly = true)
   public SubmissionsResultSet getSubmissionsResultSet(
@@ -193,20 +195,28 @@ public class SubmissionService
                 .and(SubmissionSpecification.submissionStatusIn(submissionStatuses)),
             pageable);
 
-    List<UUID> submissionIds = page.getContent().stream().map(Submission::getId).toList();
+    List<UUID> submissionIds =
+        page.getContent().stream()
+            .map(Submission::getId)
+            .toList();
 
     Map<UUID, BigDecimal> assessedTotalAmounts =
-        assessmentService.getAssessedTotalAmounts(submissionIds);
+        submissionIds.isEmpty()
+            ? Map.of()
+            : assessmentService.getAssessedTotalAmounts(submissionIds);
 
-    SubmissionsResultSet resultSet = submissionsResultSetMapper.toSubmissionsResultSet(page);
-    resultSet
-        .getContent()
-        .forEach(
-            submissionBase -> {
-              BigDecimal assessedTotal = assessedTotalAmounts.get(submissionBase.getSubmissionId());
-              submissionBase.setAssessedTotalAmount(
-                  BigDecimalUtils.scaleNullable(assessedTotal, DECIMAL_PLACES));
-            });
+    SubmissionsResultSet resultSet =
+        submissionsResultSetMapper.toSubmissionsResultSet(page);
+
+    resultSet.getContent().forEach(submissionBase -> {
+      BigDecimal assessedTotal =
+          assessedTotalAmounts.get(submissionBase.getSubmissionId());
+
+      submissionBase.setAssessedTotalAmount(
+          BigDecimalUtils.scaleNullable(assessedTotal, DECIMAL_PLACES)
+      );
+    });
+
     return resultSet;
   }
 }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
@@ -382,11 +382,34 @@ class AssessmentServiceTest {
     BigDecimal total1 = new BigDecimal("100.50");
     BigDecimal total2 = new BigDecimal("25.00");
 
-    List<Object[]> repositoryResult =
-        List.of(new Object[] {submissionId1, total1}, new Object[] {submissionId2, total2});
+    AssessmentRepository.AssessedTotalAmountProjection projection1 =
+        new AssessmentRepository.AssessedTotalAmountProjection() {
+          @Override
+          public UUID getSubmissionId() {
+            return submissionId1;
+          }
+
+          @Override
+          public BigDecimal getTotal() {
+            return total1;
+          }
+        };
+
+    AssessmentRepository.AssessedTotalAmountProjection projection2 =
+        new AssessmentRepository.AssessedTotalAmountProjection() {
+          @Override
+          public UUID getSubmissionId() {
+            return submissionId2;
+          }
+
+          @Override
+          public BigDecimal getTotal() {
+            return total2;
+          }
+        };
 
     when(assessmentRepository.getAssessedTotalAmounts(List.of(submissionId1, submissionId2)))
-        .thenReturn(repositoryResult);
+        .thenReturn(List.of(projection1, projection2));
 
     Map<UUID, BigDecimal> result =
         assessmentService.getAssessedTotalAmounts(List.of(submissionId1, submissionId2));

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
@@ -19,6 +19,7 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUt
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -370,5 +371,39 @@ class AssessmentServiceTest {
 
     assertThat(result).isNull();
     verify(assessmentRepository).getAssessedTotalAmount(submissionId);
+  }
+
+  @Test
+  void shouldReturnAssessedTotalAmountsForMultipleSubmissions() {
+    UUID submissionId1 = UUID.randomUUID();
+    UUID submissionId2 = UUID.randomUUID();
+
+    BigDecimal total1 = new BigDecimal("100.50");
+    BigDecimal total2 = new BigDecimal("25.00");
+
+    List<Object[]> repositoryResult =
+        List.of(new Object[] {submissionId1, total1}, new Object[] {submissionId2, total2});
+
+    when(assessmentRepository.getAssessedTotalAmounts(List.of(submissionId1, submissionId2)))
+        .thenReturn(repositoryResult);
+
+    Map<UUID, BigDecimal> result =
+        assessmentService.getAssessedTotalAmounts(List.of(submissionId1, submissionId2));
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(submissionId1)).isEqualByComparingTo("100.50");
+    assertThat(result.get(submissionId2)).isEqualByComparingTo("25.00");
+
+    verify(assessmentRepository).getAssessedTotalAmounts(List.of(submissionId1, submissionId2));
+  }
+
+  @Test
+  void shouldReturnEmptyMapWhenSubmissionIdsListIsEmpty() {
+    Map<UUID, BigDecimal> result =
+        assessmentService.getAssessedTotalAmounts(Collections.emptyList());
+
+    assertThat(result).isEmpty();
+
+    verify(assessmentRepository).getAssessedTotalAmounts(List.of());
   }
 }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.service.ClaimValidationService.ASSESSMENT_REASON_MUST_BE_PROVIDED_ERROR;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.API_USER_ID;
@@ -403,7 +404,6 @@ class AssessmentServiceTest {
         assessmentService.getAssessedTotalAmounts(Collections.emptyList());
 
     assertThat(result).isEmpty();
-
-    verify(assessmentRepository).getAssessedTotalAmounts(List.of());
+    verifyNoInteractions(assessmentRepository);
   }
 }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.AREA_OF_LAW;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_ID;
@@ -318,7 +319,7 @@ class SubmissionServiceTest {
         .thenReturn(expectedNonEmptyResultSet);
     when(assessmentService.getAssessedTotalAmounts(
             Collections.singletonList(submissionBase.getSubmissionId())))
-        .thenReturn(Map.of(submissionBase.getSubmissionId(), new BigDecimal("123.4")));
+        .thenReturn(Map.of(submissionBase.getSubmissionId(), new BigDecimal("123.40")));
 
     var actualResultSet =
         submissionService.getSubmissionsResultSet(
@@ -350,7 +351,6 @@ class SubmissionServiceTest {
     var expectedEmptyResultSet = new SubmissionsResultSet();
     when(submissionsResultSetMapper.toSubmissionsResultSet(resultPage))
         .thenReturn(expectedEmptyResultSet);
-    when(assessmentService.getAssessedTotalAmounts(any())).thenReturn(Map.of());
 
     var actualResultSet =
         submissionService.getSubmissionsResultSet(
@@ -365,7 +365,7 @@ class SubmissionServiceTest {
 
     assertThat(actualResultSet).isEqualTo(expectedEmptyResultSet);
     assertThat(actualResultSet.getContent()).isEmpty();
-    verify(assessmentService).getAssessedTotalAmounts(Collections.emptyList());
+    verifyNoInteractions(assessmentService);
   }
 
   @DisplayName("Should call findAll with  Specification area of law and submission period")
@@ -378,8 +378,6 @@ class SubmissionServiceTest {
 
     when(submissionsResultSetMapper.toSubmissionsResultSet(eq(resultPage)))
         .thenReturn(new SubmissionsResultSet());
-
-    when(assessmentService.getAssessedTotalAmounts(any())).thenReturn(Map.of());
 
     submissionService.getSubmissionsResultSet(
         OFFICE_CODES,
@@ -394,7 +392,7 @@ class SubmissionServiceTest {
     verify(submissionRepository)
         .findAll(
             submissionSpecificationArgumentCaptor.capture(), eq(Pageable.ofSize(10).withPage(0)));
-    verify(assessmentService).getAssessedTotalAmounts(Collections.emptyList());
+    verifyNoInteractions(assessmentService);
 
     assertThat(submissionSpecificationArgumentCaptor.getValue()).isNotNull();
   }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -305,16 +305,20 @@ class SubmissionServiceTest {
 
   @Test
   void getSubmissionsResultSet_whenFiltersMatchData_shouldReturnNonEmptyResultSet() {
-    Page<Submission> resultPage = new PageImpl<>(Collections.singletonList(new Submission()));
+    var submissionBase = SubmissionBase.builder().submissionId(UUID.randomUUID()).build();
+    var submission = new Submission();
+    submission.setId(submissionBase.getSubmissionId());
+    Page<Submission> resultPage = new PageImpl<>(Collections.singletonList(submission));
     when(submissionRepository.findAll(any(Specification.class), any(Pageable.class)))
         .thenReturn(resultPage);
 
-    var submissionBase = SubmissionBase.builder().submissionId(UUID.randomUUID()).build();
     var expectedNonEmptyResultSet =
         new SubmissionsResultSet().content(Collections.singletonList(submissionBase));
     when(submissionsResultSetMapper.toSubmissionsResultSet(resultPage))
         .thenReturn(expectedNonEmptyResultSet);
-    when(assessmentService.getAssessedTotalAmounts(anyList())).thenReturn(Map.of());
+    when(assessmentService.getAssessedTotalAmounts(
+            Collections.singletonList(submissionBase.getSubmissionId())))
+        .thenReturn(Map.of(submissionBase.getSubmissionId(), new BigDecimal("123.4")));
 
     var actualResultSet =
         submissionService.getSubmissionsResultSet(
@@ -327,9 +331,13 @@ class SubmissionServiceTest {
             SUBMISSION_STATUSES,
             Pageable.ofSize(10).withPage(0));
 
-    assertThat(actualResultSet).isEqualTo(expectedNonEmptyResultSet);
     assertThat(actualResultSet.getContent()).hasSize(1);
-    verify(assessmentService).getAssessedTotalAmounts(anyList());
+    assertThat(actualResultSet.getContent().get(0).getSubmissionId())
+        .isEqualTo(submissionBase.getSubmissionId());
+    assertThat(actualResultSet.getContent().get(0).getAssessedTotalAmount())
+        .isEqualTo(new BigDecimal("123.40"));
+    verify(assessmentService)
+        .getAssessedTotalAmounts(Collections.singletonList(submissionBase.getSubmissionId()));
   }
 
   @Test

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -308,10 +309,12 @@ class SubmissionServiceTest {
     when(submissionRepository.findAll(any(Specification.class), any(Pageable.class)))
         .thenReturn(resultPage);
 
+    var submissionBase = SubmissionBase.builder().submissionId(UUID.randomUUID()).build();
     var expectedNonEmptyResultSet =
-        new SubmissionsResultSet().content(Collections.singletonList(new SubmissionBase()));
+        new SubmissionsResultSet().content(Collections.singletonList(submissionBase));
     when(submissionsResultSetMapper.toSubmissionsResultSet(resultPage))
         .thenReturn(expectedNonEmptyResultSet);
+    when(assessmentService.getAssessedTotalAmounts(anyList())).thenReturn(Map.of());
 
     var actualResultSet =
         submissionService.getSubmissionsResultSet(
@@ -326,6 +329,7 @@ class SubmissionServiceTest {
 
     assertThat(actualResultSet).isEqualTo(expectedNonEmptyResultSet);
     assertThat(actualResultSet.getContent()).hasSize(1);
+    verify(assessmentService).getAssessedTotalAmounts(anyList());
   }
 
   @Test
@@ -338,6 +342,7 @@ class SubmissionServiceTest {
     var expectedEmptyResultSet = new SubmissionsResultSet();
     when(submissionsResultSetMapper.toSubmissionsResultSet(resultPage))
         .thenReturn(expectedEmptyResultSet);
+    when(assessmentService.getAssessedTotalAmounts(any())).thenReturn(Map.of());
 
     var actualResultSet =
         submissionService.getSubmissionsResultSet(
@@ -352,6 +357,7 @@ class SubmissionServiceTest {
 
     assertThat(actualResultSet).isEqualTo(expectedEmptyResultSet);
     assertThat(actualResultSet.getContent()).isEmpty();
+    verify(assessmentService).getAssessedTotalAmounts(Collections.emptyList());
   }
 
   @DisplayName("Should call findAll with  Specification area of law and submission period")
@@ -364,6 +370,8 @@ class SubmissionServiceTest {
 
     when(submissionsResultSetMapper.toSubmissionsResultSet(eq(resultPage)))
         .thenReturn(new SubmissionsResultSet());
+
+    when(assessmentService.getAssessedTotalAmounts(any())).thenReturn(Map.of());
 
     submissionService.getSubmissionsResultSet(
         OFFICE_CODES,
@@ -378,6 +386,7 @@ class SubmissionServiceTest {
     verify(submissionRepository)
         .findAll(
             submissionSpecificationArgumentCaptor.capture(), eq(Pageable.ofSize(10).withPage(0)));
+    verify(assessmentService).getAssessedTotalAmounts(Collections.emptyList());
 
     assertThat(submissionSpecificationArgumentCaptor.getValue()).isNotNull();
   }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/DSTEW-1396

What was changed

Added assessed_total_amount to the submission response via open-api spec
Added AssessmentRepository#getAssessedTotalAmount(UUID submissionId)
Added AssessmentService#getAssessedTotalAmount(UUID submissionId)
Updated SubmissionService to populate the new field
Added JavaDoc
Added unit tests
Added repository integration tests
Updated consumer contract / Pact coverage for the null case

Why
To expose the sum of the latest assessed totals per claim at submission level, while preserving the important distinction between:

null = no assessments exist
0 = assessments exist, but total zero

Added Assessed total value to multi parameter submissions endpoint response

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
