### PR TITLE
Bumped postgres version to 18.1 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     depends_on:
       - postgres
   postgres:
-    image: postgres:17
+    image: postgres:18.1-alpine
     container_name: local-postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## What
Cloud platform RDS instance is using version 18.1 of postgres now. This bumps the version within the docker-compose.yml file to follow the same version.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
