### PR TITLE
Snyk vulnerability fix: upgrade spring-security.version to 7.0.5

### DIFF
--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -37,11 +37,9 @@ jacocoTestCoverageVerification {
 // example:
 // Upgrade to fix CVE-xxxx-xxxxx
 // ext['dependency-name.version'] = 'x.x.x'
-ext['commons-lang3.version'] = '3.18.0'
-// Upgrade to fix HTTP Request Smuggling (SNYK-JAVA-IONETTY-15789756)
-ext['netty.version'] = '4.2.12.Final'
-// Upgrade to fix remaining Apache Tomcat vulnerabilities reported against 11.0.18/11.0.20
-ext['tomcat.version'] = '11.0.21'
+
+// **** When adding new overrides please check if any existing overrides are now redundant (by removing them and adding them back only if required)
+
 // Upgrade to fix Access Control Bypass and User Impersonation (SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-16120588, 16121326, 16121020)
 ext['spring-security.version'] = '7.0.5'
 

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -40,6 +40,8 @@ jacocoTestCoverageVerification {
 
 // **** When adding new overrides please check if any existing overrides are now redundant (by removing them and adding them back only if required)
 
+// Upgrade to fix remaining Apache Tomcat vulnerabilities reported against 11.0.18/11.0.20
+ext['tomcat.version'] = '11.0.21'
 // Upgrade to fix Access Control Bypass and User Impersonation (SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-16120588, 16121326, 16121020)
 ext['spring-security.version'] = '7.0.5'
 

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -42,6 +42,8 @@ ext['commons-lang3.version'] = '3.18.0'
 ext['netty.version'] = '4.2.12.Final'
 // Upgrade to fix remaining Apache Tomcat vulnerabilities reported against 11.0.18/11.0.20
 ext['tomcat.version'] = '11.0.21'
+// Upgrade to fix Access Control Bypass and User Impersonation (SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-16120588, 16121326, 16121020)
+ext['spring-security.version'] = '7.0.5'
 
 dependencyManagement {
     dependencies {


### PR DESCRIPTION
## What

Describe what you did and why.

Upgrade spring-security version to fix Access Control Bypass and User Impersonation (SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-16120588, 16121326, 16121020)

Removed 2 previously added overrides which are not necessary any more.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
