### PR TITLE
DSTEW-1568: Disable Cronjobs on Ephemeral UAT

### DIFF
--- a/.github/actions/deploy_branch/action.yml
+++ b/.github/actions/deploy_branch/action.yml
@@ -136,16 +136,20 @@ runs:
 
         if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
           export SPRING_PROFILE="main"
+          export CRONJOB_ENABLED="true"
         elif [ "$branch_name" == "main" ]; then
           export SPRING_PROFILE="main"
           export DB_NAME="main"
+          export CRONJOB_ENABLED="true"
         else
           export SPRING_PROFILE="preview"
           export DB_NAME="$RELEASE_NAME"
+          export CRONJOB_ENABLED="false"
         fi
 
         helm upgrade $RELEASE_NAME .helm/data-claims-api \
           --namespace ${KUBE_NAMESPACE} \
+          --set replicationSummary.enabled="${CRONJOB_ENABLED}" \
           --set replicationSummary.schedule="${{ steps.get_schedule.outputs.schedule }}" \
           --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
           --set image.tag="${IMAGE_TAG:-$GIT_SHA}" \

--- a/.helm/data-claims-api/templates/cronjob.yaml
+++ b/.helm/data-claims-api/templates/cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.replicationSummary.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -59,3 +60,4 @@ spec:
                   type: RuntimeDefault
                 capabilities:
                   drop: ["ALL"]
+{{- end }}

--- a/.helm/data-claims-api/values/production.yaml
+++ b/.helm/data-claims-api/values/production.yaml
@@ -61,3 +61,7 @@ sentry:
 
 portForward:
   enabled: false
+
+replicationSummary:
+  enabled: true
+  schedule: "0 1 * * *"

--- a/.helm/data-claims-api/values/staging.yaml
+++ b/.helm/data-claims-api/values/staging.yaml
@@ -73,3 +73,7 @@ sentry:
 
 portForward:
   enabled: false
+
+replicationSummary:
+  enabled: true
+  schedule: "0 1 * * *"

--- a/.helm/data-claims-api/values/uat.yaml
+++ b/.helm/data-claims-api/values/uat.yaml
@@ -68,3 +68,7 @@ sentry:
 
 portForward:
   enabled: true
+
+replicationSummary:
+  enabled: true
+  schedule: "0 1 * * *"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1568)

Implement configuration to disable replication summary cron jobs on ephemeral UAT preview environments while maintaining functionality for persistent environments (main UAT, staging, and production), it was redundant (and noisy) to have these jobs running in this environment.

This change wraps the entire CronJob resource with a conditional check to enable/disable creation.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
