### PR TITLE
[DSTEW-1711] - Fix mapper error on getSubmissions endpoint

### DIFF
--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/BulkSubmissionRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/BulkSubmissionRepository.java
@@ -15,11 +15,13 @@ public interface BulkSubmissionRepository extends JpaRepository<BulkSubmission, 
 
   @Modifying
   @Query(
-      "UPDATE BulkSubmission b SET b.status = COALESCE(:status, b.status), "
-          + "b.errorCode = COALESCE(:errorCode, b.errorCode), "
-          + "b.errorDescription = COALESCE(:errorDescription, b.errorDescription), "
-          + "b.updatedByUserId = COALESCE(:updatedByUserId, b.updatedByUserId) "
-          + "WHERE b.id = :id")
+      """
+        UPDATE BulkSubmission b SET b.status = COALESCE(:status, b.status),
+          b.errorCode = COALESCE(:errorCode, b.errorCode),
+          b.errorDescription = COALESCE(:errorDescription, b.errorDescription),
+          b.updatedByUserId = COALESCE(:updatedByUserId, b.updatedByUserId)
+          WHERE b.id = :id
+      """)
   int updateBulkSubmission(
       UUID id, String status, String errorCode, String errorDescription, String updatedByUserId);
 

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.repository;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -14,10 +15,58 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Submission;
 public interface SubmissionRepository
     extends JpaRepository<Submission, UUID>, JpaSpecificationExecutor<Submission> {
 
+  /**
+   * Projection for Calculated total amounts grouped by submission.
+   *
+   * <p>Used by {@link #getCalculatedTotalAmounts(List)} to return the Calculated total amount for
+   * each submission without loading full entity data.
+   */
+  interface CalculatedTotalAmountProjection {
+
+    /**
+     * Returns the identifier of the submission.
+     *
+     * @return the submission ID
+     */
+    UUID getSubmissionId();
+
+    /**
+     * Returns the Calculated total amount for the submission.
+     *
+     * @return the summed Calculated total amount
+     */
+    BigDecimal getTotal();
+  }
+
   @Query(
-      "SELECT SUM(cfd.totalAmount)"
-          + "FROM Claim c "
-          + "JOIN CalculatedFeeDetail cfd ON cfd.claim = c "
-          + "WHERE c.submission.id = :submissionId ")
+      """
+        SELECT SUM(cfd.totalAmount)
+        FROM Claim c
+        JOIN CalculatedFeeDetail cfd ON cfd.claim = c
+        WHERE c.submission.id = :submissionId
+      """)
   BigDecimal getCalculatedTotalAmount(@Param("submissionId") UUID submissionId);
+
+  /**
+   * Returns calculated total amounts for the given submissions.
+   *
+   * <p>For each submission ID provided, this query returns the sum of {@code calculatedTotalInclVat}
+   * from the cfd record for each claim belonging to that submission. Results are grouped by
+   * submission ID.
+   *
+   * <p>Submissions with no cfd records are not included in the returned list.
+   *
+   * @param submissionIds the unique identifiers of the submissions
+   * @return a list of projections containing submission IDs and their calculated total amounts
+   */
+  @Query(
+      """
+       SELECT c.submission.id AS submissionId, SUM(cfd.totalAmount) AS total
+       FROM Claim c
+       JOIN CalculatedFeeDetail cfd ON cfd.claim = c
+       WHERE c.submission.id IN :submissionIds
+       GROUP BY c.submission.id
+      """)
+  List<CalculatedTotalAmountProjection> getCalculatedTotalAmounts(
+      @Param("submissionIds") List<UUID> submissionIds);
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
@@ -50,9 +50,9 @@ public interface SubmissionRepository
   /**
    * Returns calculated total amounts for the given submissions.
    *
-   * <p>For each submission ID provided, this query returns the sum of {@code calculatedTotalInclVat}
-   * from the cfd record for each claim belonging to that submission. Results are grouped by
-   * submission ID.
+   * <p>For each submission ID provided, this query returns the sum of {@code
+   * calculatedTotalInclVat} from the cfd record for each claim belonging to that submission.
+   * Results are grouped by submission ID.
    *
    * <p>Submissions with no cfd records are not included in the returned list.
    *

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepository.java
@@ -17,10 +17,12 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.repository.projection.Valida
 public interface ValidationMessageLogRepository extends JpaRepository<ValidationMessageLog, UUID> {
 
   @Query(
-      "SELECT COUNT(DISTINCT v.claimId) "
-          + "FROM ValidationMessageLog v "
-          + "WHERE v.submissionId = :submissionId "
-          + "AND (:type IS NULL OR v.type = :type)")
+      """
+        SELECT COUNT(DISTINCT v.claimId)
+        FROM ValidationMessageLog v
+        WHERE v.submissionId = :submissionId
+        AND (:type IS NULL OR v.type = :type)
+        """)
   long countDistinctClaimIdsBySubmissionIdAndType(
       @Param("submissionId") UUID submissionId, @Param("type") ValidationMessageType type);
 

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -232,9 +232,9 @@ public class SubmissionService
   /**
    * Returns Calculated total amounts for the given submissions.
    *
-   * <p>For each submission ID provided, this method retrieves the summed {@code
-   * totalAmount} from the cfd record for each claim belonging to that submission.
-   * If the input list is {@code null} or empty, this method returns an empty map.
+   * <p>For each submission ID provided, this method retrieves the summed {@code totalAmount} from
+   * the cfd record for each claim belonging to that submission. If the input list is {@code null}
+   * or empty, this method returns an empty map.
    *
    * <p>The returned map is keyed by submission ID, with each value representing the Calculated
    * total amount for that submission. Submissions with no cfd records will not be present in the

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -8,12 +8,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Submission;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ValidationMessageLog;
 import uk.gov.justice.laa.dstew.payments.claimsdata.exception.SubmissionBadRequestException;
@@ -208,13 +210,15 @@ public class SubmissionService
 
     Map<UUID, BigDecimal> assessedTotalAmounts =
         assessmentService.getAssessedTotalAmounts(submissionIds);
+    Map<UUID, BigDecimal> calculatedTotalAmounts = getCalculatedTotalAmounts(submissionIds);
 
     resultSet
         .getContent()
         .forEach(
             submissionBase -> {
               BigDecimal assessedTotal = assessedTotalAmounts.get(submissionBase.getSubmissionId());
-              BigDecimal calcTotalAmount = submissionBase.getCalculatedTotalAmount();
+              BigDecimal calcTotalAmount =
+                  calculatedTotalAmounts.get(submissionBase.getSubmissionId());
 
               submissionBase.setAssessedTotalAmount(
                   BigDecimalUtils.scaleNullable(assessedTotal, DECIMAL_PLACES));
@@ -223,5 +227,32 @@ public class SubmissionService
             });
 
     return resultSet;
+  }
+
+  /**
+   * Returns Calculated total amounts for the given submissions.
+   *
+   * <p>For each submission ID provided, this method retrieves the summed {@code
+   * totalAmount} from the cfd record for each claim belonging to that submission.
+   * If the input list is {@code null} or empty, this method returns an empty map.
+   *
+   * <p>The returned map is keyed by submission ID, with each value representing the Calculated
+   * total amount for that submission. Submissions with no cfd records will not be present in the
+   * returned map.
+   *
+   * @param submissionIds the unique identifiers of the submissions
+   * @return a map of submission IDs to Calculated total amounts, or an empty map if the input is
+   *     {@code null} or empty
+   */
+  public Map<UUID, BigDecimal> getCalculatedTotalAmounts(List<UUID> submissionIds) {
+    if (CollectionUtils.isEmpty(submissionIds)) {
+      return Map.of();
+    }
+
+    return submissionRepository.getCalculatedTotalAmounts(submissionIds).stream()
+        .collect(
+            Collectors.toMap(
+                SubmissionRepository.CalculatedTotalAmountProjection::getSubmissionId,
+                SubmissionRepository.CalculatedTotalAmountProjection::getTotal));
   }
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -250,6 +250,7 @@ public class SubmissionService
     }
 
     return submissionRepository.getCalculatedTotalAmounts(submissionIds).stream()
+        .filter(p -> p.getSubmissionId() != null && p.getTotal() != null) // Filter out the nulls
         .collect(
             Collectors.toMap(
                 SubmissionRepository.CalculatedTotalAmountProjection::getSubmissionId,

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -211,7 +211,6 @@ public class SubmissionService
     Map<UUID, BigDecimal> assessedTotalAmounts =
         assessmentService.getAssessedTotalAmounts(submissionIds);
     Map<UUID, BigDecimal> calculatedTotalAmounts = getCalculatedTotalAmounts(submissionIds);
-
     resultSet
         .getContent()
         .forEach(

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -2,7 +2,9 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -98,7 +98,8 @@ class SubmissionServiceTest {
 
   @ParameterizedTest
   @MethodSource("getCalculatedTotalAmountArguments")
-  @DisplayName("Should retrieve a submission and correctly scale rounding variations for calculated total amount")
+  @DisplayName(
+      "Should retrieve a submission and correctly scale rounding variations for calculated total amount")
   void shouldGetSubmission(String inputTotalAmount, String expectedTotalAmount) {
     Submission entity = ClaimsDataTestUtil.getSubmission();
     when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(entity));
@@ -122,7 +123,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should retrieve submission with scaled 0.00 value when calculated total amount is exactly zero")
+  @DisplayName(
+      "Should retrieve submission with scaled 0.00 value when calculated total amount is exactly zero")
   void shouldGetSubmissionWithZeroCalculatedTotalAmount() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
     when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(entity));
@@ -137,7 +139,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should retrieve submission with a null calculated total amount if no values are recorded")
+  @DisplayName(
+      "Should retrieve submission with a null calculated total amount if no values are recorded")
   void shouldGetSubmissionWithNullCalculatedTotalAmount() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
     when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(entity));
@@ -152,7 +155,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should retrieve submission with a null assessed total amount when no assessment records exist")
+  @DisplayName(
+      "Should retrieve submission with a null assessed total amount when no assessment records exist")
   void shouldGetSubmissionWithNullAssessedTotalAmountWhenNoAssessmentsExist() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
 
@@ -169,7 +173,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should retrieve submission with scaled 0.00 assessed total amount when assessment sums to zero")
+  @DisplayName(
+      "Should retrieve submission with scaled 0.00 assessed total amount when assessment sums to zero")
   void shouldGetSubmissionWithZeroAssessedTotalAmountWhenAssessmentsTotalZero() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
 
@@ -220,7 +225,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should throw SubmissionNotFoundException when retrieving a non-existent submission ID")
+  @DisplayName(
+      "Should throw SubmissionNotFoundException when retrieving a non-existent submission ID")
   void shouldThrowWhenSubmissionNotFoundOnGet() {
     UUID id = Uuid7.timeBasedUuid();
     when(submissionRepository.findById(id)).thenReturn(Optional.empty());
@@ -243,7 +249,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should cascadingly update all associated claims to INVALID when submission status changes to VALIDATION_FAILED")
+  @DisplayName(
+      "Should cascadingly update all associated claims to INVALID when submission status changes to VALIDATION_FAILED")
   void shouldUpdateAllClaimsAsInvalidWhenSubmissionStatusIsValidationFailed() {
     UUID id = Uuid7.timeBasedUuid();
     Submission entity = Submission.builder().id(id).build();
@@ -258,7 +265,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should trigger submission validation succeeded domain event when status changes to VALIDATION_SUCCEEDED")
+  @DisplayName(
+      "Should trigger submission validation succeeded domain event when status changes to VALIDATION_SUCCEEDED")
   void shouldPublishValidationSucceededEventWhenSubmissionStatusIsValidationSucceeded() {
     UUID id = Uuid7.timeBasedUuid();
     Submission entity = Submission.builder().id(id).build();
@@ -290,7 +298,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should throw SubmissionNotFoundException when trying to patch a non-existent submission")
+  @DisplayName(
+      "Should throw SubmissionNotFoundException when trying to patch a non-existent submission")
   void shouldThrowWhenSubmissionNotFoundOnUpdate() {
     UUID id = Uuid7.timeBasedUuid();
     SubmissionPatch patch = new SubmissionPatch();
@@ -325,7 +334,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should throw SubmissionBadRequestException when office accounts list parameter is completely omitted")
+  @DisplayName(
+      "Should throw SubmissionBadRequestException when office accounts list parameter is completely omitted")
   void getSubmissionsResultSet_whenOfficesIsMissing_shouldThrowSubmissionBadRequestException() {
     assertThrows(
         SubmissionBadRequestException.class,
@@ -342,7 +352,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should throw SubmissionBadRequestException when office accounts list parameter is empty")
+  @DisplayName(
+      "Should throw SubmissionBadRequestException when office accounts list parameter is empty")
   void getSubmissionsResultSet_whenOfficesIsEmpty_shouldThrowSubmissionBadRequestException() {
     assertThrows(
         SubmissionBadRequestException.class,
@@ -359,7 +370,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should return matching paginated submissions array with calculated and assessed values formatted correctly")
+  @DisplayName(
+      "Should return matching paginated submissions array with calculated and assessed values formatted correctly")
   void getSubmissionsResultSet_whenFiltersMatchData_shouldReturnNonEmptyResultSet() {
     var submissionBase = SubmissionBase.builder().submissionId(UUID.randomUUID()).build();
     var submission = new Submission();
@@ -375,11 +387,11 @@ class SubmissionServiceTest {
 
     assertThat(submissionBase.getSubmissionId()).isNotNull();
     when(assessmentService.getAssessedTotalAmounts(
-        Collections.singletonList(submissionBase.getSubmissionId())))
+            Collections.singletonList(submissionBase.getSubmissionId())))
         .thenReturn(Map.of(submissionBase.getSubmissionId(), new BigDecimal("123.40")));
 
     when(submissionRepository.getCalculatedTotalAmounts(
-        Collections.singletonList(submissionBase.getSubmissionId())))
+            Collections.singletonList(submissionBase.getSubmissionId())))
         .thenReturn(
             getCalcTotalsProjection(submissionBase.getSubmissionId(), new BigDecimal("789.1")));
 
@@ -408,7 +420,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should bypass fetching totals downstream and return empty set structure when query yields no results")
+  @DisplayName(
+      "Should bypass fetching totals downstream and return empty set structure when query yields no results")
   void getSubmissionsResultSet_whenFiltersDoNotMatchData_shouldReturnEmptyResultSet() {
     Page<Submission> resultPage = new PageImpl<>(Collections.emptyList());
 
@@ -436,7 +449,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should execute findAll passing all filter parameters correctly mapped onto a JPA Specification object")
+  @DisplayName(
+      "Should execute findAll passing all filter parameters correctly mapped onto a JPA Specification object")
   void getSubmissionsResultSet_shouldCallFindAllWithSpecification() {
     Page<Submission> resultPage = new PageImpl<>(Collections.emptyList());
 
@@ -467,7 +481,8 @@ class SubmissionServiceTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"createdOn", "areaOfLaw", "status"})
-  @DisplayName("Should preserve standard sorting strategies, appending case-insensitive handling and secondary ID tie-breakers")
+  @DisplayName(
+      "Should preserve standard sorting strategies, appending case-insensitive handling and secondary ID tie-breakers")
   void getSubmissionsResultSet_whenSortFieldIsValid_shouldPassSortToRepository(String sortField) {
     Pageable pageableWithSort = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, sortField));
     // Service appends a secondary sort by id using the same direction as the primary sort,
@@ -498,7 +513,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should apply case-insensitive ordering when specific sorting by officeAccountNumber is requested")
+  @DisplayName(
+      "Should apply case-insensitive ordering when specific sorting by officeAccountNumber is requested")
   void getSubmissionsResultSet_whenSortByOfficeAccountNumber_shouldApplyIgnoreCase() {
     Pageable pageableWithSort =
         PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "officeAccountNumber"));
@@ -530,7 +546,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should remap 'submissionPeriod' property to 'submissionPeriodSortKey' ensuring chronological database ordering")
+  @DisplayName(
+      "Should remap 'submissionPeriod' property to 'submissionPeriodSortKey' ensuring chronological database ordering")
   void getSubmissionsResultSet_whenSortBySubmissionPeriod_shouldRemapToSortKey() {
     Pageable pageableWithPeriodSort =
         PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "submissionPeriod"));
@@ -562,7 +579,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should match tie-breaker direction (DESC) with primary sorting direction when descending order is requested")
+  @DisplayName(
+      "Should match tie-breaker direction (DESC) with primary sorting direction when descending order is requested")
   void getSubmissionsResultSet_whenSortIsDescending_tieBreakerShouldAlsoBeDescending() {
     Pageable pageableWithDescSort =
         PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdOn"));
@@ -593,7 +611,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should apply ascending sort by primary database identifier ID when no explicit sorting request is given")
+  @DisplayName(
+      "Should apply ascending sort by primary database identifier ID when no explicit sorting request is given")
   void getSubmissionsResultSet_alwaysAppendsTieBreakerSortById() {
     Pageable unorderedPageable = Pageable.ofSize(10).withPage(0);
     // No primary sort, so tie-breaker defaults to ASC
@@ -619,7 +638,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should throw SubmissionBadRequestException and short-circuit operations if requested sort property is invalid")
+  @DisplayName(
+      "Should throw SubmissionBadRequestException and short-circuit operations if requested sort property is invalid")
   void getSubmissionsResultSet_whenSortFieldIsInvalid_shouldThrowSubmissionBadRequestException() {
     Pageable pageableWithInvalidSort =
         PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "unknownField"));
@@ -641,7 +661,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should trigger submission validation initialization domain event when status becomes READY_FOR_VALIDATION")
+  @DisplayName(
+      "Should trigger submission validation initialization domain event when status becomes READY_FOR_VALIDATION")
   void updateSubmission_whenStatusIsReadyForValidation_shouldPublishValidationEvent() {
     UUID id = Uuid7.timeBasedUuid();
     Submission entity = Submission.builder().id(id).build();
@@ -656,7 +677,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should bypass validation logging entirely if provided validation messages collection list payload is empty")
+  @DisplayName(
+      "Should bypass validation logging entirely if provided validation messages collection list payload is empty")
   void updateSubmission_whenValidationMessagesListIsEmpty_shouldNotSaveLogs() {
     UUID id = Uuid7.timeBasedUuid();
     Submission entity = Submission.builder().id(id).build();
@@ -670,16 +692,19 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should return an empty tracking map immediately and bypass repository lookups if search context list is empty")
+  @DisplayName(
+      "Should return an empty tracking map immediately and bypass repository lookups if search context list is empty")
   void getCalculatedTotalAmounts_whenInputIsEmpty_shouldReturnEmptyMap() {
-    Map<UUID, BigDecimal> result = submissionService.getCalculatedTotalAmounts(Collections.emptyList());
+    Map<UUID, BigDecimal> result =
+        submissionService.getCalculatedTotalAmounts(Collections.emptyList());
 
     assertThat(result).isEmpty();
     verifyNoInteractions(submissionRepository);
   }
 
   @Test
-  @DisplayName("Should return an empty tracking map immediately and bypass repository lookups if search context list is null")
+  @DisplayName(
+      "Should return an empty tracking map immediately and bypass repository lookups if search context list is null")
   void getCalculatedTotalAmounts_whenInputIsNull_shouldReturnEmptyMap() {
     Map<UUID, BigDecimal> result = submissionService.getCalculatedTotalAmounts(null);
 
@@ -688,7 +713,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should cleanly discard structural projection entries containing invalid null fields during calculated map aggregation")
+  @DisplayName(
+      "Should cleanly discard structural projection entries containing invalid null fields during calculated map aggregation")
   void getCalculatedTotalAmounts_whenProjectionsContainNulls_shouldFilterThemOutSafely() {
     UUID validId = UUID.randomUUID();
 
@@ -708,7 +734,8 @@ class SubmissionServiceTest {
   }
 
   @Test
-  @DisplayName("Should retrieve submission with null calculated and assessed total amounts when neither exists")
+  @DisplayName(
+      "Should retrieve submission with null calculated and assessed total amounts when neither exists")
   void shouldGetSubmissionWithNullCalculatedAndAssessedTotalAmounts() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
     when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(entity));

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -10,7 +10,6 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUt
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_STATUSES;
 
-import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -22,7 +21,6 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Setter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +32,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -64,28 +61,18 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 
 @ExtendWith(MockitoExtension.class)
 class SubmissionServiceTest {
-  @Mock
-  private SubmissionRepository submissionRepository;
-  @Mock
-  private ClaimService claimService;
-  @Mock
-  private MatterStartService matterStartService;
-  @Mock
-  private SubmissionMapper submissionMapper;
-  @Mock
-  private ValidationMessageLogRepository validationMessageLogRepository;
-  @Mock
-  private SubmissionsResultSetMapper submissionsResultSetMapper;
-  @Mock
-  private SubmissionEventPublisherService submissionEventPublisherService;
-  @Mock
-  private AssessmentService assessmentService;
+  @Mock private SubmissionRepository submissionRepository;
+  @Mock private ClaimService claimService;
+  @Mock private MatterStartService matterStartService;
+  @Mock private SubmissionMapper submissionMapper;
+  @Mock private ValidationMessageLogRepository validationMessageLogRepository;
+  @Mock private SubmissionsResultSetMapper submissionsResultSetMapper;
+  @Mock private SubmissionEventPublisherService submissionEventPublisherService;
+  @Mock private AssessmentService assessmentService;
 
-  @InjectMocks
-  private SubmissionService submissionService;
+  @InjectMocks private SubmissionService submissionService;
 
-  @Captor
-  private ArgumentCaptor<Specification> submissionSpecificationArgumentCaptor;
+  @Captor private ArgumentCaptor<Specification> submissionSpecificationArgumentCaptor;
   private static final LocalDate SUBMITTED_DATE_FROM = LocalDate.of(2025, 1, 1);
   private static final LocalDate SUBMITTED_DATE_TO = LocalDate.of(2025, 12, 31);
   private static final List<String> OFFICE_CODES = List.of("office1", "office2", "office3");
@@ -368,14 +355,13 @@ class SubmissionServiceTest {
 
     assertThat(submissionBase.getSubmissionId()).isNotNull();
     when(assessmentService.getAssessedTotalAmounts(
-        Collections.singletonList(submissionBase.getSubmissionId())))
+            Collections.singletonList(submissionBase.getSubmissionId())))
         .thenReturn(Map.of(submissionBase.getSubmissionId(), new BigDecimal("123.40")));
 
     when(submissionRepository.getCalculatedTotalAmounts(
-        Collections.singletonList(submissionBase.getSubmissionId())))
+            Collections.singletonList(submissionBase.getSubmissionId())))
         .thenReturn(
-            getCalcTotalsProjection(submissionBase.getSubmissionId(),
-                new BigDecimal("789.1")));
+            getCalcTotalsProjection(submissionBase.getSubmissionId(), new BigDecimal("789.1")));
 
     var actualResultSet =
         submissionService.getSubmissionsResultSet(
@@ -397,8 +383,8 @@ class SubmissionServiceTest {
         .isEqualTo(new BigDecimal("789.10"));
     verify(assessmentService)
         .getAssessedTotalAmounts(Collections.singletonList(submissionBase.getSubmissionId()));
-    verify(submissionRepository).getCalculatedTotalAmounts(
-        Collections.singletonList(submissionBase.getSubmissionId()));
+    verify(submissionRepository)
+        .getCalculatedTotalAmounts(Collections.singletonList(submissionBase.getSubmissionId()));
   }
 
   @Test
@@ -627,8 +613,8 @@ class SubmissionServiceTest {
     verifyNoInteractions(submissionRepository);
   }
 
-  private List<SubmissionRepository.CalculatedTotalAmountProjection>
-  getCalcTotalsProjection(UUID submissionId, BigDecimal expectedCalcValue) {
+  private List<SubmissionRepository.CalculatedTotalAmountProjection> getCalcTotalsProjection(
+      UUID submissionId, BigDecimal expectedCalcValue) {
 
     TestProjection projection = new TestProjection(submissionId, expectedCalcValue);
     return new ArrayList<>(List.of(projection));

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -61,6 +61,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil;
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("SubmissionService Unit Tests")
 class SubmissionServiceTest {
   @Mock private SubmissionRepository submissionRepository;
   @Mock private ClaimService claimService;
@@ -80,6 +81,7 @@ class SubmissionServiceTest {
   private static final String SUBMISSION_PERIOD = "2025-07";
 
   @Test
+  @DisplayName("Should successfully map and persist a new submission")
   void shouldCreateSubmission() {
     UUID id = Uuid7.timeBasedUuid();
     SubmissionPost post = new SubmissionPost().submissionId(id);
@@ -96,6 +98,7 @@ class SubmissionServiceTest {
 
   @ParameterizedTest
   @MethodSource("getCalculatedTotalAmountArguments")
+  @DisplayName("Should retrieve a submission and correctly scale rounding variations for calculated total amount")
   void shouldGetSubmission(String inputTotalAmount, String expectedTotalAmount) {
     Submission entity = ClaimsDataTestUtil.getSubmission();
     when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(entity));
@@ -119,6 +122,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should retrieve submission with scaled 0.00 value when calculated total amount is exactly zero")
   void shouldGetSubmissionWithZeroCalculatedTotalAmount() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
     when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(entity));
@@ -133,6 +137,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should retrieve submission with a null calculated total amount if no values are recorded")
   void shouldGetSubmissionWithNullCalculatedTotalAmount() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
     when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(entity));
@@ -147,6 +152,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should retrieve submission with a null assessed total amount when no assessment records exist")
   void shouldGetSubmissionWithNullAssessedTotalAmountWhenNoAssessmentsExist() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
 
@@ -163,6 +169,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should retrieve submission with scaled 0.00 assessed total amount when assessment sums to zero")
   void shouldGetSubmissionWithZeroAssessedTotalAmountWhenAssessmentsTotalZero() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
 
@@ -180,6 +187,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should retrieve submission scaling the assessed total amount to two decimal places")
   void shouldGetSubmissionWithAssessedTotalAmountToTwoDecimalPlaces() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
 
@@ -197,6 +205,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should retrieve submission along with its top-level error messages field")
   void shouldGetSubmissionWithErrorMessages() {
     Submission entity = ClaimsDataTestUtil.getSubmission();
     when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(entity));
@@ -211,6 +220,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should throw SubmissionNotFoundException when retrieving a non-existent submission ID")
   void shouldThrowWhenSubmissionNotFoundOnGet() {
     UUID id = Uuid7.timeBasedUuid();
     when(submissionRepository.findById(id)).thenReturn(Optional.empty());
@@ -219,6 +229,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should successfully apply patch fields and update submission entity details")
   void shouldUpdateSubmission() {
     UUID id = Uuid7.timeBasedUuid();
     Submission entity = Submission.builder().id(id).build();
@@ -232,6 +243,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should cascadingly update all associated claims to INVALID when submission status changes to VALIDATION_FAILED")
   void shouldUpdateAllClaimsAsInvalidWhenSubmissionStatusIsValidationFailed() {
     UUID id = Uuid7.timeBasedUuid();
     Submission entity = Submission.builder().id(id).build();
@@ -246,6 +258,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should trigger submission validation succeeded domain event when status changes to VALIDATION_SUCCEEDED")
   void shouldPublishValidationSucceededEventWhenSubmissionStatusIsValidationSucceeded() {
     UUID id = Uuid7.timeBasedUuid();
     Submission entity = Submission.builder().id(id).build();
@@ -260,6 +273,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should update submission with Legal Help and Mediation references via patch")
   void shouldUpdateSubmissionWithCivilAndMediationSubmissionReferences() {
     UUID id = Uuid7.timeBasedUuid();
     Submission entity = Submission.builder().id(id).build();
@@ -276,6 +290,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should throw SubmissionNotFoundException when trying to patch a non-existent submission")
   void shouldThrowWhenSubmissionNotFoundOnUpdate() {
     UUID id = Uuid7.timeBasedUuid();
     SubmissionPatch patch = new SubmissionPatch();
@@ -286,6 +301,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should process patch and map/persist incoming validation error logging collections")
   void shouldUpdateSubmissionAndLogValidationErrors() {
     UUID id = Uuid7.timeBasedUuid();
     Submission entity = Submission.builder().id(id).build();
@@ -309,6 +325,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should throw SubmissionBadRequestException when office accounts list parameter is completely omitted")
   void getSubmissionsResultSet_whenOfficesIsMissing_shouldThrowSubmissionBadRequestException() {
     assertThrows(
         SubmissionBadRequestException.class,
@@ -325,6 +342,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should throw SubmissionBadRequestException when office accounts list parameter is empty")
   void getSubmissionsResultSet_whenOfficesIsEmpty_shouldThrowSubmissionBadRequestException() {
     assertThrows(
         SubmissionBadRequestException.class,
@@ -341,6 +359,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should return matching paginated submissions array with calculated and assessed values formatted correctly")
   void getSubmissionsResultSet_whenFiltersMatchData_shouldReturnNonEmptyResultSet() {
     var submissionBase = SubmissionBase.builder().submissionId(UUID.randomUUID()).build();
     var submission = new Submission();
@@ -356,11 +375,11 @@ class SubmissionServiceTest {
 
     assertThat(submissionBase.getSubmissionId()).isNotNull();
     when(assessmentService.getAssessedTotalAmounts(
-            Collections.singletonList(submissionBase.getSubmissionId())))
+        Collections.singletonList(submissionBase.getSubmissionId())))
         .thenReturn(Map.of(submissionBase.getSubmissionId(), new BigDecimal("123.40")));
 
     when(submissionRepository.getCalculatedTotalAmounts(
-            Collections.singletonList(submissionBase.getSubmissionId())))
+        Collections.singletonList(submissionBase.getSubmissionId())))
         .thenReturn(
             getCalcTotalsProjection(submissionBase.getSubmissionId(), new BigDecimal("789.1")));
 
@@ -389,6 +408,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should bypass fetching totals downstream and return empty set structure when query yields no results")
   void getSubmissionsResultSet_whenFiltersDoNotMatchData_shouldReturnEmptyResultSet() {
     Page<Submission> resultPage = new PageImpl<>(Collections.emptyList());
 
@@ -415,8 +435,8 @@ class SubmissionServiceTest {
     verifyNoInteractions(assessmentService);
   }
 
-  @DisplayName("Should call findAll with  Specification area of law and submission period")
   @Test
+  @DisplayName("Should execute findAll passing all filter parameters correctly mapped onto a JPA Specification object")
   void getSubmissionsResultSet_shouldCallFindAllWithSpecification() {
     Page<Submission> resultPage = new PageImpl<>(Collections.emptyList());
 
@@ -447,6 +467,7 @@ class SubmissionServiceTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"createdOn", "areaOfLaw", "status"})
+  @DisplayName("Should preserve standard sorting strategies, appending case-insensitive handling and secondary ID tie-breakers")
   void getSubmissionsResultSet_whenSortFieldIsValid_shouldPassSortToRepository(String sortField) {
     Pageable pageableWithSort = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, sortField));
     // Service appends a secondary sort by id using the same direction as the primary sort,
@@ -477,6 +498,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should apply case-insensitive ordering when specific sorting by officeAccountNumber is requested")
   void getSubmissionsResultSet_whenSortByOfficeAccountNumber_shouldApplyIgnoreCase() {
     Pageable pageableWithSort =
         PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "officeAccountNumber"));
@@ -508,6 +530,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should remap 'submissionPeriod' property to 'submissionPeriodSortKey' ensuring chronological database ordering")
   void getSubmissionsResultSet_whenSortBySubmissionPeriod_shouldRemapToSortKey() {
     Pageable pageableWithPeriodSort =
         PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "submissionPeriod"));
@@ -539,6 +562,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should match tie-breaker direction (DESC) with primary sorting direction when descending order is requested")
   void getSubmissionsResultSet_whenSortIsDescending_tieBreakerShouldAlsoBeDescending() {
     Pageable pageableWithDescSort =
         PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdOn"));
@@ -569,6 +593,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should apply ascending sort by primary database identifier ID when no explicit sorting request is given")
   void getSubmissionsResultSet_alwaysAppendsTieBreakerSortById() {
     Pageable unorderedPageable = Pageable.ofSize(10).withPage(0);
     // No primary sort, so tie-breaker defaults to ASC
@@ -594,6 +619,7 @@ class SubmissionServiceTest {
   }
 
   @Test
+  @DisplayName("Should throw SubmissionBadRequestException and short-circuit operations if requested sort property is invalid")
   void getSubmissionsResultSet_whenSortFieldIsInvalid_shouldThrowSubmissionBadRequestException() {
     Pageable pageableWithInvalidSort =
         PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "unknownField"));
@@ -612,6 +638,92 @@ class SubmissionServiceTest {
                 pageableWithInvalidSort));
 
     verifyNoInteractions(submissionRepository);
+  }
+
+  @Test
+  @DisplayName("Should trigger submission validation initialization domain event when status becomes READY_FOR_VALIDATION")
+  void updateSubmission_whenStatusIsReadyForValidation_shouldPublishValidationEvent() {
+    UUID id = Uuid7.timeBasedUuid();
+    Submission entity = Submission.builder().id(id).build();
+    SubmissionPatch patch = new SubmissionPatch().status(SubmissionStatus.READY_FOR_VALIDATION);
+    when(submissionRepository.findById(id)).thenReturn(Optional.of(entity));
+
+    submissionService.updateSubmission(id, patch);
+
+    verify(submissionMapper).updateSubmissionFromPatch(patch, entity);
+    verify(submissionRepository).save(entity);
+    verify(submissionEventPublisherService).publishSubmissionValidationEvent(id);
+  }
+
+  @Test
+  @DisplayName("Should bypass validation logging entirely if provided validation messages collection list payload is empty")
+  void updateSubmission_whenValidationMessagesListIsEmpty_shouldNotSaveLogs() {
+    UUID id = Uuid7.timeBasedUuid();
+    Submission entity = Submission.builder().id(id).build();
+    SubmissionPatch patch = new SubmissionPatch().validationMessages(Collections.emptyList());
+    when(submissionRepository.findById(id)).thenReturn(Optional.of(entity));
+
+    submissionService.updateSubmission(id, patch);
+
+    verify(submissionRepository).save(entity);
+    verifyNoInteractions(validationMessageLogRepository);
+  }
+
+  @Test
+  @DisplayName("Should return an empty tracking map immediately and bypass repository lookups if search context list is empty")
+  void getCalculatedTotalAmounts_whenInputIsEmpty_shouldReturnEmptyMap() {
+    Map<UUID, BigDecimal> result = submissionService.getCalculatedTotalAmounts(Collections.emptyList());
+
+    assertThat(result).isEmpty();
+    verifyNoInteractions(submissionRepository);
+  }
+
+  @Test
+  @DisplayName("Should return an empty tracking map immediately and bypass repository lookups if search context list is null")
+  void getCalculatedTotalAmounts_whenInputIsNull_shouldReturnEmptyMap() {
+    Map<UUID, BigDecimal> result = submissionService.getCalculatedTotalAmounts(null);
+
+    assertThat(result).isEmpty();
+    verifyNoInteractions(submissionRepository);
+  }
+
+  @Test
+  @DisplayName("Should cleanly discard structural projection entries containing invalid null fields during calculated map aggregation")
+  void getCalculatedTotalAmounts_whenProjectionsContainNulls_shouldFilterThemOutSafely() {
+    UUID validId = UUID.randomUUID();
+
+    List<SubmissionRepository.CalculatedTotalAmountProjection> projections = new ArrayList<>();
+    projections.add(new TestProjection(validId, new BigDecimal("500.00")));
+    projections.add(new TestProjection(null, new BigDecimal("100.00")));
+    projections.add(new TestProjection(UUID.randomUUID(), null));
+
+    List<UUID> queryIds = List.of(validId);
+    when(submissionRepository.getCalculatedTotalAmounts(queryIds)).thenReturn(projections);
+
+    Map<UUID, BigDecimal> result = submissionService.getCalculatedTotalAmounts(queryIds);
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey(validId);
+    assertThat(result.get(validId)).isEqualTo(new BigDecimal("500.00"));
+  }
+
+  @Test
+  @DisplayName("Should retrieve submission with null calculated and assessed total amounts when neither exists")
+  void shouldGetSubmissionWithNullCalculatedAndAssessedTotalAmounts() {
+    Submission entity = ClaimsDataTestUtil.getSubmission();
+    when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(entity));
+    when(claimService.getClaimsForSubmission(SUBMISSION_ID)).thenReturn(List.of());
+    when(matterStartService.getMatterStartIdsForSubmission(SUBMISSION_ID)).thenReturn(List.of());
+
+    // Both backend systems return null
+    when(submissionRepository.getCalculatedTotalAmount(SUBMISSION_ID)).thenReturn(null);
+    when(assessmentService.getAssessedTotalAmount(SUBMISSION_ID)).thenReturn(null);
+
+    SubmissionResponse result = submissionService.getSubmission(SUBMISSION_ID);
+
+    assertThat(result.getSubmissionId()).isEqualTo(SUBMISSION_ID);
+    assertThat(result.getCalculatedTotalAmount()).isNull();
+    assertThat(result.getAssessedTotalAmount()).isNull();
   }
 
   private List<SubmissionRepository.CalculatedTotalAmountProjection> getCalcTotalsProjection(

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -10,14 +11,19 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUt
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_STATUSES;
 
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Setter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +35,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -58,18 +65,28 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 
 @ExtendWith(MockitoExtension.class)
 class SubmissionServiceTest {
-  @Mock private SubmissionRepository submissionRepository;
-  @Mock private ClaimService claimService;
-  @Mock private MatterStartService matterStartService;
-  @Mock private SubmissionMapper submissionMapper;
-  @Mock private ValidationMessageLogRepository validationMessageLogRepository;
-  @Mock private SubmissionsResultSetMapper submissionsResultSetMapper;
-  @Mock private SubmissionEventPublisherService submissionEventPublisherService;
-  @Mock private AssessmentService assessmentService;
+  @Mock
+  private SubmissionRepository submissionRepository;
+  @Mock
+  private ClaimService claimService;
+  @Mock
+  private MatterStartService matterStartService;
+  @Mock
+  private SubmissionMapper submissionMapper;
+  @Mock
+  private ValidationMessageLogRepository validationMessageLogRepository;
+  @Mock
+  private SubmissionsResultSetMapper submissionsResultSetMapper;
+  @Mock
+  private SubmissionEventPublisherService submissionEventPublisherService;
+  @Mock
+  private AssessmentService assessmentService;
 
-  @InjectMocks private SubmissionService submissionService;
+  @InjectMocks
+  private SubmissionService submissionService;
 
-  @Captor private ArgumentCaptor<Specification> submissionSpecificationArgumentCaptor;
+  @Captor
+  private ArgumentCaptor<Specification> submissionSpecificationArgumentCaptor;
   private static final LocalDate SUBMITTED_DATE_FROM = LocalDate.of(2025, 1, 1);
   private static final LocalDate SUBMITTED_DATE_TO = LocalDate.of(2025, 12, 31);
   private static final List<String> OFFICE_CODES = List.of("office1", "office2", "office3");
@@ -335,9 +352,17 @@ class SubmissionServiceTest {
         new SubmissionsResultSet().content(Collections.singletonList(submissionBase));
     when(submissionsResultSetMapper.toSubmissionsResultSet(resultPage))
         .thenReturn(expectedNonEmptyResultSet);
+
+    assertThat(submissionBase.getSubmissionId()).isNotNull();
     when(assessmentService.getAssessedTotalAmounts(
-            Collections.singletonList(submissionBase.getSubmissionId())))
+        Collections.singletonList(submissionBase.getSubmissionId())))
         .thenReturn(Map.of(submissionBase.getSubmissionId(), new BigDecimal("123.40")));
+
+    when(submissionRepository.getCalculatedTotalAmounts(
+        Collections.singletonList(submissionBase.getSubmissionId())))
+        .thenReturn(
+            getCalcTotalsProjection(submissionBase.getSubmissionId(),
+                new BigDecimal("789.1")));
 
     var actualResultSet =
         submissionService.getSubmissionsResultSet(
@@ -355,8 +380,12 @@ class SubmissionServiceTest {
         .isEqualTo(submissionBase.getSubmissionId());
     assertThat(actualResultSet.getContent().getFirst().getAssessedTotalAmount())
         .isEqualTo(new BigDecimal("123.40"));
+    assertThat(actualResultSet.getContent().getFirst().getCalculatedTotalAmount())
+        .isEqualTo(new BigDecimal("789.10"));
     verify(assessmentService)
         .getAssessedTotalAmounts(Collections.singletonList(submissionBase.getSubmissionId()));
+    verify(submissionRepository).getCalculatedTotalAmounts(
+        Collections.singletonList(submissionBase.getSubmissionId()));
   }
 
   @Test
@@ -584,4 +613,19 @@ class SubmissionServiceTest {
 
     verifyNoInteractions(submissionRepository);
   }
+
+  private List<SubmissionRepository.CalculatedTotalAmountProjection>
+  getCalcTotalsProjection(UUID submissionId, BigDecimal expectedCalcValue) {
+
+    TestProjection projection = new TestProjection(submissionId, expectedCalcValue);
+    return new ArrayList<>(List.of(projection));
+  }
+}
+
+@AllArgsConstructor
+@Data
+class TestProjection implements SubmissionRepository.CalculatedTotalAmountProjection {
+
+  private UUID submissionId;
+  private BigDecimal total;
 }


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/browse/DSTEW-1711

There is an historic bug in the getSubmissions endpoint. The mapper doesn't appear to be mapping all fields correctly- one of the fields is calc-total-amount, so I have applied a fix for this and checked the other fields that they are present in the mapper tests

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [x] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
