### PR TITLE
[DSTEW-1538] - Fix bug in calculated total amount and ensure two decimal places even when ZERO 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.1.0'
+    id 'org.sonarqube' version '7.2.3.7755'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'net.researchgate.release' version '3.1.0'
-    id 'org.sonarqube' version '7.2.3.7755'
 }
 
 subprojects {

--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -1304,10 +1304,15 @@ components:
           description: Number of claims in this submission.
         calculated_total_amount:
           type: number
+          format: decimal
           description: Total amount calculated from the fee details of each claim.
+          example: "0.00"
+          default: "0.00"
         assessed_total_amount:
           type: number
+          format: decimal
           description: Total amount calculated from the latest assessment for each claim.
+          example: "0.00"
         submitted:
           type: string
           format: date-time

--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -1307,7 +1307,6 @@ components:
           format: decimal
           description: Total amount calculated from the fee details of each claim.
           example: "0.00"
-          default: "0.00"
         assessed_total_amount:
           type: number
           format: decimal

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -108,7 +108,8 @@ public class SubmissionService
         .numberOfClaims(submission.getNumberOfClaims())
         .submitted(OffsetDateTime.ofInstant(submission.getCreatedOn(), ZoneId.systemDefault()))
         .claims(claims)
-        .calculatedTotalAmount(BigDecimalUtils.scaleOrZero(calculatedTotalAmount, DECIMAL_PLACES))
+        .calculatedTotalAmount(
+            BigDecimalUtils.scaleOrZeroWithScale(calculatedTotalAmount, DECIMAL_PLACES))
         .assessedTotalAmount(BigDecimalUtils.scaleNullable(assessedTotalAmount, DECIMAL_PLACES))
         .matterStarts(matterStartIds)
         .createdByUserId(submission.getCreatedByUserId())

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/BigDecimalUtils.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/BigDecimalUtils.java
@@ -38,27 +38,29 @@ public final class BigDecimalUtils {
 
   /**
    * Scales the given {@link BigDecimal} to the specified number of decimal places using {@link
-   * RoundingMode#HALF_UP}, returning {@link BigDecimal#ZERO} when the input is {@code null} or
-   * numerically zero.
+   * RoundingMode#HALF_UP}. If the input is {@code null} or numerically zero, a zero {@code
+   * BigDecimal} scaled to the requested number of decimal places is returned (for example, {@code
+   * 0.00} when {@code scale} is {@code 2}).
    *
    * <p>Behaviour:
    *
    * <ul>
-   *   <li>If {@code amount} is {@code null}, this method returns {@link BigDecimal#ZERO}.
-   *   <li>If {@code amount} is numerically zero (e.g., 0, 0.0, 0.000), this method returns {@link
-   *       BigDecimal#ZERO}.
-   *   <li>Otherwise, the value is scaled to the specified {@code scale} using {@code
-   *       RoundingMode.HALF_UP}.
+   *   <li>If {@code amount} is {@code null}, this method returns a zero value with the given {@code
+   *       scale}.
+   *   <li>If {@code amount} is numerically zero (e.g. {@code 0}, {@code 0.0}, {@code 0.000}), this
+   *       method returns a zero value with the given {@code scale}.
+   *   <li>Otherwise, the value is scaled to {@code scale} decimal places using {@link
+   *       RoundingMode#HALF_UP}.
    * </ul>
    *
    * @param amount the value to scale; may be {@code null}
-   * @param scale the number of decimal places to apply when scaling
-   * @return the scaled {@code BigDecimal}, or {@link BigDecimal#ZERO} if the input is {@code null}
-   *     or numerically zero
+   * @param scale the number of decimal places to apply
+   * @return a {@code BigDecimal} scaled to {@code scale}; zero with the given scale if the input is
+   *     {@code null} or numerically zero
    */
-  public static BigDecimal scaleOrZero(BigDecimal amount, int scale) {
+  public static BigDecimal scaleOrZeroWithScale(BigDecimal amount, int scale) {
     if (amount == null || amount.compareTo(BigDecimal.ZERO) == 0) {
-      return BigDecimal.ZERO;
+      return BigDecimal.ZERO.setScale(scale, RoundingMode.HALF_UP);
     }
     return amount.setScale(scale, RoundingMode.HALF_UP);
   }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -122,7 +122,7 @@ class SubmissionServiceTest {
     SubmissionResponse result = submissionService.getSubmission(SUBMISSION_ID);
 
     assertThat(result.getSubmissionId()).isEqualTo(SUBMISSION_ID);
-    assertThat(result.getCalculatedTotalAmount()).isEqualTo(BigDecimal.ZERO);
+    assertThat(result.getCalculatedTotalAmount()).isEqualTo(new BigDecimal("0.00"));
   }
 
   @Test

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/BigDecimalUtilsTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/BigDecimalUtilsTest.java
@@ -30,16 +30,17 @@ class BigDecimalUtilsTest {
 
   @DisplayName("Scale Or Zero Tests")
   @ParameterizedTest(name = "[{index}] amount={0}, scale={1} → expected={2}")
-  @MethodSource("scaleOrZeroCases")
-  void scaleOrZero_shouldBehaveAsExpected(BigDecimal amount, int scale, BigDecimal expected) {
-    assertThat(BigDecimalUtils.scaleOrZero(amount, scale)).isEqualTo(expected);
+  @MethodSource("scaleOrZeroWithScaleCases")
+  void scaleOrZero_WithScale_shouldBehaveAsExpected(
+      BigDecimal amount, int scale, BigDecimal expected) {
+    assertThat(BigDecimalUtils.scaleOrZeroWithScale(amount, scale)).isEqualTo(expected);
   }
 
-  private static Stream<Arguments> scaleOrZeroCases() {
+  private static Stream<Arguments> scaleOrZeroWithScaleCases() {
     return Stream.of(
-        Arguments.of(null, 2, BigDecimal.ZERO),
-        Arguments.of(BigDecimal.ZERO, 2, BigDecimal.ZERO),
-        Arguments.of(new BigDecimal("0.000"), 2, BigDecimal.ZERO),
+        Arguments.of(null, 2, new BigDecimal("0.00")),
+        Arguments.of(BigDecimal.ZERO, 2, new BigDecimal("0.00")),
+        Arguments.of(new BigDecimal("0.000"), 2, new BigDecimal("0.00")),
         Arguments.of(new BigDecimal("99.995"), 2, new BigDecimal("100.00")),
         Arguments.of(new BigDecimal("99.994"), 2, new BigDecimal("99.99")));
   }


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/browse/DSTEW-XXX)](https://dsdmoj.atlassian.net/browse/DSTEW-1538

Fixed bug with calculated_total_amount and all values that are rendered by calling the BigDecimalUtil - to display 2 decimal places in all cases (except null)

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [x] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
