### PR TITLE
[DSTEW-1520] - Add Stage Disbursement Assessment type support

### DIFF
--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -2109,6 +2109,11 @@ components:
         - ESCAPE_CASE_ASSESSMENT
         - STAGE_DISBURSEMENT_ASSESSMENT
         - VOID
+      description: |
+        The type of assessment being performed on a claim.
+        - ESCAPE_CASE_ASSESSMENT: Assessment for claims that have escaped the fixed fee threshold.
+        - STAGE_DISBURSEMENT_ASSESSMENT: Assessment for stage disbursement claims.
+        - VOID: Used when voiding a previously submitted assessment.
     assessment_base:
       type: object
       properties:

--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -2107,6 +2107,7 @@ components:
       type: string
       enum:
         - ESCAPE_CASE_ASSESSMENT
+        - STAGE_DISBURSEMENT_ASSESSMENT
         - VOID
     assessment_base:
       type: object

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AssessmentControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AssessmentControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.service.ClaimValidationService.ASSESSMENT_REASON_MUST_BE_PROVIDED_ERROR;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.ClaimValidationService.ASSESSMENT_TYPE_MUST_BE_PROVIDED_ERROR;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.service.ClaimValidationService.CLAIM_WITH_ID_DOES_NOT_HAVE_VALID_STATUS_ERROR;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.service.ClaimValidationService.INVALID_CLAIM_STATUS_UPDATE_MESSAGE;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.API_URI_PREFIX;
@@ -69,9 +70,6 @@ public class AssessmentControllerIntegrationTest extends AbstractIntegrationTest
     final AssessmentPost assessmentPost = getAssessmentPost();
     assessmentPost.setClaimId(CLAIM_ID_WITH_VALID_STATUS);
     assessmentPost.setClaimSummaryFeeId(SUMMARY_FEE_ID_FOR_VALID_CLAIM);
-    // ensure assessmentType is null in AssessmentPost as it's defaulted to ESCAPE_CASE_ASSESSMENT
-    // in the service layer.
-    assertThat(assessmentPost.getAssessmentType()).isNull();
 
     // when: calling the POST endpoint with the AssessmentPost
     MvcResult result =
@@ -175,6 +173,58 @@ public class AssessmentControllerIntegrationTest extends AbstractIntegrationTest
     String responseBody = result.getResponse().getContentAsString();
     assertThat(responseBody)
         .contains(INVALID_CLAIM_STATUS_UPDATE_MESSAGE.formatted("create assessment"));
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenAssessmentTypeIsNull() throws Exception {
+    final AssessmentPost assessmentPost = getAssessmentPost();
+    assessmentPost.setClaimId(CLAIM_ID_WITH_VALID_STATUS);
+    assessmentPost.setClaimSummaryFeeId(SUMMARY_FEE_ID_FOR_VALID_CLAIM);
+    assessmentPost.setAssessmentType(null);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post(POST_AN_ASSESSMENT_ENDPOINT, CLAIM_ID_WITH_VALID_STATUS)
+                    .content(OBJECT_MAPPER.writeValueAsString(assessmentPost))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+    String responseBody = result.getResponse().getContentAsString();
+    assertThat(responseBody).contains(ASSESSMENT_TYPE_MUST_BE_PROVIDED_ERROR);
+  }
+
+  @Test
+  void shouldSaveStageDisbursementAssessmentToDatabase() throws Exception {
+    final AssessmentPost assessmentPost = getAssessmentPost();
+    assessmentPost.setClaimId(CLAIM_ID_WITH_VALID_STATUS);
+    assessmentPost.setClaimSummaryFeeId(SUMMARY_FEE_ID_FOR_VALID_CLAIM);
+    assessmentPost.setAssessmentType(AssessmentType.STAGE_DISBURSEMENT_ASSESSMENT);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post(POST_AN_ASSESSMENT_ENDPOINT, CLAIM_ID_WITH_VALID_STATUS)
+                    .content(OBJECT_MAPPER.writeValueAsString(assessmentPost))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+    String responseBody = result.getResponse().getContentAsString();
+    var createAssessment201Response =
+        OBJECT_MAPPER.readValue(responseBody, CreateAssessment201Response.class);
+    assertThat(createAssessment201Response.getId()).isNotNull();
+
+    Assessment savedAssessment =
+        assessmentRepository
+            .findById(createAssessment201Response.getId())
+            .orElseThrow(() -> new RuntimeException("Assessment not found"));
+
+    assertThat(savedAssessment.getAssessmentType())
+        .isEqualTo(AssessmentType.STAGE_DISBURSEMENT_ASSESSMENT);
   }
 
   @Test

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
@@ -55,7 +55,7 @@ public class AssessmentService {
     ClaimSummaryFee claimSummaryFee =
         claimValidationService.getClaimSummaryFeeByIdOrThrow(request.getClaimSummaryFeeId());
 
-    claimValidationService.ensureAssessmentTypeIsNotVoid(request.getAssessmentType());
+    claimValidationService.validateAssessmentType(request.getAssessmentType());
     updateClaimAssessmentStatus(claim);
 
     Assessment assessment = assessmentMapper.toAssessment(request);
@@ -66,7 +66,7 @@ public class AssessmentService {
         claimSummaryFee,
         request.getCreatedByUserId(),
         request.getAssessmentReason(),
-        AssessmentType.ESCAPE_CASE_ASSESSMENT);
+        request.getAssessmentType());
 
     return assessmentRepository.save(assessment).getId();
   }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimValidationService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimValidationService.java
@@ -43,6 +43,8 @@ public class ClaimValidationService {
       "createdByUserId must be provided";
   public static final String ASSESSMENT_REASON_MUST_BE_PROVIDED_ERROR =
       "assessmentReason must be provided";
+  public static final String ASSESSMENT_TYPE_MUST_BE_PROVIDED_ERROR =
+      "assessmentType must be provided";
   public static final String INVALID_CLAIM_STATUS_UPDATE_MESSAGE =
       "Claim status VOID cannot be set via %s endpoint. Use POST "
           + ClaimController.VOID_CLAIM_ENDPOINT;
@@ -131,12 +133,15 @@ public class ClaimValidationService {
   }
 
   /**
-   * Ensures that the provided assessment type is not VOID.
+   * Validates the provided assessment type is not null and not VOID.
    *
-   * @param assessmentType the assessment type to check
-   * @throws ClaimBadRequestException if the assessment type is VOID
+   * @param assessmentType the assessment type to validate
+   * @throws ClaimBadRequestException if the assessment type is null or VOID
    */
-  public void ensureAssessmentTypeIsNotVoid(AssessmentType assessmentType) {
+  public void validateAssessmentType(AssessmentType assessmentType) {
+    if (assessmentType == null) {
+      throw new ClaimBadRequestException(ASSESSMENT_TYPE_MUST_BE_PROVIDED_ERROR);
+    }
     if (assessmentType == AssessmentType.VOID) {
       throw new ClaimBadRequestException(
           INVALID_CLAIM_STATUS_UPDATE_MESSAGE.formatted("create assessment"));

--- a/claims-data/service/src/main/resources/db/migration/V38__add_stage_disbursement_assessment_type.sql
+++ b/claims-data/service/src/main/resources/db/migration/V38__add_stage_disbursement_assessment_type.sql
@@ -1,0 +1,9 @@
+-- Add STAGE_DISBURSEMENT_ASSESSMENT to allowed assessment_type values
+ALTER TABLE assessment
+    DROP CONSTRAINT IF EXISTS chk_assessment_type;
+
+ALTER TABLE assessment
+    ADD CONSTRAINT chk_assessment_type
+        CHECK (
+            assessment_type IN ('ESCAPE_CASE_ASSESSMENT', 'STAGE_DISBURSEMENT_ASSESSMENT', 'VOID')
+            );

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
@@ -91,7 +91,7 @@ class AssessmentServiceTest {
       assertThat(result).isEqualTo(assessment.getId());
 
       verify(claimValidationService).validateUserId(API_USER_ID);
-      verify(claimValidationService).ensureAssessmentTypeIsNotVoid(post.getAssessmentType());
+      verify(claimValidationService).validateAssessmentType(post.getAssessmentType());
       verify(claimValidationService).validateAssessmentReason(post.getAssessmentReason());
 
       verify(claimRepository).updateAssessmentStatus(claimId, true);

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimValidationServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimValidationServiceTest.java
@@ -180,16 +180,22 @@ class ClaimValidationServiceTest {
   // Assessment Type Tests
   // =====================================================
   @Test
+  void shouldThrowWhenAssessmentTypeIsNull() {
+    assertThatThrownBy(() -> validationService.validateAssessmentType(null))
+        .isInstanceOf(ClaimBadRequestException.class)
+        .hasMessageContaining("assessmentType must be provided");
+  }
+
+  @Test
   void shouldThrowWhenAssessmentTypeIsVoid() {
-    assertThatThrownBy(() -> validationService.ensureAssessmentTypeIsNotVoid(AssessmentType.VOID))
+    assertThatThrownBy(() -> validationService.validateAssessmentType(AssessmentType.VOID))
         .isInstanceOf(ClaimBadRequestException.class);
   }
 
   @Test
   void shouldNotThrowForOtherAssessmentTypes() {
     assertDoesNotThrow(
-        () ->
-            validationService.ensureAssessmentTypeIsNotVoid(AssessmentType.ESCAPE_CASE_ASSESSMENT));
+        () -> validationService.validateAssessmentType(AssessmentType.ESCAPE_CASE_ASSESSMENT));
   }
 
   // =====================================================

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimValidationServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimValidationServiceTest.java
@@ -192,10 +192,13 @@ class ClaimValidationServiceTest {
         .isInstanceOf(ClaimBadRequestException.class);
   }
 
-  @Test
-  void shouldNotThrowForOtherAssessmentTypes() {
-    assertDoesNotThrow(
-        () -> validationService.validateAssessmentType(AssessmentType.ESCAPE_CASE_ASSESSMENT));
+  @ParameterizedTest
+  @EnumSource(
+      value = AssessmentType.class,
+      names = {"VOID"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void shouldNotThrowForNonVoidAssessmentTypes(AssessmentType type) {
+    assertDoesNotThrow(() -> validationService.validateAssessmentType(type));
   }
 
   // =====================================================

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/ClaimsDataTestUtil.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/ClaimsDataTestUtil.java
@@ -14,6 +14,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Submission;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentPost;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.BulkSubmissionMatterStart;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.BulkSubmissionOutcome;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.CategoryCode;
@@ -40,7 +41,6 @@ public class ClaimsDataTestUtil {
   public static final UUID CLAIM_3_ID = Uuid7.timeBasedUuid();
   public static final UUID CLAIM_4_ID = Uuid7.timeBasedUuid();
   public static final UUID CLIENT_1_ID = Uuid7.timeBasedUuid();
-  public static final UUID CLIENT_2_ID = Uuid7.timeBasedUuid();
   public static final UUID ASSESSMENT_1_ID = Uuid7.timeBasedUuid();
   public static final UUID ASSESSMENT_2_ID = Uuid7.timeBasedUuid();
   public static final UUID CLAIM_1_SUMMARY_FEE_ID = Uuid7.timeBasedUuid();
@@ -453,6 +453,7 @@ public class ClaimsDataTestUtil {
         .allowedTotalVat(new BigDecimal("1800.00"))
         .allowedTotalInclVat(new BigDecimal("1900.00"))
         .assessmentReason("test")
+        .assessmentType(AssessmentType.ESCAPE_CASE_ASSESSMENT)
         .createdByUserId(API_USER_ID);
   }
 


### PR DESCRIPTION
## What

[DSTEW-1520](https://dsdmoj.atlassian.net/browse/DSTEW-1520)

The amend-a-claim frontend needs to create assessments for Stage Disbursement claims. Previously the API only supported `ESCAPE_CASE_ASSESSMENT` and `VOID`, and hardcoded the type regardless of what the client sent. 
This change makes the API accept and persist the assessment type from the request, enabling the frontend to distinguish between escape case and stage disbursement assessments. 

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [x] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.


[DSTEW-1520]: https://dsdmoj.atlassian.net/browse/DSTEW-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ