### PR TITLE
[BC-90] - Return empty assessment set

### DIFF
--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -1099,12 +1099,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/assessment_result_set'
-        '404':
-          description: Claim not found
         '401':
           description: Unauthorized
         '403':
           description: Forbidden
+        '404':
+          description: Claim not found
         '429':
           description: 'Too many requests'
         '500':

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.service;
 
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.ClaimValidationService.NO_CLAIM_FOUND_WITH_ID_ERROR;
+
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
@@ -16,6 +18,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
 import uk.gov.justice.laa.dstew.payments.claimsdata.exception.AssessmentNotFoundException;
+import uk.gov.justice.laa.dstew.payments.claimsdata.exception.ClaimNotFoundException;
 import uk.gov.justice.laa.dstew.payments.claimsdata.mapper.AssessmentMapper;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentGet;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentPost;
@@ -123,22 +126,21 @@ public class AssessmentService {
    * <ul>
    *   <li>Validates that the provided {@code claimId} is not null.
    *   <li>Fetches assessments from the repository ordered by creation date (descending).
-   *   <li>If no assessments are found, throws {@link AssessmentNotFoundException}.
    *   <li>Maps the list of assessments to an {@link AssessmentResultSet} using the mapper.
    * </ul>
    *
    * @param claimId the unique identifier of the claim; must not be {@code null}.
    * @return an {@link AssessmentResultSet} containing all assessments for the claim.
    * @throws IllegalArgumentException if {@code claimId} is {@code null}.
-   * @throws AssessmentNotFoundException if no assessments exist for the given claim ID.
+   * @throws ClaimNotFoundException if no claim exists for the given claim ID.
    */
   @Transactional(readOnly = true)
   public AssessmentResultSet getAssessmentsByClaimId(@NotNull UUID claimId, Pageable pageable) {
-    var assessments = assessmentRepository.findByClaimId(claimId, pageable);
-    if (assessments.isEmpty()) {
-      throw new AssessmentNotFoundException(
-          String.format("No assessments found for claimId: %s", claimId));
+    if (!claimRepository.existsById(claimId)) {
+      throw new ClaimNotFoundException(String.format(NO_CLAIM_FOUND_WITH_ID_ERROR, claimId));
     }
+
+    var assessments = assessmentRepository.findByClaimId(claimId, pageable);
     return assessmentMapper.toAssessmentResultSet(assessments);
   }
 

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AssessmentControllerTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AssessmentControllerTest.java
@@ -43,7 +43,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import uk.gov.justice.laa.dstew.payments.claimsdata.exception.AssessmentNotFoundException;
 import uk.gov.justice.laa.dstew.payments.claimsdata.exception.ClaimBadRequestException;
 import uk.gov.justice.laa.dstew.payments.claimsdata.exception.ClaimNotFoundException;
 import uk.gov.justice.laa.dstew.payments.claimsdata.exception.ClaimSummaryFeeNotFoundException;
@@ -278,16 +277,33 @@ class AssessmentControllerTest {
     }
 
     @Test
-    void shouldReturnNotFoundWhenNoAssessmentsExist() throws Exception {
+    void shouldReturnEmptyAssessmentsWhenNoAssessmentsExist() throws Exception {
+      UUID claimId = UUID.randomUUID();
+
+      AssessmentResultSet resultSet = new AssessmentResultSet();
+      resultSet.assessments(List.of());
+
+      when(assessmentService.getAssessmentsByClaimId(eq(claimId), any(Pageable.class)))
+          .thenReturn(resultSet);
+
+      mockMvc
+          .perform(get("/api/v1/claims/{claimId}/assessments", claimId))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.assessments").isArray())
+          .andExpect(jsonPath("$.assessments").isEmpty());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenNoClaimExists() throws Exception {
       UUID claimId = UUID.randomUUID();
 
       when(assessmentService.getAssessmentsByClaimId(eq(claimId), any(Pageable.class)))
-          .thenThrow(new AssessmentNotFoundException("No assessments found"));
+          .thenThrow(new ClaimNotFoundException("No claim found"));
 
       mockMvc
           .perform(get("/api/v1/claims/{claimId}/assessments", claimId))
           .andExpect(status().isNotFound())
-          .andExpect(jsonPath("$.message").value("No assessments found"));
+          .andExpect(jsonPath("$.message").value("No claim found"));
     }
 
     @Test

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/AssessmentMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/AssessmentMapperTest.java
@@ -151,6 +151,19 @@ class AssessmentMapperTest {
     assertEquals(r2.getClaimSummaryFeeId(), a2.getClaimSummaryFee().getId());
   }
 
+  @Test
+  void toAssessmentResultSet_mapsEmptyPage() {
+    var page = new PageImpl<Assessment>(List.of());
+
+    var result = mapper.toAssessmentResultSet(page);
+
+    assertNotNull(result);
+    assertEquals(0, result.getNumber());
+    assertEquals(0, result.getSize());
+    assertEquals(0, result.getTotalElements());
+    assertEquals(1, page.getTotalPages());
+  }
+
   private static Assessment assessment(
       UUID id, UUID claimId, UUID claimSummaryFeeId, Instant createdAt) {
     Assessment a = new Assessment();

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.service.ClaimValidationService.ASSESSMENT_REASON_MUST_BE_PROVIDED_ERROR;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.ClaimValidationService.NO_CLAIM_FOUND_WITH_ID_ERROR;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.API_USER_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.ASSESSMENT_1_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
@@ -260,6 +261,7 @@ class AssessmentServiceTest {
             .assessments(List.of(new AssessmentGet().claimId(CLAIM_1_ID)))
             .totalElements(1);
 
+    when(claimRepository.existsById(CLAIM_1_ID)).thenReturn(true);
     when(assessmentRepository.findByClaimId(eq(CLAIM_1_ID), any(Pageable.class))).thenReturn(page);
     when(assessmentMapper.toAssessmentResultSet(page)).thenReturn(results);
 
@@ -272,14 +274,29 @@ class AssessmentServiceTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenAssessmentsEmpty() {
-    when(assessmentRepository.findByClaimId(eq(CLAIM_1_ID), any(Pageable.class)))
-        .thenReturn(new PageImpl<>(Collections.emptyList()));
+  void shouldReturnEmptyResultSetWhenAssessmentsEmpty() {
+    var page = new PageImpl<Assessment>(List.of());
+    var results = AssessmentResultSet.builder().assessments(List.of()).totalElements(0).build();
+
+    when(claimRepository.existsById(CLAIM_1_ID)).thenReturn(true);
+    when(assessmentRepository.findByClaimId(eq(CLAIM_1_ID), any(Pageable.class))).thenReturn(page);
+    when(assessmentMapper.toAssessmentResultSet(page)).thenReturn(results);
+
+    AssessmentResultSet result =
+        assessmentService.getAssessmentsByClaimId(CLAIM_1_ID, Pageable.unpaged());
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAssessments()).hasSize(0);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenClaimNotFound() {
+    when(claimRepository.existsById(CLAIM_1_ID)).thenReturn(false);
 
     assertThatThrownBy(
             () -> assessmentService.getAssessmentsByClaimId(CLAIM_1_ID, Pageable.unpaged()))
-        .isInstanceOf(AssessmentNotFoundException.class)
-        .hasMessageContaining("No assessments found for claimId");
+        .isInstanceOf(ClaimNotFoundException.class)
+        .hasMessageContaining(NO_CLAIM_FOUND_WITH_ID_ERROR.formatted(CLAIM_1_ID));
   }
 
   @Test


### PR DESCRIPTION
## What

If a claim exists but has no assessments then we should return a 200 and an empty result set instead of a 404

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [x] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
