### PR TITLE
Added `local` spring profile to `claims-api` service in docker-compose.yml

### DIFF
--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -132,6 +132,10 @@ dependencies {
     implementation 'org.apache.tomcat.embed:tomcat-embed-websocket'
 }
 
+bootRun {
+    jvmArgs = ["-Dspring.profiles.active=local"]
+}
+
 sourceSets {
     pactTest {
         java {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=dummy-access-key
       - AWS_ENDPOINT_URL=http://host.docker.internal:4566
       - AWS_SQS_ENDPOINT=http://host.docker.internal:4566
+      - SPRING_PROFILES_ACTIVE=local
     depends_on:
       - postgres
   postgres:


### PR DESCRIPTION
## What
Fixes issues with the docker compose service not starting correctly due to a dependent property not being used in `application-local.yml`. This adds `SPRING_PROFILES_ACTIVE=local` to the `docker-compose.yml` file to use this property.
