### PR TITLE
[DSTEW-1396] - Updated return value to render to 2 decimal places in al…

### DIFF
--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/BigDecimalUtils.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/BigDecimalUtils.java
@@ -24,23 +24,16 @@ public final class BigDecimalUtils {
    *
    * <ul>
    *   <li>If {@code amount} is {@code null}, this method returns {@code null}.
-   *   <li>If {@code amount} is numerically zero (e.g., 0, 0.0, 0.000), the method returns {@link
-   *       BigDecimal#ZERO} without applying scaling.
    *   <li>Otherwise, the value is scaled to the specified {@code scale} using HALF_UP rounding.
    * </ul>
    *
    * @param amount the value to scale; may be {@code null}
    * @param scale the number of decimal places to apply when scaling
-   * @return the scaled {@code BigDecimal}, {@code null}, or {@code BigDecimal.ZERO}
+   * @return the scaled {@code BigDecimal}, {@code null}
    */
   public static BigDecimal scaleNullable(BigDecimal amount, int scale) {
-    if (amount == null) {
-      return null;
-    }
-    if (amount.compareTo(BigDecimal.ZERO) == 0) {
-      return BigDecimal.ZERO;
-    }
-    return amount.setScale(scale, RoundingMode.HALF_UP);
+
+    return amount == null ? null : amount.setScale(scale, RoundingMode.HALF_UP);
   }
 
   /**

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -149,12 +149,13 @@ class SubmissionServiceTest {
     when(claimService.getClaimsForSubmission(SUBMISSION_ID)).thenReturn(List.of());
     when(matterStartService.getMatterStartIdsForSubmission(SUBMISSION_ID)).thenReturn(List.of());
     when(submissionRepository.getCalculatedTotalAmount(SUBMISSION_ID)).thenReturn(BigDecimal.ZERO);
-    when(assessmentService.getAssessedTotalAmount(SUBMISSION_ID)).thenReturn(BigDecimal.ZERO);
+    when(assessmentService.getAssessedTotalAmount(SUBMISSION_ID))
+        .thenReturn(new BigDecimal("0.00"));
 
     SubmissionResponse result = submissionService.getSubmission(SUBMISSION_ID);
 
     assertThat(result.getSubmissionId()).isEqualTo(SUBMISSION_ID);
-    assertThat(result.getAssessedTotalAmount()).isEqualTo(BigDecimal.ZERO);
+    assertThat(result.getAssessedTotalAmount()).isEqualTo(new BigDecimal("0.00"));
   }
 
   @Test

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/BigDecimalUtilsTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/BigDecimalUtilsTest.java
@@ -22,8 +22,8 @@ class BigDecimalUtilsTest {
   private static Stream<Arguments> scaleNullableCases() {
     return Stream.of(
         Arguments.of(null, 2, null),
-        Arguments.of(BigDecimal.ZERO, 2, BigDecimal.ZERO),
-        Arguments.of(new BigDecimal("0.000"), 2, BigDecimal.ZERO),
+        Arguments.of(BigDecimal.ZERO, 2, new BigDecimal("0.00")),
+        Arguments.of(new BigDecimal("0.000"), 2, new BigDecimal("0.00")),
         Arguments.of(new BigDecimal("12.345"), 2, new BigDecimal("12.35")),
         Arguments.of(new BigDecimal("12.344"), 2, new BigDecimal("12.34")));
   }


### PR DESCRIPTION
Updated return value of assessed total to render to 2 decimal places in all situations except NULL

## What

https://dsdmoj.atlassian.net/browse/DSTEW-1396

Updated return value of assessed total to render to 2 decimal places in all situations except NULL - this replaces the BigDecimal.ZERO - as all decimal values need to show 2 decimal places going forward.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [x] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
