### PR TITLE
DSTEW-1763: Retrieve claim and build in-memory post-amendment state

### DIFF
--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -93,6 +93,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
     implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
     implementation platform("software.amazon.awssdk:bom:2.32.22")
     implementation 'software.amazon.awssdk:sts'

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AbstractIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AbstractIntegrationTest.java
@@ -94,6 +94,18 @@ public abstract class AbstractIntegrationTest {
   protected static final String OFFICE_ACCOUNT_NUMBER_1 = "office1";
   protected static final String OFFICE_ACCOUNT_NUMBER_2 = "office2";
 
+  // Convention: a seed value is promoted to a named constant only when a test asserts on it, so the
+  // seed below and that assertion share a single source of truth and cannot drift. The remaining
+  // seed literals are deliberately left inline - they are arbitrary, single-use, unasserted fixture
+  // data, so naming them would add noise without any drift or de-duplication benefit. These are the
+  // CLAIM_1 before-state values the amendment integration tests assert on.
+  protected static final String SEEDED_CLIENT_FORENAME = "Alice";
+  protected static final String SEEDED_UNIQUE_CLIENT_NUMBER = "UCN_111";
+  protected static final String SEEDED_CASE_ID = "CASE_ID_1";
+  protected static final int SEEDED_ADVICE_TIME = 120;
+  protected static final String SEEDED_CATEGORY_OF_LAW = "IMMIGRATION";
+  protected static final String SEEDED_LATEST_ASSESSMENT_ALLOWED_TOTAL_INCL_VAT = "240.00";
+
   @Autowired protected ValidationMessageLogRepository validationMessageLogRepository;
   @Autowired protected BulkSubmissionRepository bulkSubmissionRepository;
   @Autowired protected SubmissionRepository submissionRepository;
@@ -281,7 +293,7 @@ public abstract class AbstractIntegrationTest {
         ClaimSummaryFee.builder()
             .id(CLAIM_1_SUMMARY_FEE_ID)
             .claim(claimRepository.getReferenceById(CLAIM_1_ID))
-            .adviceTime(120)
+            .adviceTime(SEEDED_ADVICE_TIME)
             .travelTime(45)
             .waitingTime(30)
             .netProfitCostsAmount(BigDecimal.valueOf(250))
@@ -369,7 +381,7 @@ public abstract class AbstractIntegrationTest {
             .feeCode("CALC-FEE-1")
             .feeType(FeeCalculationType.DISB_ONLY)
             .feeCodeDescription("Calculated fee for claim 1")
-            .categoryOfLaw("IMMIGRATION")
+            .categoryOfLaw(SEEDED_CATEGORY_OF_LAW)
             .totalAmount(BigDecimal.valueOf(125))
             .vatIndicator(true)
             .vatRateApplied(new BigDecimal("0.20"))
@@ -451,9 +463,9 @@ public abstract class AbstractIntegrationTest {
             Client.builder()
                 .id(Uuid7.timeBasedUuid())
                 .claim(claimRepository.getReferenceById(CLAIM_1_ID))
-                .clientForename("Alice")
+                .clientForename(SEEDED_CLIENT_FORENAME)
                 .clientSurname("Smith")
-                .uniqueClientNumber("UCN_111")
+                .uniqueClientNumber(SEEDED_UNIQUE_CLIENT_NUMBER)
                 .createdByUserId(USER_ID)
                 .createdOn(CREATED_ON)
                 .build(),
@@ -472,7 +484,7 @@ public abstract class AbstractIntegrationTest {
             ClaimCase.builder()
                 .id(Uuid7.timeBasedUuid())
                 .claim(claimRepository.getReferenceById(CLAIM_1_ID))
-                .caseId("CASE_ID_1")
+                .caseId(SEEDED_CASE_ID)
                 .uniqueCaseId("UC_ID_1")
                 .caseStageCode("CASE_STAGE_CODE")
                 .stageReachedCode("STAGE_REACHED_CODE")
@@ -557,7 +569,7 @@ public abstract class AbstractIntegrationTest {
             .assessmentType(AssessmentType.ESCAPE_CASE_ASSESSMENT)
             .assessmentReason("Reason for assessment")
             .allowedTotalVat(new BigDecimal("200.00"))
-            .allowedTotalInclVat(new BigDecimal("240.00"))
+            .allowedTotalInclVat(new BigDecimal(SEEDED_LATEST_ASSESSMENT_ALLOWED_TOTAL_INCL_VAT))
             .createdOn(Instant.now())
             .build();
     Assessment assessment3 =

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentJacksonIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentJacksonIntegrationTest.java
@@ -1,0 +1,162 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_BEFORE_STATE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_CASE_REFERENCE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_CLAIM_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_HAS_ASSESSMENT;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_POST_AMENDMENT_STATE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_REQUEST_PAYLOAD;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_SCHEDULE_REFERENCE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_UNIQUE_FILE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.SCHEDULE_REFERENCE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.UPDATED_SCHEDULE_REFERENCE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+
+/**
+ * Integration tests that verify the tri-state ({@link JsonNullable}) serialisation and
+ * deserialisation behaviour using the application's Spring-configured {@link ObjectMapper}.
+ *
+ * <p>This guards the wiring the amendment-history JSONB columns depend on: that the {@code
+ * JsonNullableModule} is registered on the primary mapper and that {@code JsonInclude.NON_ABSENT}
+ * drops omitted fields while preserving an explicit null. Unit tests can't catch a missing module
+ * registration on the real bean - this can.
+ *
+ * <ul>
+ *   <li>omitted &rarr; field absent from JSON;
+ *   <li>explicit null &rarr; {@code "field": null};
+ *   <li>value &rarr; serialised normally;
+ *   <li>a fully-omitted payload serialises to an empty object;
+ *   <li>the omitted, explicit-null and value distinctions survive a serialise/deserialise round
+ *       trip;
+ *   <li>the before/after snapshot and the amendment aggregate serialise to the expected shape.
+ * </ul>
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+@DisplayName("Claim amendment Jackson tri-state Integration Test")
+class ClaimAmendmentJacksonIntegrationTest extends AbstractIntegrationTest {
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Test
+  @DisplayName("Omitted fields are dropped, explicit null is kept, values are serialised")
+  void payload_serialises_omittedNullAndValueCorrectly() throws Exception {
+    ClaimAmendmentPayload payload =
+        ClaimAmendmentPayload.builder()
+            .scheduleReference(JsonNullable.of(SCHEDULE_REFERENCE)) // value
+            .uniqueFileNumber(JsonNullable.of((String) null)) // explicit clear
+            // caseReferenceNumber omitted (undefined)
+            .build();
+
+    JsonNode node = objectMapper.readTree(objectMapper.writeValueAsString(payload));
+
+    assertThat(node.has(FIELD_SCHEDULE_REFERENCE)).isTrue();
+    assertThat(node.get(FIELD_SCHEDULE_REFERENCE).asText()).isEqualTo(SCHEDULE_REFERENCE);
+
+    assertThat(node.has(FIELD_UNIQUE_FILE_NUMBER)).isTrue();
+    assertThat(node.get(FIELD_UNIQUE_FILE_NUMBER).isNull()).isTrue();
+
+    assertThat(node.has(FIELD_CASE_REFERENCE_NUMBER)).isFalse();
+  }
+
+  @Test
+  @DisplayName("A fully-omitted payload serialises to an empty object")
+  void payload_fullyOmitted_serialisesToEmptyObject() throws Exception {
+    ClaimAmendmentPayload payload = ClaimAmendmentPayload.builder().build();
+
+    JsonNode node = objectMapper.readTree(objectMapper.writeValueAsString(payload));
+
+    assertThat(node.isObject()).isTrue();
+    assertThat(node.isEmpty()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Tri-state distinctions survive a serialise/deserialise round trip")
+  void payload_roundTrip_preservesOmittedNullAndValue() throws Exception {
+    ClaimAmendmentPayload original =
+        ClaimAmendmentPayload.builder()
+            .scheduleReference(JsonNullable.of(SCHEDULE_REFERENCE)) // value
+            .uniqueFileNumber(JsonNullable.of((String) null)) // explicit clear
+            // caseReferenceNumber omitted (undefined)
+            .build();
+
+    String json = objectMapper.writeValueAsString(original);
+    ClaimAmendmentPayload restored = objectMapper.readValue(json, ClaimAmendmentPayload.class);
+
+    // value preserved
+    assertThat(restored.getScheduleReference().isPresent()).isTrue();
+    assertThat(restored.getScheduleReference().get()).isEqualTo(SCHEDULE_REFERENCE);
+
+    // explicit null preserved (present, holding null)
+    assertThat(restored.getUniqueFileNumber().isPresent()).isTrue();
+    assertThat(restored.getUniqueFileNumber().get()).isNull();
+
+    // omitted restored as undefined (not present), thanks to @Builder.Default via @Jacksonized
+    assertThat(restored.getCaseReferenceNumber().isPresent()).isFalse();
+  }
+
+  @Test
+  @DisplayName("Before-state snapshot serialises with a stable hasAssessment property")
+  void snapshot_serialises_withStableHasAssessmentProperty() throws Exception {
+    ClaimStateSnapshot snapshot =
+        ClaimStateSnapshot.builder()
+            .claimId(CLAIM_1_ID)
+            .scheduleReference(SCHEDULE_REFERENCE)
+            .status(ClaimStatus.READY_TO_PROCESS)
+            .hasAssessment(true)
+            .build();
+
+    JsonNode node = objectMapper.readTree(objectMapper.writeValueAsString(snapshot));
+
+    assertThat(node.has(FIELD_HAS_ASSESSMENT)).isTrue();
+    assertThat(node.get(FIELD_HAS_ASSESSMENT).asBoolean()).isTrue();
+    assertThat(node.get(FIELD_SCHEDULE_REFERENCE).asText()).isEqualTo(SCHEDULE_REFERENCE);
+    assertThat(node.get(FIELD_CLAIM_ID).asText()).isEqualTo(CLAIM_1_ID.toString());
+  }
+
+  @Test
+  @DisplayName("Amendment aggregate serialises to the before/payload/after diff shape")
+  void amendmentState_serialises_withBeforePayloadAndAfter() throws Exception {
+    ClaimStateSnapshot before =
+        ClaimStateSnapshot.builder()
+            .claimId(CLAIM_1_ID)
+            .scheduleReference(SCHEDULE_REFERENCE)
+            .build();
+    ClaimAmendmentPayload payload =
+        ClaimAmendmentPayload.builder()
+            .scheduleReference(JsonNullable.of(UPDATED_SCHEDULE_REFERENCE))
+            .build();
+    ClaimStateSnapshot after =
+        before.toBuilder().scheduleReference(UPDATED_SCHEDULE_REFERENCE).build();
+
+    ClaimAmendmentState state =
+        ClaimAmendmentState.builder()
+            .beforeState(before)
+            .requestPayload(payload)
+            .postAmendmentState(after)
+            .build();
+
+    JsonNode node = objectMapper.readTree(objectMapper.writeValueAsString(state));
+
+    assertThat(node.has(FIELD_BEFORE_STATE)).isTrue();
+    assertThat(node.has(FIELD_REQUEST_PAYLOAD)).isTrue();
+    assertThat(node.has(FIELD_POST_AMENDMENT_STATE)).isTrue();
+    assertThat(node.get(FIELD_BEFORE_STATE).get(FIELD_SCHEDULE_REFERENCE).asText())
+        .isEqualTo(SCHEDULE_REFERENCE);
+    assertThat(node.get(FIELD_REQUEST_PAYLOAD).get(FIELD_SCHEDULE_REFERENCE).asText())
+        .isEqualTo(UPDATED_SCHEDULE_REFERENCE);
+    assertThat(node.get(FIELD_POST_AMENDMENT_STATE).get(FIELD_SCHEDULE_REFERENCE).asText())
+        .isEqualTo(UPDATED_SCHEDULE_REFERENCE);
+  }
+}

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/runner/ReplicationSummaryRunnerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/runner/ReplicationSummaryRunnerIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -38,9 +39,9 @@ public class ReplicationSummaryRunnerIntegrationTest extends AbstractIntegration
         id, data, status, error_code, error_description, created_by_user_id,
         created_on, updated_by_user_id, updated_on, authorised_offices
     ) VALUES
-        ('11111111-1111-1111-1111-111111111111', '{"ID": "1"}', 'READY_FOR_PARSING', NULL, NULL,
+        ('11111111-1111-1111-1111-111111111111', '{}', 'READY_FOR_PARSING', NULL, NULL,
          'test_user', NOW() - interval '3 day', NULL, NOW() - interval '1 day', 'OfficeA,OfficeB'),
-        ('11111111-1111-1111-1111-111111111112', '{"ID": "2"}', 'READY_FOR_PARSING', NULL, NULL,
+        ('11111111-1111-1111-1111-111111111112', '{}', 'READY_FOR_PARSING', NULL, NULL,
          'test_user', NOW() - interval '4 day', NULL, NOW() - interval '2 day', 'OfficeA,OfficeB');
     """);
 
@@ -52,15 +53,29 @@ public class ReplicationSummaryRunnerIntegrationTest extends AbstractIntegration
         error_messages, created_by_user_id, created_on, updated_on, provider_user_id
     ) VALUES
         ('22222222-2222-2222-2222-222222222222', '11111111-1111-1111-1111-111111111111',
-         'OA001', '2025-04', 'Crime', 'VALIDATION_SUCCEEDED', 'CSN001', NULL, FALSE, 1,
+         'OA001', 'APR-2025', 'CRIME_LOWER', 'VALIDATION_SUCCEEDED', 'CSN001', NULL, FALSE, 1,
          NULL, 'test_user', NOW() - interval '3 day', NOW() - interval '3 day', 'test provider user'),
         ('22222222-2222-2222-2222-222222222223', '11111111-1111-1111-1111-111111111112',
-         'OA001', '2025-04', 'Crime', 'VALIDATION_SUCCEEDED', 'CSN001', NULL, FALSE, 1,
+         'OA001', 'APR-2025', 'CRIME_LOWER', 'VALIDATION_SUCCEEDED', 'CSN001', NULL, FALSE, 1,
          NULL, 'test_user', NOW() - interval '1 day', NOW() - interval '1 day', 'test provider user'),
         ('22222222-2222-2222-2222-222222222224', '11111111-1111-1111-1111-111111111112',
-         'OA001', '2025-04', 'Crime', 'VALIDATION_SUCCEEDED', 'CSN001', NULL, FALSE, 1,
+         'OA001', 'APR-2025', 'CRIME_LOWER', 'VALIDATION_SUCCEEDED', 'CSN001', NULL, FALSE, 1,
          NULL, 'test_user', NOW() - interval '1 day', NOW() - interval '1 day', 'test provider user');
     """);
+  }
+
+  /**
+   * Removes the rows this test inserts via raw SQL. Those rows are not loaded as JPA entities by
+   * this test, but other integration tests clear the database with {@code repository.deleteAll()},
+   * which first materialises every row into a JPA entity; leaving rows behind here would break that
+   * loading if any value were ever invalid for the entity mapping. Cleaning up keeps this test
+   * fully isolated regardless of execution order.
+   */
+  @AfterEach
+  void cleanUpDatabase() {
+    jdbcTemplate.execute("TRUNCATE claims.replication_summary CASCADE");
+    jdbcTemplate.execute("TRUNCATE claims.bulk_submission CASCADE");
+    jdbcTemplate.execute("TRUNCATE claims.submission CASCADE");
   }
 
   @Test

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceIntegrationTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentPayload;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
@@ -30,7 +31,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
  * Integration tests for {@link ClaimAmendmentStateService}.
  *
  * <p>These exercise the full Spring wiring (service, MapStruct mapper, builder), the JPA
- * repositories and the read-only transaction boundary against a real PostgreSQL (Testcontainers).
+ * repositories and the retrieve-and-build behaviour against a real PostgreSQL (Testcontainers).
  * They complement the fast, mock-based unit tests by verifying the end-to-end retrieve-and-build
  * behaviour the parent amendment flow relies on:
  *
@@ -44,8 +45,14 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
  *   <li>selection of the latest assessment;
  *   <li>graceful handling of a claim with no associated records.
  * </ul>
+ *
+ * <p>The class is {@code @Transactional} to stand in for the parent orchestrator's single atomic
+ * amendment transaction: the service declares no transaction of its own, so the test must supply
+ * one to keep the persistence context open for the mapper's lazy navigation (e.g. {@code
+ * claim.submission}), exactly as the orchestrator will in production.
  */
 @TestInstance(Lifecycle.PER_CLASS)
+@Transactional
 @DisplayName("ClaimAmendmentStateService Integration Test")
 class ClaimAmendmentStateServiceIntegrationTest extends AbstractIntegrationTest {
 

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceIntegrationTest.java
@@ -1,0 +1,253 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CASE_REFERENCE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_4_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.FEE_CODE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.MATTER_TYPE_CODE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SCHEDULE_REFERENCE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_1_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.UNIQUE_FILE_NUMBER;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentPayload;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+
+/**
+ * Integration tests for {@link ClaimAmendmentStateService}.
+ *
+ * <p>These exercise the full Spring wiring (service, MapStruct mapper, builder), the JPA
+ * repositories and the read-only transaction boundary against a real PostgreSQL (Testcontainers).
+ * They complement the fast, mock-based unit tests by verifying the end-to-end retrieve-and-build
+ * behaviour the parent amendment flow relies on:
+ *
+ * <ul>
+ *   <li>a populated before-state and a correctly applied post-amendment state;
+ *   <li>a missing claim reported as {@link Optional#empty()} (mapped upstream to {@code
+ *       INVALID_CLAIM_NOT_FOUND});
+ *   <li>no database side effects (this step is read-only);
+ *   <li>tri-state apply semantics (explicit null clears; omitted retains);
+ *   <li>UCN/UFN never recomputed from name/DOB/case-id changes;
+ *   <li>selection of the latest assessment;
+ *   <li>graceful handling of a claim with no associated records.
+ * </ul>
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+@DisplayName("ClaimAmendmentStateService Integration Test")
+class ClaimAmendmentStateServiceIntegrationTest extends AbstractIntegrationTest {
+
+  // Amended (submitted) values
+  private static final String AMENDED_SCHEDULE_REFERENCE = "NEW-SCH";
+  private static final String AMENDED_CLIENT_FORENAME = "Alicia";
+  private static final String UPDATED_SCHEDULE_REFERENCE = "CHANGED";
+  private static final String AMENDED_FORENAME = "Changed";
+  private static final String AMENDED_SURNAME = "Name";
+  private static final LocalDate AMENDED_DATE_OF_BIRTH = LocalDate.of(1990, 1, 1);
+  private static final String AMENDED_CASE_ID = "NEW_CASE_ID";
+
+  @Autowired private ClaimAmendmentStateService amendmentStateService;
+
+  @Test
+  @DisplayName("Builds before-state and applies sparse payload to produce post-amendment state")
+  void retrievesAmendmentState_happyPath_buildsBeforeAndPostState() {
+    seedAssessmentsData();
+
+    ClaimAmendmentPayload payload =
+        ClaimAmendmentPayload.builder()
+            .scheduleReference(JsonNullable.of(AMENDED_SCHEDULE_REFERENCE))
+            .clientForename(JsonNullable.of(AMENDED_CLIENT_FORENAME))
+            .isVatApplicable(JsonNullable.of(false))
+            .build();
+
+    Optional<ClaimAmendmentState> result =
+        amendmentStateService.retrieveAmendmentState(CLAIM_1_ID, payload);
+
+    assertThat(result).isPresent();
+    ClaimAmendmentState state = result.get();
+
+    // requestPayload is carried through as submitted
+    assertThat(state.getRequestPayload()).isSameAs(payload);
+
+    // before-state reflects the stored values
+    ClaimStateSnapshot before = state.getBeforeState();
+    assertThat(before.getClaimId()).isEqualTo(CLAIM_1_ID);
+    assertThat(before.getSubmissionId()).isEqualTo(SUBMISSION_1_ID);
+    assertThat(before.getStatus()).isEqualTo(ClaimStatus.READY_TO_PROCESS);
+    assertThat(before.getScheduleReference()).isEqualTo(SCHEDULE_REFERENCE);
+    assertThat(before.getCaseReferenceNumber()).isEqualTo(CASE_REFERENCE);
+    assertThat(before.getFeeCode()).isEqualTo(FEE_CODE);
+    assertThat(before.getUniqueFileNumber()).isEqualTo(UNIQUE_FILE_NUMBER);
+    assertThat(before.getMatterTypeCode()).isEqualTo(MATTER_TYPE_CODE);
+    assertThat(before.getClientForename()).isEqualTo(SEEDED_CLIENT_FORENAME);
+    assertThat(before.getUniqueClientNumber()).isEqualTo(SEEDED_UNIQUE_CLIENT_NUMBER);
+    assertThat(before.getCaseId()).isEqualTo(SEEDED_CASE_ID);
+    assertThat(before.getAdviceTime()).isEqualTo(SEEDED_ADVICE_TIME);
+    assertThat(before.getIsVatApplicable()).isTrue();
+    assertThat(before.getCategoryOfLaw()).isEqualTo(SEEDED_CATEGORY_OF_LAW);
+    assertThat(before.getCalculatedFeeDetail()).isNotNull();
+    assertThat(before.getCalculatedFeeDetail().getCategoryOfLaw())
+        .isEqualTo(SEEDED_CATEGORY_OF_LAW);
+    assertThat(before.getLatestAssessment()).isNotNull();
+    assertThat(before.getLatestAssessment().getAllowedTotalInclVat())
+        .isEqualByComparingTo(SEEDED_LATEST_ASSESSMENT_ALLOWED_TOTAL_INCL_VAT);
+
+    // post-amendment state: submitted fields change, omitted fields retain stored values
+    ClaimStateSnapshot after = state.getPostAmendmentState();
+    assertThat(after.getScheduleReference()).isEqualTo(AMENDED_SCHEDULE_REFERENCE);
+    assertThat(after.getClientForename()).isEqualTo(AMENDED_CLIENT_FORENAME);
+    assertThat(after.getIsVatApplicable()).isFalse();
+    // unchanged (omitted) fields
+    assertThat(after.getCaseReferenceNumber()).isEqualTo(CASE_REFERENCE);
+    assertThat(after.getFeeCode()).isEqualTo(FEE_CODE);
+    assertThat(after.getUniqueFileNumber()).isEqualTo(UNIQUE_FILE_NUMBER);
+    assertThat(after.getUniqueClientNumber()).isEqualTo(SEEDED_UNIQUE_CLIENT_NUMBER);
+    assertThat(after.getAdviceTime()).isEqualTo(SEEDED_ADVICE_TIME);
+    // read-only context carried over unchanged
+    assertThat(after.getStatus()).isEqualTo(ClaimStatus.READY_TO_PROCESS);
+    assertThat(after.getCategoryOfLaw()).isEqualTo(SEEDED_CATEGORY_OF_LAW);
+    assertThat(after.getCalculatedFeeDetail()).isSameAs(before.getCalculatedFeeDetail());
+    assertThat(after.getLatestAssessment()).isSameAs(before.getLatestAssessment());
+  }
+
+  @Test
+  @DisplayName("Returns empty when the claim does not exist")
+  void retrievesAmendmentState_whenClaimMissing_returnsEmpty() {
+    seedClaimsData();
+
+    Optional<ClaimAmendmentState> result =
+        amendmentStateService.retrieveAmendmentState(
+            UUID.randomUUID(), ClaimAmendmentPayload.builder().build());
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Performs no database writes (read-only step)")
+  void retrievesAmendmentState_doesNotMutateDatabase() {
+    seedAssessmentsData();
+
+    final long claims = claimRepository.count();
+    final long clients = clientRepository.count();
+    final long cases = claimCaseRepository.count();
+    final long summaryFees = claimSummaryFeeRepository.count();
+    final long calculatedFees = calculatedFeeDetailRepository.count();
+    final long assessments = assessmentRepository.count();
+    final long submissions = submissionRepository.count();
+
+    ClaimAmendmentPayload payload =
+        ClaimAmendmentPayload.builder()
+            .scheduleReference(JsonNullable.of(UPDATED_SCHEDULE_REFERENCE))
+            .caseReferenceNumber(JsonNullable.of((String) null))
+            .build();
+
+    amendmentStateService.retrieveAmendmentState(CLAIM_1_ID, payload);
+
+    assertThat(claimRepository.count()).isEqualTo(claims);
+    assertThat(clientRepository.count()).isEqualTo(clients);
+    assertThat(claimCaseRepository.count()).isEqualTo(cases);
+    assertThat(claimSummaryFeeRepository.count()).isEqualTo(summaryFees);
+    assertThat(calculatedFeeDetailRepository.count()).isEqualTo(calculatedFees);
+    assertThat(assessmentRepository.count()).isEqualTo(assessments);
+    assertThat(submissionRepository.count()).isEqualTo(submissions);
+
+    // the stored claim is untouched
+    Claim stored = claimRepository.findById(CLAIM_1_ID).orElseThrow();
+    assertThat(stored.getScheduleReference()).isEqualTo(SCHEDULE_REFERENCE);
+    assertThat(stored.getCaseReferenceNumber()).isEqualTo(CASE_REFERENCE);
+  }
+
+  @Test
+  @DisplayName("Explicit null in the payload clears the field in the post-state only")
+  void retrievesAmendmentState_explicitNull_clearsPostStateButKeepsBeforeState() {
+    seedClaimsData();
+
+    ClaimAmendmentPayload payload =
+        ClaimAmendmentPayload.builder().scheduleReference(JsonNullable.of((String) null)).build();
+
+    ClaimAmendmentState state =
+        amendmentStateService.retrieveAmendmentState(CLAIM_1_ID, payload).orElseThrow();
+
+    assertThat(state.getBeforeState().getScheduleReference()).isEqualTo(SCHEDULE_REFERENCE);
+    assertThat(state.getPostAmendmentState().getScheduleReference()).isNull();
+  }
+
+  @Test
+  @DisplayName("UCN and UFN are never recomputed when name, DOB or case id are amended")
+  void retrievesAmendmentState_doesNotRecomputeUcnOrUfn() {
+    seedClaimsData();
+
+    ClaimAmendmentPayload payload =
+        ClaimAmendmentPayload.builder()
+            .clientForename(JsonNullable.of(AMENDED_FORENAME))
+            .clientSurname(JsonNullable.of(AMENDED_SURNAME))
+            .clientDateOfBirth(JsonNullable.of(AMENDED_DATE_OF_BIRTH))
+            .caseId(JsonNullable.of(AMENDED_CASE_ID))
+            .build();
+
+    ClaimStateSnapshot after =
+        amendmentStateService
+            .retrieveAmendmentState(CLAIM_1_ID, payload)
+            .orElseThrow()
+            .getPostAmendmentState();
+
+    // amended identity inputs applied
+    assertThat(after.getClientForename()).isEqualTo(AMENDED_FORENAME);
+    assertThat(after.getCaseId()).isEqualTo(AMENDED_CASE_ID);
+    // derived identifiers left untouched (not recomputed)
+    assertThat(after.getUniqueClientNumber()).isEqualTo(SEEDED_UNIQUE_CLIENT_NUMBER);
+    assertThat(after.getUniqueFileNumber()).isEqualTo(UNIQUE_FILE_NUMBER);
+  }
+
+  @Test
+  @DisplayName("Selects the latest assessment for the before-state")
+  void retrievesAmendmentState_selectsLatestAssessment() {
+    // CLAIM_1 has two assessments; the later one (240.00) must win over the earlier (120.00).
+    seedAssessmentsData();
+
+    ClaimStateSnapshot before =
+        amendmentStateService
+            .retrieveAmendmentState(CLAIM_1_ID, ClaimAmendmentPayload.builder().build())
+            .orElseThrow()
+            .getBeforeState();
+
+    assertThat(before.getLatestAssessment()).isNotNull();
+    assertThat(before.getLatestAssessment().getAllowedTotalInclVat())
+        .isEqualByComparingTo(SEEDED_LATEST_ASSESSMENT_ALLOWED_TOTAL_INCL_VAT);
+  }
+
+  @Test
+  @DisplayName("Builds a snapshot for a claim that has no associated records")
+  void retrievesAmendmentState_claimWithoutAssociations_buildsSnapshotWithNulls() {
+    // CLAIM_4 is persisted with a submission but no client, case, summary fee, calc fee or
+    // assessment.
+    seedClaimsData();
+
+    ClaimStateSnapshot before =
+        amendmentStateService
+            .retrieveAmendmentState(CLAIM_4_ID, ClaimAmendmentPayload.builder().build())
+            .orElseThrow()
+            .getBeforeState();
+
+    assertThat(before.getClaimId()).isEqualTo(CLAIM_4_ID);
+    assertThat(before.getScheduleReference()).isEqualTo(SCHEDULE_REFERENCE);
+    assertThat(before.getClientForename()).isNull();
+    assertThat(before.getCaseId()).isNull();
+    assertThat(before.getCategoryOfLaw()).isNull();
+    assertThat(before.getCalculatedFeeDetail()).isNull();
+    assertThat(before.getLatestAssessment()).isNull();
+    assertThat(before.hasAssessment()).isFalse();
+  }
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/config/JacksonMappingConfig.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/config/JacksonMappingConfig.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -24,6 +25,9 @@ public class JacksonMappingConfig {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     objectMapper.registerModule(new JavaTimeModule());
+    // Required so JsonNullable<> fields (e.g. sparse amendment payloads) serialize correctly,
+    // preserving the distinction between an omitted field and an explicit null.
+    objectMapper.registerModule(new JsonNullableModule());
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     return objectMapper;
   }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/AssessmentSnapshot.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/AssessmentSnapshot.java
@@ -1,0 +1,24 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Value;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentType;
+
+/**
+ * Immutable read-only snapshot of the latest assessment for a claim. Captures only the state needed
+ * to enforce assessed-claim amendment rules. Not provider-amendable.
+ */
+@Value
+@Builder
+public class AssessmentSnapshot {
+
+  AssessmentOutcome assessmentOutcome;
+  AssessmentType assessmentType;
+  String assessmentReason;
+  BigDecimal assessedTotalVat;
+  BigDecimal assessedTotalInclVat;
+  BigDecimal allowedTotalVat;
+  BigDecimal allowedTotalInclVat;
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/CalculatedFeeDetailSnapshot.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/CalculatedFeeDetailSnapshot.java
@@ -1,0 +1,50 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Value;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.FeeCalculationType;
+
+/**
+ * Immutable read-only snapshot of the latest calculated fee detail (as produced by the Fee Scheme
+ * Platform). Used by downstream validation to compare a fresh FSP response against the previously
+ * calculated state. Not provider-amendable.
+ */
+@Value
+@Builder
+public class CalculatedFeeDetailSnapshot {
+
+  String feeCode;
+  FeeCalculationType feeType;
+  String feeCodeDescription;
+  String categoryOfLaw;
+  BigDecimal totalAmount;
+  Boolean vatIndicator;
+  BigDecimal vatRateApplied;
+  BigDecimal calculatedVatAmount;
+  BigDecimal disbursementAmount;
+  BigDecimal requestedNetDisbursementAmount;
+  BigDecimal disbursementVatAmount;
+  BigDecimal hourlyTotalAmount;
+  BigDecimal fixedFeeAmount;
+  BigDecimal netProfitCostsAmount;
+  BigDecimal requestedNetProfitCostsAmount;
+  BigDecimal netCostOfCounselAmount;
+  BigDecimal netTravelCostsAmount;
+  BigDecimal netWaitingCostsAmount;
+  BigDecimal detentionTravelAndWaitingCostsAmount;
+  BigDecimal jrFormFillingAmount;
+  BigDecimal travelAndWaitingCostsAmount;
+  BigDecimal boltOnTotalFeeAmount;
+  Integer boltOnAdjournedHearingCount;
+  BigDecimal boltOnAdjournedHearingFee;
+  Integer boltOnCmrhTelephoneCount;
+  BigDecimal boltOnCmrhTelephoneFee;
+  Integer boltOnCmrhOralCount;
+  BigDecimal boltOnCmrhOralFee;
+  Integer boltOnHomeOfficeInterviewCount;
+  BigDecimal boltOnHomeOfficeInterviewFee;
+  BigDecimal boltOnSubstantiveHearingFee;
+  Boolean escapeCaseFlag;
+  String schemeId;
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentPayload.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentPayload.java
@@ -1,0 +1,203 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+import org.openapitools.jackson.nullable.JsonNullable;
+
+/**
+ * Sparse amendment payload as submitted by the provider (via AaBC).
+ *
+ * <p>Each field is wrapped in {@link JsonNullable} so the three submission states can be
+ * distinguished and preserved end to end:
+ *
+ * <ul>
+ *   <li><b>omitted</b> &rarr; {@code JsonNullable.undefined()} (field not present, leave
+ *       unchanged);
+ *   <li><b>explicit null</b> &rarr; {@code JsonNullable.of(null)} (requested clear, validated
+ *       later);
+ *   <li><b>value</b> &rarr; {@code JsonNullable.of(value)} (requested change).
+ * </ul>
+ *
+ * <p>{@link JsonInclude.Include#NON_ABSENT} ensures undefined (omitted) fields are dropped during
+ * serialisation while an explicit null is written as {@code "field": null}. This shape is the basis
+ * for the {@code requestPayload} JSONB column in the amendment history record.
+ *
+ * <p>Deserialisation is supported via {@code @Jacksonized}: Jackson populates the Lombok builder so
+ * the {@code @Builder.Default} values apply, meaning an omitted field is restored as {@code
+ * JsonNullable.undefined()} and an explicit null as {@code JsonNullable.of(null)}. The omitted,
+ * explicit-null and value distinctions therefore survive a serialise/deserialise round trip.
+ *
+ * <p>Covers every provider-amendable field across the claim, client, claim-case and
+ * claim-summary-fee records. This is an in-memory contract only; it performs no persistence and
+ * makes no external calls.
+ */
+@Data
+@Builder
+@Jacksonized
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+public class ClaimAmendmentPayload {
+
+  // ---------------------------------------------------------------------------
+  // Claim fields
+  // ---------------------------------------------------------------------------
+  @Builder.Default private JsonNullable<String> scheduleReference = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> lineNumber = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> caseReferenceNumber = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> uniqueFileNumber = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<LocalDate> caseStartDate = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<LocalDate> caseConcludedDate = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> matterTypeCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> crimeMatterTypeCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> feeSchemeCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> feeCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> procurementAreaCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> accessPointCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> deliveryLocation = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<LocalDate> representationOrderDate = JsonNullable.undefined();
+
+  @Builder.Default private JsonNullable<Integer> suspectsDefendantsCount = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<Integer> policeStationCourtAttendancesCount = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<String> policeStationCourtPrisonId = JsonNullable.undefined();
+
+  @Builder.Default private JsonNullable<String> dsccNumber = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> maatId = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<String> prisonLawPriorApprovalNumber = JsonNullable.undefined();
+
+  @Builder.Default private JsonNullable<Boolean> isDutySolicitor = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Boolean> isYouthCourt = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> schemeId = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> mediationSessionsCount = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> mediationTimeMinutes = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> outreachLocation = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> referralSource = JsonNullable.undefined();
+
+  // ---------------------------------------------------------------------------
+  // Client fields
+  // ---------------------------------------------------------------------------
+  @Builder.Default private JsonNullable<String> clientForename = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> clientSurname = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<LocalDate> clientDateOfBirth = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> uniqueClientNumber = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> clientPostcode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> genderCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> ethnicityCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> disabilityCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Boolean> isLegallyAided = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> clientTypeCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> homeOfficeClientNumber = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> claReferenceNumber = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> claExemptionCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> client2Forename = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> client2Surname = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<LocalDate> client2DateOfBirth = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> client2Ucn = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> client2Postcode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> client2GenderCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> client2EthnicityCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> client2DisabilityCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Boolean> client2IsLegallyAided = JsonNullable.undefined();
+
+  // ---------------------------------------------------------------------------
+  // Claim-case fields
+  // ---------------------------------------------------------------------------
+  @Builder.Default private JsonNullable<String> caseId = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> uniqueCaseId = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> caseStageCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> stageReachedCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> standardFeeCategoryCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> outcomeCode = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<String> designatedAccreditedRepresentativeCode = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<Boolean> isPostalApplicationAccepted = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<Boolean> isClient2PostalApplicationAccepted = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<String> mentalHealthTribunalReference = JsonNullable.undefined();
+
+  @Builder.Default private JsonNullable<Boolean> isNrmAdvice = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> followOnWork = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<LocalDate> transferDate = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<String> exemptionCriteriaSatisfied = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<String> exceptionalCaseFundingReference = JsonNullable.undefined();
+
+  @Builder.Default private JsonNullable<Boolean> isLegacyCase = JsonNullable.undefined();
+
+  // ---------------------------------------------------------------------------
+  // Claim-summary-fee fields (provider-entered fee inputs)
+  // ---------------------------------------------------------------------------
+  @Builder.Default private JsonNullable<Integer> adviceTime = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> travelTime = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> waitingTime = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<BigDecimal> netProfitCostsAmount = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<BigDecimal> netDisbursementAmount = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<BigDecimal> netCounselCostsAmount = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<BigDecimal> disbursementsVatAmount = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<BigDecimal> travelWaitingCostsAmount = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<BigDecimal> netWaitingCostsAmount = JsonNullable.undefined();
+
+  @Builder.Default private JsonNullable<Boolean> isVatApplicable = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Boolean> isToleranceApplicable = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> priorAuthorityReference = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Boolean> isLondonRate = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<Integer> adjournedHearingFeeAmount = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<Boolean> isAdditionalTravelPayment = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<BigDecimal> costsDamagesRecoveredAmount = JsonNullable.undefined();
+
+  @Builder.Default private JsonNullable<String> meetingsAttendedCode = JsonNullable.undefined();
+
+  @Builder.Default
+  private JsonNullable<BigDecimal> detentionTravelWaitingCostsAmount = JsonNullable.undefined();
+
+  @Builder.Default private JsonNullable<BigDecimal> jrFormFillingAmount = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Boolean> isEligibleClient = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> courtLocationCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> adviceTypeCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> medicalReportsCount = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Boolean> isIrcSurgery = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<LocalDate> surgeryDate = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> surgeryClientsCount = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> surgeryMattersCount = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> cmrhOralCount = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> cmrhTelephoneCount = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> aitHearingCentreCode = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Boolean> isSubstantiveHearing = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<Integer> hoInterview = JsonNullable.undefined();
+  @Builder.Default private JsonNullable<String> localAuthorityNumber = JsonNullable.undefined();
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentState.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentState.java
@@ -1,0 +1,33 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * In-memory aggregate describing a claim amendment in progress, passed from the retrieval/build
+ * step to downstream validation, history and persistence tasks.
+ *
+ * <p>It bundles the three pieces the amendment flow needs:
+ *
+ * <ul>
+ *   <li>{@link #beforeState} - the current stored values (basis for the {@code beforeState} JSONB);
+ *   <li>{@link #requestPayload} - the sparse, presence-aware submission (basis for the {@code
+ *       requestPayload} JSONB);
+ *   <li>{@link #postAmendmentState} - the proposed amended values, built by applying the sparse
+ *       payload onto the before-state (omitted fields retain stored values; explicit nulls are
+ *       retained as requested clears).
+ * </ul>
+ *
+ * <p>The before/after snapshots plus the payload's field presence are sufficient to compute the
+ * {@code diff} JSONB.
+ */
+@Data
+@Builder
+public class ClaimAmendmentState {
+
+  private ClaimStateSnapshot beforeState;
+
+  private ClaimAmendmentPayload requestPayload;
+
+  private ClaimStateSnapshot postAmendmentState;
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimStateSnapshot.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimStateSnapshot.java
@@ -1,0 +1,188 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+
+/**
+ * Immutable, fully-resolved snapshot of the current stored claim state at the point an amendment is
+ * submitted.
+ *
+ * <p>Unlike {@link ClaimAmendmentPayload}, every field carries a concrete value (no tri-state) - it
+ * captures the "before" picture used by downstream validation, amendment history and diff
+ * construction. This is the basis for the {@code beforeState} JSONB column.
+ *
+ * <p>It holds the before-state of every provider-amendable field plus read-only identity,
+ * submission context and FSP/assessment state needed by downstream validation. This is an in-memory
+ * contract only; it performs no persistence and makes no external calls.
+ */
+@Value
+@Builder(toBuilder = true)
+public class ClaimStateSnapshot {
+
+  // ---------------------------------------------------------------------------
+  // Claim identity and lifecycle (read-only)
+  // ---------------------------------------------------------------------------
+  UUID claimId;
+  UUID submissionId;
+  Long version;
+
+  /** Claim lifecycle status. Read-only context - not a provider-amendable value. */
+  ClaimStatus status;
+
+  /**
+   * Assessed-state indicator. The Lombok-generated getter is suppressed so the accessor reads
+   * naturally as {@link #hasAssessment()} rather than {@code isHasAssessment()}.
+   * {@code @JsonProperty} keeps the serialised property name stable for the {@code beforeState}
+   * JSONB.
+   */
+  @Getter(AccessLevel.NONE)
+  @JsonProperty("hasAssessment")
+  boolean hasAssessment;
+
+  boolean amended;
+
+  // ---------------------------------------------------------------------------
+  // Submission context (read-only)
+  // ---------------------------------------------------------------------------
+  AreaOfLaw areaOfLaw;
+  String officeAccountNumber;
+  String submissionPeriod;
+
+  // ---------------------------------------------------------------------------
+  // Claim fields (provider-amendable, before values)
+  // ---------------------------------------------------------------------------
+  String scheduleReference;
+  Integer lineNumber;
+  String caseReferenceNumber;
+  String uniqueFileNumber;
+  LocalDate caseStartDate;
+  LocalDate caseConcludedDate;
+  String matterTypeCode;
+  String crimeMatterTypeCode;
+  String feeSchemeCode;
+  String feeCode;
+  String procurementAreaCode;
+  String accessPointCode;
+  String deliveryLocation;
+  LocalDate representationOrderDate;
+  Integer suspectsDefendantsCount;
+  Integer policeStationCourtAttendancesCount;
+  String policeStationCourtPrisonId;
+  String dsccNumber;
+  String maatId;
+  String prisonLawPriorApprovalNumber;
+  Boolean dutySolicitor;
+  Boolean youthCourt;
+  String schemeId;
+  Integer mediationSessionsCount;
+  Integer mediationTimeMinutes;
+  String outreachLocation;
+  String referralSource;
+
+  // ---------------------------------------------------------------------------
+  // Client fields (provider-amendable, before values)
+  // ---------------------------------------------------------------------------
+  String clientForename;
+  String clientSurname;
+  LocalDate clientDateOfBirth;
+  String uniqueClientNumber;
+  String clientPostcode;
+  String genderCode;
+  String ethnicityCode;
+  String disabilityCode;
+  Boolean isLegallyAided;
+  String clientTypeCode;
+  String homeOfficeClientNumber;
+  String claReferenceNumber;
+  String claExemptionCode;
+  String client2Forename;
+  String client2Surname;
+  LocalDate client2DateOfBirth;
+  String client2Ucn;
+  String client2Postcode;
+  String client2GenderCode;
+  String client2EthnicityCode;
+  String client2DisabilityCode;
+  Boolean client2IsLegallyAided;
+
+  // ---------------------------------------------------------------------------
+  // Claim-case fields (provider-amendable, before values)
+  // ---------------------------------------------------------------------------
+  String caseId;
+  String uniqueCaseId;
+  String caseStageCode;
+  String stageReachedCode;
+  String standardFeeCategoryCode;
+  String outcomeCode;
+  String designatedAccreditedRepresentativeCode;
+  Boolean isPostalApplicationAccepted;
+  Boolean isClient2PostalApplicationAccepted;
+  String mentalHealthTribunalReference;
+  Boolean isNrmAdvice;
+  String followOnWork;
+  LocalDate transferDate;
+  String exemptionCriteriaSatisfied;
+  String exceptionalCaseFundingReference;
+  Boolean isLegacyCase;
+
+  // ---------------------------------------------------------------------------
+  // Claim-summary-fee fields (provider-amendable, before values)
+  // ---------------------------------------------------------------------------
+  Integer adviceTime;
+  Integer travelTime;
+  Integer waitingTime;
+  BigDecimal netProfitCostsAmount;
+  BigDecimal netDisbursementAmount;
+  BigDecimal netCounselCostsAmount;
+  BigDecimal disbursementsVatAmount;
+  BigDecimal travelWaitingCostsAmount;
+  BigDecimal netWaitingCostsAmount;
+  Boolean isVatApplicable;
+  Boolean isToleranceApplicable;
+  String priorAuthorityReference;
+  Boolean isLondonRate;
+  Integer adjournedHearingFeeAmount;
+  Boolean isAdditionalTravelPayment;
+  BigDecimal costsDamagesRecoveredAmount;
+  String meetingsAttendedCode;
+  BigDecimal detentionTravelWaitingCostsAmount;
+  BigDecimal jrFormFillingAmount;
+  Boolean isEligibleClient;
+  String courtLocationCode;
+  String adviceTypeCode;
+  Integer medicalReportsCount;
+  Boolean isIrcSurgery;
+  LocalDate surgeryDate;
+  Integer surgeryClientsCount;
+  Integer surgeryMattersCount;
+  Integer cmrhOralCount;
+  Integer cmrhTelephoneCount;
+  String aitHearingCentreCode;
+  Boolean isSubstantiveHearing;
+  Integer hoInterview;
+  String localAuthorityNumber;
+
+  // ---------------------------------------------------------------------------
+  // Read-only FSP / assessment context
+  // ---------------------------------------------------------------------------
+  String categoryOfLaw;
+  CalculatedFeeDetailSnapshot calculatedFeeDetail;
+  AssessmentSnapshot latestAssessment;
+
+  /**
+   * Whether the claim has an assessment (assessed-state indicator).
+   *
+   * @return {@code true} if the claim is assessed
+   */
+  public boolean hasAssessment() {
+    return hasAssessment;
+  }
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimStateSnapshotMapper.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimStateSnapshotMapper.java
@@ -1,0 +1,111 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.mapper;
+
+import java.util.Optional;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AssessmentSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.CalculatedFeeDetailSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.CalculatedFeeDetail;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimCase;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Client;
+
+/**
+ * Assembles an immutable {@link ClaimStateSnapshot} (the "before" state) from the persisted claim
+ * aggregate.
+ *
+ * <p>Same-named, same-typed properties are mapped automatically by MapStruct. Explicit
+ * {@code @Mapping}s cover: nested submission paths, and the property names that exist on more than
+ * one source ({@code feeCode}/{@code schemeId} on claim vs calculated fee detail; {@code
+ * netProfitCostsAmount}/{@code netWaitingCostsAmount}/{@code jrFormFillingAmount}/ {@code
+ * isVatApplicable} on summary fee vs calculated fee detail/assessment) so the correct source wins.
+ * Read-only calculated-fee and assessment context are mapped via the nested sub-mappers below.
+ *
+ * <p>Null-safe: MapStruct null-guards each source argument and nested path, so missing associations
+ * leave the corresponding fields null. Performs no persistence and makes no external calls.
+ */
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ClaimStateSnapshotMapper {
+
+  /**
+   * Builds a before-state snapshot from the supplied claim aggregate.
+   *
+   * @param claim the claim entity (required)
+   * @param client the associated client, if any
+   * @param claimCase the associated claim case, if any
+   * @param summaryFee the associated claim summary fee, if any
+   * @param calculatedFeeDetail the latest calculated fee detail, if any
+   * @param latestAssessment the latest assessment, if any
+   * @return an immutable snapshot of the current stored claim values
+   */
+  @Mapping(target = "claimId", source = "claim.id")
+  @Mapping(target = "submissionId", source = "claim.submission.id")
+  @Mapping(target = "areaOfLaw", source = "claim.submission.areaOfLaw")
+  @Mapping(target = "officeAccountNumber", source = "claim.submission.officeAccountNumber")
+  @Mapping(target = "submissionPeriod", source = "claim.submission.submissionPeriod")
+  @Mapping(target = "feeCode", source = "claim.feeCode")
+  @Mapping(target = "schemeId", source = "claim.schemeId")
+  @Mapping(target = "netProfitCostsAmount", source = "summaryFee.netProfitCostsAmount")
+  @Mapping(target = "netWaitingCostsAmount", source = "summaryFee.netWaitingCostsAmount")
+  @Mapping(target = "jrFormFillingAmount", source = "summaryFee.jrFormFillingAmount")
+  @Mapping(target = "isVatApplicable", source = "summaryFee.isVatApplicable")
+  @Mapping(target = "categoryOfLaw", source = "calculatedFeeDetail.categoryOfLaw")
+  @Mapping(target = "calculatedFeeDetail", source = "calculatedFeeDetail")
+  @Mapping(target = "latestAssessment", source = "latestAssessment")
+  ClaimStateSnapshot toSnapshot(
+      Claim claim,
+      Client client,
+      ClaimCase claimCase,
+      ClaimSummaryFee summaryFee,
+      CalculatedFeeDetail calculatedFeeDetail,
+      Assessment latestAssessment);
+
+  /**
+   * Convenience overload accepting {@link Optional} associations.
+   *
+   * @param claim the claim entity (required)
+   * @param client the associated client, if any
+   * @param claimCase the associated claim case, if any
+   * @param summaryFee the associated claim summary fee, if any
+   * @param calculatedFeeDetail the latest calculated fee detail, if any
+   * @param latestAssessment the latest assessment, if any
+   * @return an immutable snapshot of the current stored claim values
+   */
+  default ClaimStateSnapshot toSnapshot(
+      Claim claim,
+      Optional<Client> client,
+      Optional<ClaimCase> claimCase,
+      Optional<ClaimSummaryFee> summaryFee,
+      Optional<CalculatedFeeDetail> calculatedFeeDetail,
+      Optional<Assessment> latestAssessment) {
+
+    return toSnapshot(
+        claim,
+        client.orElse(null),
+        claimCase.orElse(null),
+        summaryFee.orElse(null),
+        calculatedFeeDetail.orElse(null),
+        latestAssessment.orElse(null));
+  }
+
+  /**
+   * Maps the latest calculated fee detail to its read-only snapshot. Same-named fields auto-map.
+   *
+   * @param calculatedFeeDetail the calculated fee detail entity, may be {@code null}
+   * @return the snapshot, or {@code null} if the input is {@code null}
+   */
+  CalculatedFeeDetailSnapshot toCalculatedFeeDetailSnapshot(
+      CalculatedFeeDetail calculatedFeeDetail);
+
+  /**
+   * Maps the latest assessment to its read-only snapshot. Same-named fields auto-map.
+   *
+   * @param assessment the assessment entity, may be {@code null}
+   * @return the snapshot, or {@code null} if the input is {@code null}
+   */
+  AssessmentSnapshot toAssessmentSnapshot(Assessment assessment);
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
@@ -49,6 +49,14 @@ public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
   Optional<Assessment> findByIdAndClaimId(UUID assessmentId, UUID claimId);
 
   /**
+   * Finds the most recent assessment for the given claim, ordered by creation time descending.
+   *
+   * @param claimId the unique identifier of the claim
+   * @return an {@link Optional} containing the latest assessment, or empty if none found
+   */
+  Optional<Assessment> findFirstByClaimIdOrderByCreatedOnDesc(UUID claimId);
+
+  /**
    * Returns a paginated list of assessments for the given claim.
    *
    * @param claimId the unique identifier of the claim

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/AssessmentRepository.java
@@ -49,12 +49,14 @@ public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
   Optional<Assessment> findByIdAndClaimId(UUID assessmentId, UUID claimId);
 
   /**
-   * Finds the most recent assessment for the given claim, ordered by creation time descending.
+   * Finds the most recent assessment for the given claim, ordered by creation time descending with
+   * the (time-ordered UUIDv7) id as a tie-breaker so the latest row is selected deterministically
+   * even when two assessments share a {@code createdOn}.
    *
    * @param claimId the unique identifier of the claim
    * @return an {@link Optional} containing the latest assessment, or empty if none found
    */
-  Optional<Assessment> findFirstByClaimIdOrderByCreatedOnDesc(UUID claimId);
+  Optional<Assessment> findFirstByClaimIdOrderByCreatedOnDescIdDesc(UUID claimId);
 
   /**
    * Returns a paginated list of assessments for the given claim.

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateBuilder.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateBuilder.java
@@ -1,0 +1,257 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment;
+
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentPayload;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+
+/**
+ * Builds the in-memory post-amendment state for a claim by applying a sparse amendment payload onto
+ * the current (before) state.
+ *
+ * <p>Sparse-payload semantics (see {@link ClaimAmendmentPayload}):
+ *
+ * <ul>
+ *   <li><b>omitted</b> field ({@code JsonNullable.undefined()}) &rarr; the stored value is
+ *       retained;
+ *   <li><b>explicit null</b> ({@code JsonNullable.of(null)}) &rarr; the value is cleared (kept as
+ *       {@code null} for later validation);
+ *   <li><b>value present</b> &rarr; the submitted value is applied.
+ * </ul>
+ *
+ * <p>UCN ({@code uniqueClientNumber}) and UFN ({@code uniqueFileNumber}) are treated like any other
+ * field: they change only when explicitly present in the payload. They are never recomputed from
+ * client forename, surname, date of birth or case id - applying each field independently guarantees
+ * this.
+ *
+ * <p>Read-only context (identity, lifecycle status, submission context, category of law, calculated
+ * fee detail and latest assessment) is carried over unchanged from the before-state.
+ *
+ * <p>This component performs no persistence and makes no external calls.
+ */
+@Component
+public class ClaimAmendmentStateBuilder {
+
+  /**
+   * Applies the sparse payload onto the before-state and returns the proposed post-amendment state.
+   *
+   * @param beforeState the current stored claim state
+   * @param payload the sparse amendment payload as submitted
+   * @return the proposed post-amendment state
+   */
+  ClaimStateSnapshot buildPostAmendmentState(
+      ClaimStateSnapshot beforeState, ClaimAmendmentPayload payload) {
+
+    return beforeState.toBuilder()
+        // claim fields
+        .scheduleReference(
+            resolve(payload.getScheduleReference(), beforeState.getScheduleReference()))
+        .lineNumber(resolve(payload.getLineNumber(), beforeState.getLineNumber()))
+        .caseReferenceNumber(
+            resolve(payload.getCaseReferenceNumber(), beforeState.getCaseReferenceNumber()))
+        .uniqueFileNumber(resolve(payload.getUniqueFileNumber(), beforeState.getUniqueFileNumber()))
+        .caseStartDate(resolve(payload.getCaseStartDate(), beforeState.getCaseStartDate()))
+        .caseConcludedDate(
+            resolve(payload.getCaseConcludedDate(), beforeState.getCaseConcludedDate()))
+        .matterTypeCode(resolve(payload.getMatterTypeCode(), beforeState.getMatterTypeCode()))
+        .crimeMatterTypeCode(
+            resolve(payload.getCrimeMatterTypeCode(), beforeState.getCrimeMatterTypeCode()))
+        .feeSchemeCode(resolve(payload.getFeeSchemeCode(), beforeState.getFeeSchemeCode()))
+        .feeCode(resolve(payload.getFeeCode(), beforeState.getFeeCode()))
+        .procurementAreaCode(
+            resolve(payload.getProcurementAreaCode(), beforeState.getProcurementAreaCode()))
+        .accessPointCode(resolve(payload.getAccessPointCode(), beforeState.getAccessPointCode()))
+        .deliveryLocation(resolve(payload.getDeliveryLocation(), beforeState.getDeliveryLocation()))
+        .representationOrderDate(
+            resolve(payload.getRepresentationOrderDate(), beforeState.getRepresentationOrderDate()))
+        .suspectsDefendantsCount(
+            resolve(payload.getSuspectsDefendantsCount(), beforeState.getSuspectsDefendantsCount()))
+        .policeStationCourtAttendancesCount(
+            resolve(
+                payload.getPoliceStationCourtAttendancesCount(),
+                beforeState.getPoliceStationCourtAttendancesCount()))
+        .policeStationCourtPrisonId(
+            resolve(
+                payload.getPoliceStationCourtPrisonId(),
+                beforeState.getPoliceStationCourtPrisonId()))
+        .dsccNumber(resolve(payload.getDsccNumber(), beforeState.getDsccNumber()))
+        .maatId(resolve(payload.getMaatId(), beforeState.getMaatId()))
+        .prisonLawPriorApprovalNumber(
+            resolve(
+                payload.getPrisonLawPriorApprovalNumber(),
+                beforeState.getPrisonLawPriorApprovalNumber()))
+        .dutySolicitor(resolve(payload.getIsDutySolicitor(), beforeState.getDutySolicitor()))
+        .youthCourt(resolve(payload.getIsYouthCourt(), beforeState.getYouthCourt()))
+        .schemeId(resolve(payload.getSchemeId(), beforeState.getSchemeId()))
+        .mediationSessionsCount(
+            resolve(payload.getMediationSessionsCount(), beforeState.getMediationSessionsCount()))
+        .mediationTimeMinutes(
+            resolve(payload.getMediationTimeMinutes(), beforeState.getMediationTimeMinutes()))
+        .outreachLocation(resolve(payload.getOutreachLocation(), beforeState.getOutreachLocation()))
+        .referralSource(resolve(payload.getReferralSource(), beforeState.getReferralSource()))
+        // client fields
+        .clientForename(resolve(payload.getClientForename(), beforeState.getClientForename()))
+        .clientSurname(resolve(payload.getClientSurname(), beforeState.getClientSurname()))
+        .clientDateOfBirth(
+            resolve(payload.getClientDateOfBirth(), beforeState.getClientDateOfBirth()))
+        .uniqueClientNumber(
+            resolve(payload.getUniqueClientNumber(), beforeState.getUniqueClientNumber()))
+        .clientPostcode(resolve(payload.getClientPostcode(), beforeState.getClientPostcode()))
+        .genderCode(resolve(payload.getGenderCode(), beforeState.getGenderCode()))
+        .ethnicityCode(resolve(payload.getEthnicityCode(), beforeState.getEthnicityCode()))
+        .disabilityCode(resolve(payload.getDisabilityCode(), beforeState.getDisabilityCode()))
+        .isLegallyAided(resolve(payload.getIsLegallyAided(), beforeState.getIsLegallyAided()))
+        .clientTypeCode(resolve(payload.getClientTypeCode(), beforeState.getClientTypeCode()))
+        .homeOfficeClientNumber(
+            resolve(payload.getHomeOfficeClientNumber(), beforeState.getHomeOfficeClientNumber()))
+        .claReferenceNumber(
+            resolve(payload.getClaReferenceNumber(), beforeState.getClaReferenceNumber()))
+        .claExemptionCode(resolve(payload.getClaExemptionCode(), beforeState.getClaExemptionCode()))
+        .client2Forename(resolve(payload.getClient2Forename(), beforeState.getClient2Forename()))
+        .client2Surname(resolve(payload.getClient2Surname(), beforeState.getClient2Surname()))
+        .client2DateOfBirth(
+            resolve(payload.getClient2DateOfBirth(), beforeState.getClient2DateOfBirth()))
+        .client2Ucn(resolve(payload.getClient2Ucn(), beforeState.getClient2Ucn()))
+        .client2Postcode(resolve(payload.getClient2Postcode(), beforeState.getClient2Postcode()))
+        .client2GenderCode(
+            resolve(payload.getClient2GenderCode(), beforeState.getClient2GenderCode()))
+        .client2EthnicityCode(
+            resolve(payload.getClient2EthnicityCode(), beforeState.getClient2EthnicityCode()))
+        .client2DisabilityCode(
+            resolve(payload.getClient2DisabilityCode(), beforeState.getClient2DisabilityCode()))
+        .client2IsLegallyAided(
+            resolve(payload.getClient2IsLegallyAided(), beforeState.getClient2IsLegallyAided()))
+        // claim-case fields
+        .caseId(resolve(payload.getCaseId(), beforeState.getCaseId()))
+        .uniqueCaseId(resolve(payload.getUniqueCaseId(), beforeState.getUniqueCaseId()))
+        .caseStageCode(resolve(payload.getCaseStageCode(), beforeState.getCaseStageCode()))
+        .stageReachedCode(resolve(payload.getStageReachedCode(), beforeState.getStageReachedCode()))
+        .standardFeeCategoryCode(
+            resolve(payload.getStandardFeeCategoryCode(), beforeState.getStandardFeeCategoryCode()))
+        .outcomeCode(resolve(payload.getOutcomeCode(), beforeState.getOutcomeCode()))
+        .designatedAccreditedRepresentativeCode(
+            resolve(
+                payload.getDesignatedAccreditedRepresentativeCode(),
+                beforeState.getDesignatedAccreditedRepresentativeCode()))
+        .isPostalApplicationAccepted(
+            resolve(
+                payload.getIsPostalApplicationAccepted(),
+                beforeState.getIsPostalApplicationAccepted()))
+        .isClient2PostalApplicationAccepted(
+            resolve(
+                payload.getIsClient2PostalApplicationAccepted(),
+                beforeState.getIsClient2PostalApplicationAccepted()))
+        .mentalHealthTribunalReference(
+            resolve(
+                payload.getMentalHealthTribunalReference(),
+                beforeState.getMentalHealthTribunalReference()))
+        .isNrmAdvice(resolve(payload.getIsNrmAdvice(), beforeState.getIsNrmAdvice()))
+        .followOnWork(resolve(payload.getFollowOnWork(), beforeState.getFollowOnWork()))
+        .transferDate(resolve(payload.getTransferDate(), beforeState.getTransferDate()))
+        .exemptionCriteriaSatisfied(
+            resolve(
+                payload.getExemptionCriteriaSatisfied(),
+                beforeState.getExemptionCriteriaSatisfied()))
+        .exceptionalCaseFundingReference(
+            resolve(
+                payload.getExceptionalCaseFundingReference(),
+                beforeState.getExceptionalCaseFundingReference()))
+        .isLegacyCase(resolve(payload.getIsLegacyCase(), beforeState.getIsLegacyCase()))
+        // claim-summary-fee fields
+        .adviceTime(resolve(payload.getAdviceTime(), beforeState.getAdviceTime()))
+        .travelTime(resolve(payload.getTravelTime(), beforeState.getTravelTime()))
+        .waitingTime(resolve(payload.getWaitingTime(), beforeState.getWaitingTime()))
+        .netProfitCostsAmount(
+            resolve(payload.getNetProfitCostsAmount(), beforeState.getNetProfitCostsAmount()))
+        .netDisbursementAmount(
+            resolve(payload.getNetDisbursementAmount(), beforeState.getNetDisbursementAmount()))
+        .netCounselCostsAmount(
+            resolve(payload.getNetCounselCostsAmount(), beforeState.getNetCounselCostsAmount()))
+        .disbursementsVatAmount(
+            resolve(payload.getDisbursementsVatAmount(), beforeState.getDisbursementsVatAmount()))
+        .travelWaitingCostsAmount(
+            resolve(
+                payload.getTravelWaitingCostsAmount(), beforeState.getTravelWaitingCostsAmount()))
+        .netWaitingCostsAmount(
+            resolve(payload.getNetWaitingCostsAmount(), beforeState.getNetWaitingCostsAmount()))
+        .isVatApplicable(resolve(payload.getIsVatApplicable(), beforeState.getIsVatApplicable()))
+        .isToleranceApplicable(
+            resolve(payload.getIsToleranceApplicable(), beforeState.getIsToleranceApplicable()))
+        .priorAuthorityReference(
+            resolve(payload.getPriorAuthorityReference(), beforeState.getPriorAuthorityReference()))
+        .isLondonRate(resolve(payload.getIsLondonRate(), beforeState.getIsLondonRate()))
+        .adjournedHearingFeeAmount(
+            resolve(
+                payload.getAdjournedHearingFeeAmount(), beforeState.getAdjournedHearingFeeAmount()))
+        .isAdditionalTravelPayment(
+            resolve(
+                payload.getIsAdditionalTravelPayment(), beforeState.getIsAdditionalTravelPayment()))
+        .costsDamagesRecoveredAmount(
+            resolve(
+                payload.getCostsDamagesRecoveredAmount(),
+                beforeState.getCostsDamagesRecoveredAmount()))
+        .meetingsAttendedCode(
+            resolve(payload.getMeetingsAttendedCode(), beforeState.getMeetingsAttendedCode()))
+        .detentionTravelWaitingCostsAmount(
+            resolve(
+                payload.getDetentionTravelWaitingCostsAmount(),
+                beforeState.getDetentionTravelWaitingCostsAmount()))
+        .jrFormFillingAmount(
+            resolve(payload.getJrFormFillingAmount(), beforeState.getJrFormFillingAmount()))
+        .isEligibleClient(resolve(payload.getIsEligibleClient(), beforeState.getIsEligibleClient()))
+        .courtLocationCode(
+            resolve(payload.getCourtLocationCode(), beforeState.getCourtLocationCode()))
+        .adviceTypeCode(resolve(payload.getAdviceTypeCode(), beforeState.getAdviceTypeCode()))
+        .medicalReportsCount(
+            resolve(payload.getMedicalReportsCount(), beforeState.getMedicalReportsCount()))
+        .isIrcSurgery(resolve(payload.getIsIrcSurgery(), beforeState.getIsIrcSurgery()))
+        .surgeryDate(resolve(payload.getSurgeryDate(), beforeState.getSurgeryDate()))
+        .surgeryClientsCount(
+            resolve(payload.getSurgeryClientsCount(), beforeState.getSurgeryClientsCount()))
+        .surgeryMattersCount(
+            resolve(payload.getSurgeryMattersCount(), beforeState.getSurgeryMattersCount()))
+        .cmrhOralCount(resolve(payload.getCmrhOralCount(), beforeState.getCmrhOralCount()))
+        .cmrhTelephoneCount(
+            resolve(payload.getCmrhTelephoneCount(), beforeState.getCmrhTelephoneCount()))
+        .aitHearingCentreCode(
+            resolve(payload.getAitHearingCentreCode(), beforeState.getAitHearingCentreCode()))
+        .isSubstantiveHearing(
+            resolve(payload.getIsSubstantiveHearing(), beforeState.getIsSubstantiveHearing()))
+        .hoInterview(resolve(payload.getHoInterview(), beforeState.getHoInterview()))
+        .localAuthorityNumber(
+            resolve(payload.getLocalAuthorityNumber(), beforeState.getLocalAuthorityNumber()))
+        .build();
+  }
+
+  /**
+   * Builds the full amendment aggregate bundling the before-state, the request payload and the
+   * computed post-amendment state.
+   *
+   * @param beforeState the current stored claim state
+   * @param payload the sparse amendment payload as submitted
+   * @return the amendment state aggregate
+   */
+  public ClaimAmendmentState buildAmendmentState(
+      ClaimStateSnapshot beforeState, ClaimAmendmentPayload payload) {
+
+    return ClaimAmendmentState.builder()
+        .beforeState(beforeState)
+        .requestPayload(payload)
+        .postAmendmentState(buildPostAmendmentState(beforeState, payload))
+        .build();
+  }
+
+  /**
+   * Resolves a single field: returns the submitted value when present (including an explicit null),
+   * otherwise retains the current value.
+   *
+   * @param submitted the submitted tri-state value
+   * @param current the current stored value
+   * @param <T> the field type
+   * @return the resolved value for the post-amendment state
+   */
+  private static <T> T resolve(JsonNullable<T> submitted, T current) {
+    return submitted.isPresent() ? submitted.get() : current;
+  }
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateBuilder.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateBuilder.java
@@ -212,12 +212,16 @@ public class ClaimAmendmentStateBuilder {
    * including an explicit {@code null} - overwrites it (an explicit null clears the field for later
    * validation).
    *
+   * <p>A {@code null} wrapper (only reachable if a payload is built programmatically with a field
+   * explicitly set to {@code null}, bypassing the {@code JsonNullable.undefined()} defaults) is
+   * treated the same as if that field were omitted: the before-state value is retained.
+   *
    * @param submitted the submitted tri-state value
    * @param setter the builder setter for the corresponding field
    * @param <T> the field type
    */
   private static <T> void applyIfPresent(JsonNullable<T> submitted, Consumer<T> setter) {
-    if (submitted.isPresent()) {
+    if (submitted != null && submitted.isPresent()) {
       setter.accept(submitted.get());
     }
   }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateBuilder.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment;
 
+import java.util.function.Consumer;
 import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentPayload;
@@ -43,185 +44,146 @@ public class ClaimAmendmentStateBuilder {
   ClaimStateSnapshot buildPostAmendmentState(
       ClaimStateSnapshot beforeState, ClaimAmendmentPayload payload) {
 
-    return beforeState.toBuilder()
-        // claim fields
-        .scheduleReference(
-            resolve(payload.getScheduleReference(), beforeState.getScheduleReference()))
-        .lineNumber(resolve(payload.getLineNumber(), beforeState.getLineNumber()))
-        .caseReferenceNumber(
-            resolve(payload.getCaseReferenceNumber(), beforeState.getCaseReferenceNumber()))
-        .uniqueFileNumber(resolve(payload.getUniqueFileNumber(), beforeState.getUniqueFileNumber()))
-        .caseStartDate(resolve(payload.getCaseStartDate(), beforeState.getCaseStartDate()))
-        .caseConcludedDate(
-            resolve(payload.getCaseConcludedDate(), beforeState.getCaseConcludedDate()))
-        .matterTypeCode(resolve(payload.getMatterTypeCode(), beforeState.getMatterTypeCode()))
-        .crimeMatterTypeCode(
-            resolve(payload.getCrimeMatterTypeCode(), beforeState.getCrimeMatterTypeCode()))
-        .feeSchemeCode(resolve(payload.getFeeSchemeCode(), beforeState.getFeeSchemeCode()))
-        .feeCode(resolve(payload.getFeeCode(), beforeState.getFeeCode()))
-        .procurementAreaCode(
-            resolve(payload.getProcurementAreaCode(), beforeState.getProcurementAreaCode()))
-        .accessPointCode(resolve(payload.getAccessPointCode(), beforeState.getAccessPointCode()))
-        .deliveryLocation(resolve(payload.getDeliveryLocation(), beforeState.getDeliveryLocation()))
-        .representationOrderDate(
-            resolve(payload.getRepresentationOrderDate(), beforeState.getRepresentationOrderDate()))
-        .suspectsDefendantsCount(
-            resolve(payload.getSuspectsDefendantsCount(), beforeState.getSuspectsDefendantsCount()))
-        .policeStationCourtAttendancesCount(
-            resolve(
-                payload.getPoliceStationCourtAttendancesCount(),
-                beforeState.getPoliceStationCourtAttendancesCount()))
-        .policeStationCourtPrisonId(
-            resolve(
-                payload.getPoliceStationCourtPrisonId(),
-                beforeState.getPoliceStationCourtPrisonId()))
-        .dsccNumber(resolve(payload.getDsccNumber(), beforeState.getDsccNumber()))
-        .maatId(resolve(payload.getMaatId(), beforeState.getMaatId()))
-        .prisonLawPriorApprovalNumber(
-            resolve(
-                payload.getPrisonLawPriorApprovalNumber(),
-                beforeState.getPrisonLawPriorApprovalNumber()))
-        .dutySolicitor(resolve(payload.getIsDutySolicitor(), beforeState.getDutySolicitor()))
-        .youthCourt(resolve(payload.getIsYouthCourt(), beforeState.getYouthCourt()))
-        .schemeId(resolve(payload.getSchemeId(), beforeState.getSchemeId()))
-        .mediationSessionsCount(
-            resolve(payload.getMediationSessionsCount(), beforeState.getMediationSessionsCount()))
-        .mediationTimeMinutes(
-            resolve(payload.getMediationTimeMinutes(), beforeState.getMediationTimeMinutes()))
-        .outreachLocation(resolve(payload.getOutreachLocation(), beforeState.getOutreachLocation()))
-        .referralSource(resolve(payload.getReferralSource(), beforeState.getReferralSource()))
-        // client fields
-        .clientForename(resolve(payload.getClientForename(), beforeState.getClientForename()))
-        .clientSurname(resolve(payload.getClientSurname(), beforeState.getClientSurname()))
-        .clientDateOfBirth(
-            resolve(payload.getClientDateOfBirth(), beforeState.getClientDateOfBirth()))
-        .uniqueClientNumber(
-            resolve(payload.getUniqueClientNumber(), beforeState.getUniqueClientNumber()))
-        .clientPostcode(resolve(payload.getClientPostcode(), beforeState.getClientPostcode()))
-        .genderCode(resolve(payload.getGenderCode(), beforeState.getGenderCode()))
-        .ethnicityCode(resolve(payload.getEthnicityCode(), beforeState.getEthnicityCode()))
-        .disabilityCode(resolve(payload.getDisabilityCode(), beforeState.getDisabilityCode()))
-        .isLegallyAided(resolve(payload.getIsLegallyAided(), beforeState.getIsLegallyAided()))
-        .clientTypeCode(resolve(payload.getClientTypeCode(), beforeState.getClientTypeCode()))
-        .homeOfficeClientNumber(
-            resolve(payload.getHomeOfficeClientNumber(), beforeState.getHomeOfficeClientNumber()))
-        .claReferenceNumber(
-            resolve(payload.getClaReferenceNumber(), beforeState.getClaReferenceNumber()))
-        .claExemptionCode(resolve(payload.getClaExemptionCode(), beforeState.getClaExemptionCode()))
-        .client2Forename(resolve(payload.getClient2Forename(), beforeState.getClient2Forename()))
-        .client2Surname(resolve(payload.getClient2Surname(), beforeState.getClient2Surname()))
-        .client2DateOfBirth(
-            resolve(payload.getClient2DateOfBirth(), beforeState.getClient2DateOfBirth()))
-        .client2Ucn(resolve(payload.getClient2Ucn(), beforeState.getClient2Ucn()))
-        .client2Postcode(resolve(payload.getClient2Postcode(), beforeState.getClient2Postcode()))
-        .client2GenderCode(
-            resolve(payload.getClient2GenderCode(), beforeState.getClient2GenderCode()))
-        .client2EthnicityCode(
-            resolve(payload.getClient2EthnicityCode(), beforeState.getClient2EthnicityCode()))
-        .client2DisabilityCode(
-            resolve(payload.getClient2DisabilityCode(), beforeState.getClient2DisabilityCode()))
-        .client2IsLegallyAided(
-            resolve(payload.getClient2IsLegallyAided(), beforeState.getClient2IsLegallyAided()))
-        // claim-case fields
-        .caseId(resolve(payload.getCaseId(), beforeState.getCaseId()))
-        .uniqueCaseId(resolve(payload.getUniqueCaseId(), beforeState.getUniqueCaseId()))
-        .caseStageCode(resolve(payload.getCaseStageCode(), beforeState.getCaseStageCode()))
-        .stageReachedCode(resolve(payload.getStageReachedCode(), beforeState.getStageReachedCode()))
-        .standardFeeCategoryCode(
-            resolve(payload.getStandardFeeCategoryCode(), beforeState.getStandardFeeCategoryCode()))
-        .outcomeCode(resolve(payload.getOutcomeCode(), beforeState.getOutcomeCode()))
-        .designatedAccreditedRepresentativeCode(
-            resolve(
-                payload.getDesignatedAccreditedRepresentativeCode(),
-                beforeState.getDesignatedAccreditedRepresentativeCode()))
-        .isPostalApplicationAccepted(
-            resolve(
-                payload.getIsPostalApplicationAccepted(),
-                beforeState.getIsPostalApplicationAccepted()))
-        .isClient2PostalApplicationAccepted(
-            resolve(
-                payload.getIsClient2PostalApplicationAccepted(),
-                beforeState.getIsClient2PostalApplicationAccepted()))
-        .mentalHealthTribunalReference(
-            resolve(
-                payload.getMentalHealthTribunalReference(),
-                beforeState.getMentalHealthTribunalReference()))
-        .isNrmAdvice(resolve(payload.getIsNrmAdvice(), beforeState.getIsNrmAdvice()))
-        .followOnWork(resolve(payload.getFollowOnWork(), beforeState.getFollowOnWork()))
-        .transferDate(resolve(payload.getTransferDate(), beforeState.getTransferDate()))
-        .exemptionCriteriaSatisfied(
-            resolve(
-                payload.getExemptionCriteriaSatisfied(),
-                beforeState.getExemptionCriteriaSatisfied()))
-        .exceptionalCaseFundingReference(
-            resolve(
-                payload.getExceptionalCaseFundingReference(),
-                beforeState.getExceptionalCaseFundingReference()))
-        .isLegacyCase(resolve(payload.getIsLegacyCase(), beforeState.getIsLegacyCase()))
-        // claim-summary-fee fields
-        .adviceTime(resolve(payload.getAdviceTime(), beforeState.getAdviceTime()))
-        .travelTime(resolve(payload.getTravelTime(), beforeState.getTravelTime()))
-        .waitingTime(resolve(payload.getWaitingTime(), beforeState.getWaitingTime()))
-        .netProfitCostsAmount(
-            resolve(payload.getNetProfitCostsAmount(), beforeState.getNetProfitCostsAmount()))
-        .netDisbursementAmount(
-            resolve(payload.getNetDisbursementAmount(), beforeState.getNetDisbursementAmount()))
-        .netCounselCostsAmount(
-            resolve(payload.getNetCounselCostsAmount(), beforeState.getNetCounselCostsAmount()))
-        .disbursementsVatAmount(
-            resolve(payload.getDisbursementsVatAmount(), beforeState.getDisbursementsVatAmount()))
-        .travelWaitingCostsAmount(
-            resolve(
-                payload.getTravelWaitingCostsAmount(), beforeState.getTravelWaitingCostsAmount()))
-        .netWaitingCostsAmount(
-            resolve(payload.getNetWaitingCostsAmount(), beforeState.getNetWaitingCostsAmount()))
-        .isVatApplicable(resolve(payload.getIsVatApplicable(), beforeState.getIsVatApplicable()))
-        .isToleranceApplicable(
-            resolve(payload.getIsToleranceApplicable(), beforeState.getIsToleranceApplicable()))
-        .priorAuthorityReference(
-            resolve(payload.getPriorAuthorityReference(), beforeState.getPriorAuthorityReference()))
-        .isLondonRate(resolve(payload.getIsLondonRate(), beforeState.getIsLondonRate()))
-        .adjournedHearingFeeAmount(
-            resolve(
-                payload.getAdjournedHearingFeeAmount(), beforeState.getAdjournedHearingFeeAmount()))
-        .isAdditionalTravelPayment(
-            resolve(
-                payload.getIsAdditionalTravelPayment(), beforeState.getIsAdditionalTravelPayment()))
-        .costsDamagesRecoveredAmount(
-            resolve(
-                payload.getCostsDamagesRecoveredAmount(),
-                beforeState.getCostsDamagesRecoveredAmount()))
-        .meetingsAttendedCode(
-            resolve(payload.getMeetingsAttendedCode(), beforeState.getMeetingsAttendedCode()))
-        .detentionTravelWaitingCostsAmount(
-            resolve(
-                payload.getDetentionTravelWaitingCostsAmount(),
-                beforeState.getDetentionTravelWaitingCostsAmount()))
-        .jrFormFillingAmount(
-            resolve(payload.getJrFormFillingAmount(), beforeState.getJrFormFillingAmount()))
-        .isEligibleClient(resolve(payload.getIsEligibleClient(), beforeState.getIsEligibleClient()))
-        .courtLocationCode(
-            resolve(payload.getCourtLocationCode(), beforeState.getCourtLocationCode()))
-        .adviceTypeCode(resolve(payload.getAdviceTypeCode(), beforeState.getAdviceTypeCode()))
-        .medicalReportsCount(
-            resolve(payload.getMedicalReportsCount(), beforeState.getMedicalReportsCount()))
-        .isIrcSurgery(resolve(payload.getIsIrcSurgery(), beforeState.getIsIrcSurgery()))
-        .surgeryDate(resolve(payload.getSurgeryDate(), beforeState.getSurgeryDate()))
-        .surgeryClientsCount(
-            resolve(payload.getSurgeryClientsCount(), beforeState.getSurgeryClientsCount()))
-        .surgeryMattersCount(
-            resolve(payload.getSurgeryMattersCount(), beforeState.getSurgeryMattersCount()))
-        .cmrhOralCount(resolve(payload.getCmrhOralCount(), beforeState.getCmrhOralCount()))
-        .cmrhTelephoneCount(
-            resolve(payload.getCmrhTelephoneCount(), beforeState.getCmrhTelephoneCount()))
-        .aitHearingCentreCode(
-            resolve(payload.getAitHearingCentreCode(), beforeState.getAitHearingCentreCode()))
-        .isSubstantiveHearing(
-            resolve(payload.getIsSubstantiveHearing(), beforeState.getIsSubstantiveHearing()))
-        .hoInterview(resolve(payload.getHoInterview(), beforeState.getHoInterview()))
-        .localAuthorityNumber(
-            resolve(payload.getLocalAuthorityNumber(), beforeState.getLocalAuthorityNumber()))
-        .build();
+    // The builder starts as a copy of the before-state, so each helper only needs to overwrite the
+    // fields the payload actually carries; omitted fields keep their before-state value.
+    ClaimStateSnapshot.ClaimStateSnapshotBuilder builder = beforeState.toBuilder();
+    applyClaimFields(builder, payload);
+    applyClientFields(builder, payload);
+    applyClaimCaseFields(builder, payload);
+    applyClaimSummaryFeeFields(builder, payload);
+    return builder.build();
+  }
+
+  /** Applies the provider-amendable claim fields onto the post-amendment builder. */
+  private static void applyClaimFields(
+      ClaimStateSnapshot.ClaimStateSnapshotBuilder builder, ClaimAmendmentPayload payload) {
+
+    applyIfPresent(payload.getScheduleReference(), builder::scheduleReference);
+    applyIfPresent(payload.getLineNumber(), builder::lineNumber);
+    applyIfPresent(payload.getCaseReferenceNumber(), builder::caseReferenceNumber);
+    applyIfPresent(payload.getUniqueFileNumber(), builder::uniqueFileNumber);
+    applyIfPresent(payload.getCaseStartDate(), builder::caseStartDate);
+    applyIfPresent(payload.getCaseConcludedDate(), builder::caseConcludedDate);
+    applyIfPresent(payload.getMatterTypeCode(), builder::matterTypeCode);
+    applyIfPresent(payload.getCrimeMatterTypeCode(), builder::crimeMatterTypeCode);
+    applyIfPresent(payload.getFeeSchemeCode(), builder::feeSchemeCode);
+    applyIfPresent(payload.getFeeCode(), builder::feeCode);
+    applyIfPresent(payload.getProcurementAreaCode(), builder::procurementAreaCode);
+    applyIfPresent(payload.getAccessPointCode(), builder::accessPointCode);
+    applyIfPresent(payload.getDeliveryLocation(), builder::deliveryLocation);
+    applyIfPresent(payload.getRepresentationOrderDate(), builder::representationOrderDate);
+    applyIfPresent(payload.getSuspectsDefendantsCount(), builder::suspectsDefendantsCount);
+    applyIfPresent(
+        payload.getPoliceStationCourtAttendancesCount(),
+        builder::policeStationCourtAttendancesCount);
+    applyIfPresent(payload.getPoliceStationCourtPrisonId(), builder::policeStationCourtPrisonId);
+    applyIfPresent(payload.getDsccNumber(), builder::dsccNumber);
+    applyIfPresent(payload.getMaatId(), builder::maatId);
+    applyIfPresent(
+        payload.getPrisonLawPriorApprovalNumber(), builder::prisonLawPriorApprovalNumber);
+    applyIfPresent(payload.getIsDutySolicitor(), builder::dutySolicitor);
+    applyIfPresent(payload.getIsYouthCourt(), builder::youthCourt);
+    applyIfPresent(payload.getSchemeId(), builder::schemeId);
+    applyIfPresent(payload.getMediationSessionsCount(), builder::mediationSessionsCount);
+    applyIfPresent(payload.getMediationTimeMinutes(), builder::mediationTimeMinutes);
+    applyIfPresent(payload.getOutreachLocation(), builder::outreachLocation);
+    applyIfPresent(payload.getReferralSource(), builder::referralSource);
+  }
+
+  /** Applies the provider-amendable client fields onto the post-amendment builder. */
+  private static void applyClientFields(
+      ClaimStateSnapshot.ClaimStateSnapshotBuilder builder, ClaimAmendmentPayload payload) {
+
+    applyIfPresent(payload.getClientForename(), builder::clientForename);
+    applyIfPresent(payload.getClientSurname(), builder::clientSurname);
+    applyIfPresent(payload.getClientDateOfBirth(), builder::clientDateOfBirth);
+    applyIfPresent(payload.getUniqueClientNumber(), builder::uniqueClientNumber);
+    applyIfPresent(payload.getClientPostcode(), builder::clientPostcode);
+    applyIfPresent(payload.getGenderCode(), builder::genderCode);
+    applyIfPresent(payload.getEthnicityCode(), builder::ethnicityCode);
+    applyIfPresent(payload.getDisabilityCode(), builder::disabilityCode);
+    applyIfPresent(payload.getIsLegallyAided(), builder::isLegallyAided);
+    applyIfPresent(payload.getClientTypeCode(), builder::clientTypeCode);
+    applyIfPresent(payload.getHomeOfficeClientNumber(), builder::homeOfficeClientNumber);
+    applyIfPresent(payload.getClaReferenceNumber(), builder::claReferenceNumber);
+    applyIfPresent(payload.getClaExemptionCode(), builder::claExemptionCode);
+    applyIfPresent(payload.getClient2Forename(), builder::client2Forename);
+    applyIfPresent(payload.getClient2Surname(), builder::client2Surname);
+    applyIfPresent(payload.getClient2DateOfBirth(), builder::client2DateOfBirth);
+    applyIfPresent(payload.getClient2Ucn(), builder::client2Ucn);
+    applyIfPresent(payload.getClient2Postcode(), builder::client2Postcode);
+    applyIfPresent(payload.getClient2GenderCode(), builder::client2GenderCode);
+    applyIfPresent(payload.getClient2EthnicityCode(), builder::client2EthnicityCode);
+    applyIfPresent(payload.getClient2DisabilityCode(), builder::client2DisabilityCode);
+    applyIfPresent(payload.getClient2IsLegallyAided(), builder::client2IsLegallyAided);
+  }
+
+  /** Applies the provider-amendable claim-case fields onto the post-amendment builder. */
+  private static void applyClaimCaseFields(
+      ClaimStateSnapshot.ClaimStateSnapshotBuilder builder, ClaimAmendmentPayload payload) {
+
+    applyIfPresent(payload.getCaseId(), builder::caseId);
+    applyIfPresent(payload.getUniqueCaseId(), builder::uniqueCaseId);
+    applyIfPresent(payload.getCaseStageCode(), builder::caseStageCode);
+    applyIfPresent(payload.getStageReachedCode(), builder::stageReachedCode);
+    applyIfPresent(payload.getStandardFeeCategoryCode(), builder::standardFeeCategoryCode);
+    applyIfPresent(payload.getOutcomeCode(), builder::outcomeCode);
+    applyIfPresent(
+        payload.getDesignatedAccreditedRepresentativeCode(),
+        builder::designatedAccreditedRepresentativeCode);
+    applyIfPresent(payload.getIsPostalApplicationAccepted(), builder::isPostalApplicationAccepted);
+    applyIfPresent(
+        payload.getIsClient2PostalApplicationAccepted(),
+        builder::isClient2PostalApplicationAccepted);
+    applyIfPresent(
+        payload.getMentalHealthTribunalReference(), builder::mentalHealthTribunalReference);
+    applyIfPresent(payload.getIsNrmAdvice(), builder::isNrmAdvice);
+    applyIfPresent(payload.getFollowOnWork(), builder::followOnWork);
+    applyIfPresent(payload.getTransferDate(), builder::transferDate);
+    applyIfPresent(payload.getExemptionCriteriaSatisfied(), builder::exemptionCriteriaSatisfied);
+    applyIfPresent(
+        payload.getExceptionalCaseFundingReference(), builder::exceptionalCaseFundingReference);
+    applyIfPresent(payload.getIsLegacyCase(), builder::isLegacyCase);
+  }
+
+  /** Applies the provider-amendable claim-summary-fee fields onto the post-amendment builder. */
+  private static void applyClaimSummaryFeeFields(
+      ClaimStateSnapshot.ClaimStateSnapshotBuilder builder, ClaimAmendmentPayload payload) {
+
+    applyIfPresent(payload.getAdviceTime(), builder::adviceTime);
+    applyIfPresent(payload.getTravelTime(), builder::travelTime);
+    applyIfPresent(payload.getWaitingTime(), builder::waitingTime);
+    applyIfPresent(payload.getNetProfitCostsAmount(), builder::netProfitCostsAmount);
+    applyIfPresent(payload.getNetDisbursementAmount(), builder::netDisbursementAmount);
+    applyIfPresent(payload.getNetCounselCostsAmount(), builder::netCounselCostsAmount);
+    applyIfPresent(payload.getDisbursementsVatAmount(), builder::disbursementsVatAmount);
+    applyIfPresent(payload.getTravelWaitingCostsAmount(), builder::travelWaitingCostsAmount);
+    applyIfPresent(payload.getNetWaitingCostsAmount(), builder::netWaitingCostsAmount);
+    applyIfPresent(payload.getIsVatApplicable(), builder::isVatApplicable);
+    applyIfPresent(payload.getIsToleranceApplicable(), builder::isToleranceApplicable);
+    applyIfPresent(payload.getPriorAuthorityReference(), builder::priorAuthorityReference);
+    applyIfPresent(payload.getIsLondonRate(), builder::isLondonRate);
+    applyIfPresent(payload.getAdjournedHearingFeeAmount(), builder::adjournedHearingFeeAmount);
+    applyIfPresent(payload.getIsAdditionalTravelPayment(), builder::isAdditionalTravelPayment);
+    applyIfPresent(payload.getCostsDamagesRecoveredAmount(), builder::costsDamagesRecoveredAmount);
+    applyIfPresent(payload.getMeetingsAttendedCode(), builder::meetingsAttendedCode);
+    applyIfPresent(
+        payload.getDetentionTravelWaitingCostsAmount(), builder::detentionTravelWaitingCostsAmount);
+    applyIfPresent(payload.getJrFormFillingAmount(), builder::jrFormFillingAmount);
+    applyIfPresent(payload.getIsEligibleClient(), builder::isEligibleClient);
+    applyIfPresent(payload.getCourtLocationCode(), builder::courtLocationCode);
+    applyIfPresent(payload.getAdviceTypeCode(), builder::adviceTypeCode);
+    applyIfPresent(payload.getMedicalReportsCount(), builder::medicalReportsCount);
+    applyIfPresent(payload.getIsIrcSurgery(), builder::isIrcSurgery);
+    applyIfPresent(payload.getSurgeryDate(), builder::surgeryDate);
+    applyIfPresent(payload.getSurgeryClientsCount(), builder::surgeryClientsCount);
+    applyIfPresent(payload.getSurgeryMattersCount(), builder::surgeryMattersCount);
+    applyIfPresent(payload.getCmrhOralCount(), builder::cmrhOralCount);
+    applyIfPresent(payload.getCmrhTelephoneCount(), builder::cmrhTelephoneCount);
+    applyIfPresent(payload.getAitHearingCentreCode(), builder::aitHearingCentreCode);
+    applyIfPresent(payload.getIsSubstantiveHearing(), builder::isSubstantiveHearing);
+    applyIfPresent(payload.getHoInterview(), builder::hoInterview);
+    applyIfPresent(payload.getLocalAuthorityNumber(), builder::localAuthorityNumber);
   }
 
   /**
@@ -243,15 +205,20 @@ public class ClaimAmendmentStateBuilder {
   }
 
   /**
-   * Resolves a single field: returns the submitted value when present (including an explicit null),
-   * otherwise retains the current value.
+   * Applies a single submitted field onto the builder, but only when the payload carries it.
+   *
+   * <p>The builder is pre-seeded with the before-state, so an omitted field ({@code
+   * JsonNullable.undefined()}) is left untouched and retains its stored value. A present value -
+   * including an explicit {@code null} - overwrites it (an explicit null clears the field for later
+   * validation).
    *
    * @param submitted the submitted tri-state value
-   * @param current the current stored value
+   * @param setter the builder setter for the corresponding field
    * @param <T> the field type
-   * @return the resolved value for the post-amendment state
    */
-  private static <T> T resolve(JsonNullable<T> submitted, T current) {
-    return submitted.isPresent() ? submitted.get() : current;
+  private static <T> void applyIfPresent(JsonNullable<T> submitted, Consumer<T> setter) {
+    if (submitted.isPresent()) {
+      setter.accept(submitted.get());
+    }
   }
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateService.java
@@ -63,7 +63,7 @@ public class ClaimAmendmentStateService {
             clientRepository.findByClaimId(claimId),
             claimCaseRepository.findByClaimId(claimId),
             claimSummaryFeeRepository.findByClaimId(claimId),
-            calculatedFeeDetailRepository.findByClaimId(claimId),
+            calculatedFeeDetailRepository.findFirstByClaimIdOrderByCreatedOnDescIdDesc(claimId),
             assessmentRepository.findFirstByClaimIdOrderByCreatedOnDesc(claimId));
 
     return Optional.of(amendmentStateBuilder.buildAmendmentState(beforeState, payload));

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateService.java
@@ -1,0 +1,71 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment;
+
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentPayload;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.mapper.ClaimStateSnapshotMapper;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.AssessmentRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.CalculatedFeeDetailRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimCaseRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimSummaryFeeRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClientRepository;
+
+/**
+ * Retrieves the current claim aggregate by id, captures the before-state, and builds the in-memory
+ * post-amendment state by applying the sparse amendment payload.
+ *
+ * <p>This step performs no persistence and makes no external calls. A missing claim is reported as
+ * {@link Optional#empty()} so the parent orchestration can map it to {@code
+ * INVALID_CLAIM_NOT_FOUND} without relying on exception flow.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ClaimAmendmentStateService {
+
+  private final ClaimRepository claimRepository;
+  private final ClientRepository clientRepository;
+  private final ClaimCaseRepository claimCaseRepository;
+  private final ClaimSummaryFeeRepository claimSummaryFeeRepository;
+  private final CalculatedFeeDetailRepository calculatedFeeDetailRepository;
+  private final AssessmentRepository assessmentRepository;
+  private final ClaimStateSnapshotMapper snapshotMapper;
+  private final ClaimAmendmentStateBuilder amendmentStateBuilder;
+
+  /**
+   * Retrieves the claim and builds the amendment state.
+   *
+   * @param claimId the claim identifier
+   * @param payload the sparse amendment payload as submitted
+   * @return the built amendment state, or {@link Optional#empty()} if the claim does not exist
+   */
+  @Transactional(readOnly = true)
+  public Optional<ClaimAmendmentState> retrieveAmendmentState(
+      UUID claimId, ClaimAmendmentPayload payload) {
+
+    Optional<Claim> claim = claimRepository.findById(claimId);
+    if (claim.isEmpty()) {
+      log.debug("No claim found for id {} during amendment retrieval", claimId);
+      return Optional.empty();
+    }
+
+    ClaimStateSnapshot beforeState =
+        snapshotMapper.toSnapshot(
+            claim.get(),
+            clientRepository.findByClaimId(claimId),
+            claimCaseRepository.findByClaimId(claimId),
+            claimSummaryFeeRepository.findByClaimId(claimId),
+            calculatedFeeDetailRepository.findByClaimId(claimId),
+            assessmentRepository.findFirstByClaimIdOrderByCreatedOnDesc(claimId));
+
+    return Optional.of(amendmentStateBuilder.buildAmendmentState(beforeState, payload));
+  }
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateService.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentPayload;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
@@ -25,6 +24,11 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClientRepository;
  * <p>This step performs no persistence and makes no external calls. A missing claim is reported as
  * {@link Optional#empty()} so the parent orchestration can map it to {@code
  * INVALID_CLAIM_NOT_FOUND} without relying on exception flow.
+ *
+ * <p>No transaction is declared here on purpose: this read is one step of the single atomic
+ * amendment transaction (retrieve, validate, then save) owned by the parent orchestrator. It must
+ * therefore run within the caller's transaction, which also keeps the persistence context open for
+ * the mapper's lazy navigation (e.g. {@code claim.submission}).
  */
 @Service
 @Slf4j
@@ -47,7 +51,6 @@ public class ClaimAmendmentStateService {
    * @param payload the sparse amendment payload as submitted
    * @return the built amendment state, or {@link Optional#empty()} if the claim does not exist
    */
-  @Transactional(readOnly = true)
   public Optional<ClaimAmendmentState> retrieveAmendmentState(
       UUID claimId, ClaimAmendmentPayload payload) {
 
@@ -64,7 +67,7 @@ public class ClaimAmendmentStateService {
             claimCaseRepository.findByClaimId(claimId),
             claimSummaryFeeRepository.findByClaimId(claimId),
             calculatedFeeDetailRepository.findFirstByClaimIdOrderByCreatedOnDescIdDesc(claimId),
-            assessmentRepository.findFirstByClaimIdOrderByCreatedOnDesc(claimId));
+            assessmentRepository.findFirstByClaimIdOrderByCreatedOnDescIdDesc(claimId));
 
     return Optional.of(amendmentStateBuilder.buildAmendmentState(beforeState, payload));
   }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentPayloadTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentPayloadTest.java
@@ -1,0 +1,142 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CASE_START_DATE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_CASE_REFERENCE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_SCHEDULE_REFERENCE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FIELD_UNIQUE_FILE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.LINE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.NET_PROFIT_COSTS_AMOUNT;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.SCHEDULE_REFERENCE;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+
+/**
+ * Unit tests for {@link ClaimAmendmentPayload} Jackson behaviour.
+ *
+ * <p>Uses a stand-alone {@link ObjectMapper} configured exactly like the application bean
+ * (registers {@code JsonNullableModule} and {@code JavaTimeModule}) so the tri-state contract is
+ * verified in isolation, independently of the Spring context. The integration test {@code
+ * ClaimAmendmentJacksonIntegrationTest} additionally proves the real primary bean is wired the same
+ * way.
+ */
+@DisplayName("ClaimAmendmentPayload Jackson Test")
+class ClaimAmendmentPayloadTest {
+
+  private static final String EXPLICIT_NULL_JSON = "{\"" + FIELD_SCHEDULE_REFERENCE + "\":null}";
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.registerModule(new JsonNullableModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
+
+  @Nested
+  @DisplayName("Serialisation")
+  class Serialisation {
+
+    @Test
+    @DisplayName("Drops omitted fields, keeps explicit null, writes values")
+    void serialises_omittedNullAndValue() throws Exception {
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder()
+              .scheduleReference(JsonNullable.of(SCHEDULE_REFERENCE)) // value
+              .uniqueFileNumber(JsonNullable.of((String) null)) // explicit clear
+              // caseReferenceNumber omitted (undefined)
+              .build();
+
+      JsonNode node = objectMapper.readTree(objectMapper.writeValueAsString(payload));
+
+      assertThat(node.get(FIELD_SCHEDULE_REFERENCE).asText()).isEqualTo(SCHEDULE_REFERENCE);
+      assertThat(node.has(FIELD_UNIQUE_FILE_NUMBER)).isTrue();
+      assertThat(node.get(FIELD_UNIQUE_FILE_NUMBER).isNull()).isTrue();
+      assertThat(node.has(FIELD_CASE_REFERENCE_NUMBER)).isFalse();
+    }
+
+    @Test
+    @DisplayName("A fully-omitted payload serialises to an empty object")
+    void serialises_fullyOmittedToEmptyObject() throws Exception {
+      ClaimAmendmentPayload payload = ClaimAmendmentPayload.builder().build();
+
+      JsonNode node = objectMapper.readTree(objectMapper.writeValueAsString(payload));
+
+      assertThat(node.isObject()).isTrue();
+      assertThat(node.isEmpty()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("Deserialisation / round trip")
+  class Deserialisation {
+
+    @Test
+    @DisplayName("Preserves omitted, explicit null and value distinctions")
+    void roundTrip_preservesTriState() throws Exception {
+      ClaimAmendmentPayload original =
+          ClaimAmendmentPayload.builder()
+              .scheduleReference(JsonNullable.of(SCHEDULE_REFERENCE)) // value
+              .uniqueFileNumber(JsonNullable.of((String) null)) // explicit clear
+              // caseReferenceNumber omitted (undefined)
+              .build();
+
+      ClaimAmendmentPayload restored =
+          objectMapper.readValue(
+              objectMapper.writeValueAsString(original), ClaimAmendmentPayload.class);
+
+      assertThat(restored.getScheduleReference().isPresent()).isTrue();
+      assertThat(restored.getScheduleReference().get()).isEqualTo(SCHEDULE_REFERENCE);
+
+      assertThat(restored.getUniqueFileNumber().isPresent()).isTrue();
+      assertThat(restored.getUniqueFileNumber().get()).isNull();
+
+      assertThat(restored.getCaseReferenceNumber().isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Reads explicit null from raw JSON as a present, null-holding value")
+    void readsExplicitNullFromRawJson() throws Exception {
+      ClaimAmendmentPayload restored =
+          objectMapper.readValue(EXPLICIT_NULL_JSON, ClaimAmendmentPayload.class);
+
+      assertThat(restored.getScheduleReference().isPresent()).isTrue();
+      assertThat(restored.getScheduleReference().get()).isNull();
+      // a property simply absent from the JSON stays undefined
+      assertThat(restored.getUniqueFileNumber().isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Round-trips typed values (date, integer, decimal, boolean)")
+    void roundTrip_preservesTypedValues() throws Exception {
+      ClaimAmendmentPayload original =
+          ClaimAmendmentPayload.builder()
+              .caseStartDate(JsonNullable.of(CASE_START_DATE))
+              .lineNumber(JsonNullable.of(LINE_NUMBER))
+              .netProfitCostsAmount(JsonNullable.of(NET_PROFIT_COSTS_AMOUNT))
+              .isVatApplicable(JsonNullable.of(true))
+              .build();
+
+      ClaimAmendmentPayload restored =
+          objectMapper.readValue(
+              objectMapper.writeValueAsString(original), ClaimAmendmentPayload.class);
+
+      assertThat(restored.getCaseStartDate().get()).isEqualTo(CASE_START_DATE);
+      assertThat(restored.getLineNumber().get()).isEqualTo(LINE_NUMBER);
+      assertThat(restored.getNetProfitCostsAmount().get())
+          .isEqualByComparingTo(NET_PROFIT_COSTS_AMOUNT);
+      assertThat(restored.getIsVatApplicable().get()).isTrue();
+    }
+  }
+}

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimStateSnapshotMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimStateSnapshotMapperTest.java
@@ -1,0 +1,351 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.ASSESSED_TOTAL_INCL_VAT;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CASE_CONCLUDED_DATE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CASE_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CASE_REFERENCE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CASE_START_DATE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CATEGORY_OF_LAW;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CLAIM_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CLIENT_DATE_OF_BIRTH;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CLIENT_FORENAME;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CLIENT_SURNAME;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CMRH_ORAL_COUNT;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CREATED_BY_USER_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.EXEMPTION_CRITERIA_SATISFIED;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FEE_CODE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.LINE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.MATTER_TYPE_CODE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.NET_PROFIT_COSTS_AMOUNT;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.OFFICE_ACCOUNT_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.PROVIDER_USER_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.REPRESENTATION_ORDER_DATE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.SCHEDULE_REFERENCE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.SUBMISSION_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.SUBMISSION_PERIOD;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.UNIQUE_CLIENT_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.UNIQUE_FILE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.VERSION;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.CalculatedFeeDetail;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimCase;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Client;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Submission;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+
+@DisplayName("ClaimStateSnapshotMapper Tests")
+class ClaimStateSnapshotMapperTest {
+
+  private final ClaimStateSnapshotMapper mapper = new ClaimStateSnapshotMapperImpl();
+
+  private static Claim claim(Submission submission) {
+    return Claim.builder()
+        .id(CLAIM_ID)
+        .submission(submission)
+        .status(ClaimStatus.READY_TO_PROCESS)
+        .version(VERSION)
+        .hasAssessment(true)
+        .isAmended(false)
+        .lineNumber(LINE_NUMBER)
+        .matterTypeCode(MATTER_TYPE_CODE)
+        .scheduleReference(SCHEDULE_REFERENCE)
+        .caseReferenceNumber(CASE_REFERENCE_NUMBER)
+        .uniqueFileNumber(UNIQUE_FILE_NUMBER)
+        .caseStartDate(CASE_START_DATE)
+        .caseConcludedDate(CASE_CONCLUDED_DATE)
+        .representationOrderDate(REPRESENTATION_ORDER_DATE)
+        .feeCode(FEE_CODE)
+        .createdByUserId(CREATED_BY_USER_ID)
+        .build();
+  }
+
+  private static Submission submission() {
+    return Submission.builder()
+        .id(SUBMISSION_ID)
+        .bulkSubmissionId(UUID.randomUUID())
+        .officeAccountNumber(OFFICE_ACCOUNT_NUMBER)
+        .submissionPeriod(SUBMISSION_PERIOD)
+        .areaOfLaw(AreaOfLaw.CRIME_LOWER)
+        .createdByUserId(CREATED_BY_USER_ID)
+        .providerUserId(PROVIDER_USER_ID)
+        .build();
+  }
+
+  @Test
+  @DisplayName("maps all values from a fully-populated aggregate")
+  void mapsFullyPopulatedAggregate() {
+    Client client =
+        Client.builder()
+            .clientForename(CLIENT_FORENAME)
+            .clientSurname(CLIENT_SURNAME)
+            .clientDateOfBirth(CLIENT_DATE_OF_BIRTH)
+            .uniqueClientNumber(UNIQUE_CLIENT_NUMBER)
+            .createdByUserId(CREATED_BY_USER_ID)
+            .build();
+    ClaimCase claimCase =
+        ClaimCase.builder()
+            .caseId(CASE_ID)
+            .exemptionCriteriaSatisfied(EXEMPTION_CRITERIA_SATISFIED)
+            .createdByUserId(CREATED_BY_USER_ID)
+            .build();
+    CalculatedFeeDetail feeDetail =
+        CalculatedFeeDetail.builder()
+            .categoryOfLaw(CATEGORY_OF_LAW)
+            .createdByUserId(CREATED_BY_USER_ID)
+            .build();
+    ClaimSummaryFee summaryFee =
+        ClaimSummaryFee.builder()
+            .netProfitCostsAmount(NET_PROFIT_COSTS_AMOUNT)
+            .isVatApplicable(true)
+            .cmrhOralCount(CMRH_ORAL_COUNT)
+            .createdByUserId(CREATED_BY_USER_ID)
+            .build();
+    Assessment assessment =
+        Assessment.builder().assessedTotalInclVat(ASSESSED_TOTAL_INCL_VAT).build();
+
+    ClaimStateSnapshot snapshot =
+        mapper.toSnapshot(
+            claim(submission()), client, claimCase, summaryFee, feeDetail, assessment);
+
+    assertThat(snapshot.getClaimId()).isEqualTo(CLAIM_ID);
+    assertThat(snapshot.getSubmissionId()).isEqualTo(SUBMISSION_ID);
+    assertThat(snapshot.getStatus()).isEqualTo(ClaimStatus.READY_TO_PROCESS);
+    assertThat(snapshot.getVersion()).isEqualTo(VERSION);
+    assertThat(snapshot.hasAssessment()).isTrue();
+    assertThat(snapshot.isAmended()).isFalse();
+    assertThat(snapshot.getAreaOfLaw()).isEqualTo(AreaOfLaw.CRIME_LOWER);
+    assertThat(snapshot.getOfficeAccountNumber()).isEqualTo(OFFICE_ACCOUNT_NUMBER);
+    assertThat(snapshot.getSubmissionPeriod()).isEqualTo(SUBMISSION_PERIOD);
+    assertThat(snapshot.getUniqueFileNumber()).isEqualTo(UNIQUE_FILE_NUMBER);
+    assertThat(snapshot.getFeeCode()).isEqualTo(FEE_CODE);
+    assertThat(snapshot.getCategoryOfLaw()).isEqualTo(CATEGORY_OF_LAW);
+    assertThat(snapshot.getClientForename()).isEqualTo(CLIENT_FORENAME);
+    assertThat(snapshot.getClientSurname()).isEqualTo(CLIENT_SURNAME);
+    assertThat(snapshot.getClientDateOfBirth()).isEqualTo(CLIENT_DATE_OF_BIRTH);
+    assertThat(snapshot.getUniqueClientNumber()).isEqualTo(UNIQUE_CLIENT_NUMBER);
+    assertThat(snapshot.getCaseId()).isEqualTo(CASE_ID);
+    assertThat(snapshot.getExemptionCriteriaSatisfied()).isEqualTo(EXEMPTION_CRITERIA_SATISFIED);
+    // claim-summary-fee fields
+    assertThat(snapshot.getNetProfitCostsAmount()).isEqualByComparingTo(NET_PROFIT_COSTS_AMOUNT);
+    assertThat(snapshot.getIsVatApplicable()).isTrue();
+    assertThat(snapshot.getCmrhOralCount()).isEqualTo(CMRH_ORAL_COUNT);
+    // read-only nested context
+    assertThat(snapshot.getCalculatedFeeDetail()).isNotNull();
+    assertThat(snapshot.getLatestAssessment()).isNotNull();
+    assertThat(snapshot.getLatestAssessment().getAssessedTotalInclVat())
+        .isEqualByComparingTo(ASSESSED_TOTAL_INCL_VAT);
+  }
+
+  @Test
+  @DisplayName("missing associations leave the corresponding fields null")
+  void missingAssociationsLeaveFieldsNull() {
+    ClaimStateSnapshot snapshot =
+        mapper.toSnapshot(
+            claim(submission()),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+
+    assertThat(snapshot.getClaimId()).isEqualTo(CLAIM_ID);
+    assertThat(snapshot.getUniqueFileNumber()).isEqualTo(UNIQUE_FILE_NUMBER);
+    // associations absent
+    assertThat(snapshot.getClientForename()).isNull();
+    assertThat(snapshot.getUniqueClientNumber()).isNull();
+    assertThat(snapshot.getCaseId()).isNull();
+    assertThat(snapshot.getExemptionCriteriaSatisfied()).isNull();
+    assertThat(snapshot.getCategoryOfLaw()).isNull();
+    assertThat(snapshot.getNetProfitCostsAmount()).isNull();
+    assertThat(snapshot.getCalculatedFeeDetail()).isNull();
+    assertThat(snapshot.getLatestAssessment()).isNull();
+  }
+
+  @Test
+  @DisplayName("null submission leaves submission-context fields null without failing")
+  void nullSubmissionIsNullSafe() {
+    ClaimStateSnapshot snapshot =
+        mapper.toSnapshot(
+            claim(null),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+
+    assertThat(snapshot.getSubmissionId()).isNull();
+    assertThat(snapshot.getAreaOfLaw()).isNull();
+    assertThat(snapshot.getOfficeAccountNumber()).isNull();
+    assertThat(snapshot.getSubmissionPeriod()).isNull();
+  }
+
+  @Test
+  @DisplayName("a fully-populated aggregate leaves no snapshot field null (guards silent nulls)")
+  void fullyPopulatedAggregateLeavesNoSnapshotFieldNull() throws IllegalAccessException {
+    // Values without a named constant below are arbitrary, single-use non-null fillers: this test
+    // only asserts that every snapshot field is populated, never their specific values.
+    Submission submission = submission();
+
+    Claim claim =
+        Claim.builder()
+            .id(CLAIM_ID)
+            .submission(submission)
+            .status(ClaimStatus.READY_TO_PROCESS)
+            .version(VERSION)
+            .hasAssessment(true)
+            .isAmended(true)
+            .scheduleReference(SCHEDULE_REFERENCE)
+            .lineNumber(LINE_NUMBER)
+            .caseReferenceNumber(CASE_REFERENCE_NUMBER)
+            .uniqueFileNumber(UNIQUE_FILE_NUMBER)
+            .caseStartDate(CASE_START_DATE)
+            .caseConcludedDate(CASE_CONCLUDED_DATE)
+            .matterTypeCode(MATTER_TYPE_CODE)
+            .crimeMatterTypeCode("CMT-1")
+            .feeSchemeCode("FS-1")
+            .feeCode(FEE_CODE)
+            .procurementAreaCode("PA-1")
+            .accessPointCode("AP-1")
+            .deliveryLocation("DL-1")
+            .representationOrderDate(REPRESENTATION_ORDER_DATE)
+            .suspectsDefendantsCount(2)
+            .policeStationCourtAttendancesCount(3)
+            .policeStationCourtPrisonId("PSC-1")
+            .dsccNumber("DSCC-1")
+            .maatId("MAAT-1")
+            .prisonLawPriorApprovalNumber("PLPA-1")
+            .dutySolicitor(true)
+            .youthCourt(false)
+            .schemeId("SCHEME-1")
+            .mediationSessionsCount(4)
+            .mediationTimeMinutes(120)
+            .outreachLocation("OUT-1")
+            .referralSource("REF-1")
+            .createdByUserId(CREATED_BY_USER_ID)
+            .build();
+
+    Client client =
+        Client.builder()
+            .clientForename(CLIENT_FORENAME)
+            .clientSurname(CLIENT_SURNAME)
+            .clientDateOfBirth(CLIENT_DATE_OF_BIRTH)
+            .uniqueClientNumber(UNIQUE_CLIENT_NUMBER)
+            .clientPostcode("AB1 2CD")
+            .genderCode("F")
+            .ethnicityCode("ETH-1")
+            .disabilityCode("DIS-1")
+            .isLegallyAided(true)
+            .clientTypeCode("CT-1")
+            .homeOfficeClientNumber("HO-1")
+            .claReferenceNumber("CLA-1")
+            .claExemptionCode("CLAEX-1")
+            .client2Forename("Grace")
+            .client2Surname("Hopper")
+            .client2DateOfBirth(LocalDate.of(1985, 3, 10))
+            .client2Ucn("UCN-2")
+            .client2Postcode("EF3 4GH")
+            .client2GenderCode("F")
+            .client2EthnicityCode("ETH-2")
+            .client2DisabilityCode("DIS-2")
+            .client2IsLegallyAided(false)
+            .createdByUserId(CREATED_BY_USER_ID)
+            .build();
+
+    ClaimCase claimCase =
+        ClaimCase.builder()
+            .caseId(CASE_ID)
+            .uniqueCaseId("UCID-1")
+            .caseStageCode("CS-1")
+            .stageReachedCode("SR-1")
+            .standardFeeCategoryCode("SFC-1")
+            .outcomeCode("OUT-1")
+            .designatedAccreditedRepresentativeCode("DAR-1")
+            .isPostalApplicationAccepted(true)
+            .isClient2PostalApplicationAccepted(false)
+            .mentalHealthTribunalReference("MHTR-1")
+            .isNrmAdvice(true)
+            .followOnWork("FOW-1")
+            .transferDate(LocalDate.of(2026, 3, 1))
+            .exemptionCriteriaSatisfied(EXEMPTION_CRITERIA_SATISFIED)
+            .exceptionalCaseFundingReference("ECF-1")
+            .isLegacyCase(false)
+            .createdByUserId(CREATED_BY_USER_ID)
+            .build();
+
+    ClaimSummaryFee summaryFee =
+        ClaimSummaryFee.builder()
+            .adviceTime(10)
+            .travelTime(20)
+            .waitingTime(30)
+            .netProfitCostsAmount(NET_PROFIT_COSTS_AMOUNT)
+            .netDisbursementAmount(new BigDecimal("11.00"))
+            .netCounselCostsAmount(new BigDecimal("12.00"))
+            .disbursementsVatAmount(new BigDecimal("2.40"))
+            .travelWaitingCostsAmount(new BigDecimal("13.00"))
+            .netWaitingCostsAmount(new BigDecimal("14.00"))
+            .isVatApplicable(true)
+            .isToleranceApplicable(false)
+            .priorAuthorityReference("PAR-1")
+            .isLondonRate(true)
+            .adjournedHearingFeeAmount(5)
+            .isAdditionalTravelPayment(false)
+            .costsDamagesRecoveredAmount(new BigDecimal("15.00"))
+            .meetingsAttendedCode("MA-1")
+            .detentionTravelWaitingCostsAmount(new BigDecimal("16.00"))
+            .jrFormFillingAmount(new BigDecimal("17.00"))
+            .isEligibleClient(true)
+            .courtLocationCode("CL-1")
+            .adviceTypeCode("AT-1")
+            .medicalReportsCount(1)
+            .isIrcSurgery(false)
+            .surgeryDate(LocalDate.of(2026, 4, 1))
+            .surgeryClientsCount(2)
+            .surgeryMattersCount(3)
+            .cmrhOralCount(CMRH_ORAL_COUNT)
+            .cmrhTelephoneCount(1)
+            .aitHearingCentreCode("AIT-1")
+            .isSubstantiveHearing(true)
+            .hoInterview(1)
+            .localAuthorityNumber("LA-1")
+            .createdByUserId(CREATED_BY_USER_ID)
+            .build();
+
+    CalculatedFeeDetail feeDetail =
+        CalculatedFeeDetail.builder()
+            .categoryOfLaw(CATEGORY_OF_LAW)
+            .createdByUserId(CREATED_BY_USER_ID)
+            .build();
+    Assessment assessment =
+        Assessment.builder().assessedTotalInclVat(ASSESSED_TOTAL_INCL_VAT).build();
+
+    ClaimStateSnapshot snapshot =
+        mapper.toSnapshot(claim, client, claimCase, summaryFee, feeDetail, assessment);
+
+    // Reflectively assert every (non-static, non-synthetic) field is populated. This converts the
+    // latent silent-null risk from unmappedTargetPolicy = IGNORE into an explicit, future-proof
+    // guard: a newly added snapshot field with no matching source will fail this test.
+    for (Field field : ClaimStateSnapshot.class.getDeclaredFields()) {
+      if (field.isSynthetic() || Modifier.isStatic(field.getModifiers())) {
+        continue;
+      }
+      field.setAccessible(true);
+      assertThat(field.get(snapshot))
+          .as("snapshot field '%s' should be mapped from a source", field.getName())
+          .isNotNull();
+    }
+  }
+}

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateBuilderTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateBuilderTest.java
@@ -1,0 +1,246 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.AMENDED_CASE_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.AMENDED_CLIENT_DATE_OF_BIRTH;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.AMENDED_CLIENT_FORENAME;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.AMENDED_CLIENT_SURNAME;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.AMENDED_FEE_CODE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.AMENDED_UNIQUE_CLIENT_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.AMENDED_UNIQUE_FILE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CASE_CONCLUDED_DATE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CASE_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CASE_REFERENCE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CASE_START_DATE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CATEGORY_OF_LAW;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CLAIM_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CLIENT_DATE_OF_BIRTH;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CLIENT_FORENAME;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CLIENT_SURNAME;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.EXEMPTION_CRITERIA_SATISFIED;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.FEE_CODE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.MATTER_TYPE_CODE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.OFFICE_ACCOUNT_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.REPRESENTATION_ORDER_DATE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.SCHEDULE_REFERENCE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.SUBMISSION_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.SUBMISSION_PERIOD;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.UNIQUE_CLIENT_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.UNIQUE_FILE_NUMBER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.VERSION;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentPayload;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+
+@DisplayName("ClaimAmendmentStateBuilder Tests")
+class ClaimAmendmentStateBuilderTest {
+
+  private final ClaimAmendmentStateBuilder builder = new ClaimAmendmentStateBuilder();
+
+  private static ClaimStateSnapshot beforeState() {
+    return ClaimStateSnapshot.builder()
+        .claimId(CLAIM_ID)
+        .submissionId(SUBMISSION_ID)
+        .status(ClaimStatus.READY_TO_PROCESS)
+        .version(VERSION)
+        .hasAssessment(false)
+        .amended(false)
+        .areaOfLaw(AreaOfLaw.CRIME_LOWER)
+        .officeAccountNumber(OFFICE_ACCOUNT_NUMBER)
+        .submissionPeriod(SUBMISSION_PERIOD)
+        .scheduleReference(SCHEDULE_REFERENCE)
+        .caseReferenceNumber(CASE_REFERENCE_NUMBER)
+        .uniqueFileNumber(UNIQUE_FILE_NUMBER)
+        .caseStartDate(CASE_START_DATE)
+        .caseConcludedDate(CASE_CONCLUDED_DATE)
+        .representationOrderDate(REPRESENTATION_ORDER_DATE)
+        .matterTypeCode(MATTER_TYPE_CODE)
+        .feeCode(FEE_CODE)
+        .categoryOfLaw(CATEGORY_OF_LAW)
+        .clientForename(CLIENT_FORENAME)
+        .clientSurname(CLIENT_SURNAME)
+        .clientDateOfBirth(CLIENT_DATE_OF_BIRTH)
+        .uniqueClientNumber(UNIQUE_CLIENT_NUMBER)
+        .caseId(CASE_ID)
+        .exemptionCriteriaSatisfied(EXEMPTION_CRITERIA_SATISFIED)
+        .build();
+  }
+
+  @Nested
+  @DisplayName("Sparse payload semantics")
+  class SparsePayloadSemantics {
+
+    @Test
+    @DisplayName("omitted field retains the stored value")
+    void omittedFieldRetainsStoredValue() {
+      // empty payload: every field undefined
+      ClaimAmendmentPayload payload = ClaimAmendmentPayload.builder().build();
+
+      ClaimStateSnapshot after = builder.buildPostAmendmentState(beforeState(), payload);
+
+      assertThat(after.getFeeCode()).isEqualTo(FEE_CODE);
+      assertThat(after.getCaseReferenceNumber()).isEqualTo(CASE_REFERENCE_NUMBER);
+      assertThat(after.getClientForename()).isEqualTo(CLIENT_FORENAME);
+    }
+
+    @Test
+    @DisplayName("explicit null clears the field for later validation")
+    void explicitNullClearsField() {
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder().feeCode(JsonNullable.of(null)).build();
+
+      ClaimStateSnapshot after = builder.buildPostAmendmentState(beforeState(), payload);
+
+      assertThat(after.getFeeCode()).isNull();
+      // unrelated field untouched
+      assertThat(after.getCaseReferenceNumber()).isEqualTo(CASE_REFERENCE_NUMBER);
+    }
+
+    @Test
+    @DisplayName("changed scalar value is applied")
+    void changedScalarValueApplied() {
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder().feeCode(JsonNullable.of(AMENDED_FEE_CODE)).build();
+
+      ClaimStateSnapshot after = builder.buildPostAmendmentState(beforeState(), payload);
+
+      assertThat(after.getFeeCode()).isEqualTo(AMENDED_FEE_CODE);
+    }
+
+    @Test
+    @DisplayName("no-op same-value payload leaves the field unchanged")
+    void noOpSameValueLeavesFieldUnchanged() {
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder().feeCode(JsonNullable.of(FEE_CODE)).build();
+
+      ClaimStateSnapshot after = builder.buildPostAmendmentState(beforeState(), payload);
+
+      assertThat(after.getFeeCode()).isEqualTo(FEE_CODE);
+    }
+  }
+
+  @Nested
+  @DisplayName("UCN/UFN handling")
+  class UcnUfnHandling {
+
+    @Test
+    @DisplayName("UCN/UFN remain unchanged when name, date of birth and case id change")
+    void ucnUfnUnchangedWhenIdentityFieldsChange() {
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder()
+              .clientForename(JsonNullable.of(AMENDED_CLIENT_FORENAME))
+              .clientSurname(JsonNullable.of(AMENDED_CLIENT_SURNAME))
+              .clientDateOfBirth(JsonNullable.of(AMENDED_CLIENT_DATE_OF_BIRTH))
+              .caseId(JsonNullable.of(AMENDED_CASE_ID))
+              .build();
+
+      ClaimStateSnapshot after = builder.buildPostAmendmentState(beforeState(), payload);
+
+      assertThat(after.getClientForename()).isEqualTo(AMENDED_CLIENT_FORENAME);
+      assertThat(after.getClientSurname()).isEqualTo(AMENDED_CLIENT_SURNAME);
+      assertThat(after.getClientDateOfBirth()).isEqualTo(AMENDED_CLIENT_DATE_OF_BIRTH);
+      assertThat(after.getCaseId()).isEqualTo(AMENDED_CASE_ID);
+      // UCN/UFN must not be recomputed
+      assertThat(after.getUniqueClientNumber()).isEqualTo(UNIQUE_CLIENT_NUMBER);
+      assertThat(after.getUniqueFileNumber()).isEqualTo(UNIQUE_FILE_NUMBER);
+    }
+
+    @Test
+    @DisplayName("UCN/UFN change only when explicitly submitted")
+    void ucnUfnChangeWhenExplicitlySubmitted() {
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder()
+              .uniqueClientNumber(JsonNullable.of(AMENDED_UNIQUE_CLIENT_NUMBER))
+              .uniqueFileNumber(JsonNullable.of(AMENDED_UNIQUE_FILE_NUMBER))
+              .build();
+
+      ClaimStateSnapshot after = builder.buildPostAmendmentState(beforeState(), payload);
+
+      assertThat(after.getUniqueClientNumber()).isEqualTo(AMENDED_UNIQUE_CLIENT_NUMBER);
+      assertThat(after.getUniqueFileNumber()).isEqualTo(AMENDED_UNIQUE_FILE_NUMBER);
+    }
+  }
+
+  @Nested
+  @DisplayName("Identity and context fields")
+  class IdentityAndContext {
+
+    @Test
+    @DisplayName("non-amendable identity/context fields are carried over unchanged")
+    void identityAndContextCarriedOver() {
+      ClaimStateSnapshot before = beforeState();
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder().feeCode(JsonNullable.of(AMENDED_FEE_CODE)).build();
+
+      ClaimStateSnapshot after = builder.buildPostAmendmentState(before, payload);
+
+      assertThat(after.getClaimId()).isEqualTo(before.getClaimId());
+      assertThat(after.getSubmissionId()).isEqualTo(before.getSubmissionId());
+      assertThat(after.getVersion()).isEqualTo(before.getVersion());
+      assertThat(after.getAreaOfLaw()).isEqualTo(before.getAreaOfLaw());
+      assertThat(after.getOfficeAccountNumber()).isEqualTo(before.getOfficeAccountNumber());
+      assertThat(after.getSubmissionPeriod()).isEqualTo(before.getSubmissionPeriod());
+      assertThat(after.getCategoryOfLaw()).isEqualTo(before.getCategoryOfLaw());
+      assertThat(after.getExemptionCriteriaSatisfied())
+          .isEqualTo(before.getExemptionCriteriaSatisfied());
+    }
+
+    @Test
+    @DisplayName("status is read-only and carried over unchanged from the before-state")
+    void statusCarriedOverUnchanged() {
+      ClaimStateSnapshot before = beforeState();
+      // An amendment touching an unrelated field must never affect the (read-only) status.
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder().feeCode(JsonNullable.of(AMENDED_FEE_CODE)).build();
+
+      ClaimStateSnapshot after = builder.buildPostAmendmentState(before, payload);
+
+      assertThat(after.getStatus()).isEqualTo(ClaimStatus.READY_TO_PROCESS);
+      assertThat(after.getStatus()).isEqualTo(before.getStatus());
+    }
+  }
+
+  @Nested
+  @DisplayName("Aggregate building")
+  class AggregateBuilding {
+
+    @Test
+    @DisplayName("buildAmendmentState bundles before-state, payload and post-amendment state")
+    void buildAmendmentStateBundlesEverything() {
+      ClaimStateSnapshot before = beforeState();
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder().feeCode(JsonNullable.of(AMENDED_FEE_CODE)).build();
+
+      ClaimAmendmentState state = builder.buildAmendmentState(before, payload);
+
+      assertThat(state.getBeforeState()).isSameAs(before);
+      assertThat(state.getRequestPayload()).isSameAs(payload);
+      assertThat(state.getPostAmendmentState().getFeeCode()).isEqualTo(AMENDED_FEE_CODE);
+      // before-state remains untouched (immutability)
+      assertThat(before.getFeeCode()).isEqualTo(FEE_CODE);
+    }
+
+    @Test
+    @DisplayName("AC3: an omitted field stays undefined in the retained request payload")
+    void omittedFieldRemainsUndefinedInRequestPayload() {
+      ClaimStateSnapshot before = beforeState();
+      // caseReferenceNumber is omitted; feeCode is the only submitted change.
+      ClaimAmendmentPayload payload =
+          ClaimAmendmentPayload.builder().feeCode(JsonNullable.of(AMENDED_FEE_CODE)).build();
+
+      ClaimAmendmentState state = builder.buildAmendmentState(before, payload);
+
+      // An omitted field must not be recorded as a requested change.
+      assertThat(state.getRequestPayload().getCaseReferenceNumber().isPresent()).isFalse();
+      // ...while the submitted field is present.
+      assertThat(state.getRequestPayload().getFeeCode().isPresent()).isTrue();
+    }
+  }
+}

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceTest.java
@@ -71,7 +71,8 @@ class ClaimAmendmentStateServiceTest {
     when(clientRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
     when(claimCaseRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
     when(claimSummaryFeeRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
-    when(calculatedFeeDetailRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(calculatedFeeDetailRepository.findFirstByClaimIdOrderByCreatedOnDescIdDesc(CLAIM_ID))
+        .thenReturn(Optional.empty());
     when(assessmentRepository.findFirstByClaimIdOrderByCreatedOnDesc(CLAIM_ID))
         .thenReturn(Optional.empty());
 
@@ -113,7 +114,8 @@ class ClaimAmendmentStateServiceTest {
     when(clientRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
     when(claimCaseRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
     when(claimSummaryFeeRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
-    when(calculatedFeeDetailRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(calculatedFeeDetailRepository.findFirstByClaimIdOrderByCreatedOnDescIdDesc(CLAIM_ID))
+        .thenReturn(Optional.empty());
     when(assessmentRepository.findFirstByClaimIdOrderByCreatedOnDesc(CLAIM_ID))
         .thenReturn(Optional.empty());
 

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceTest.java
@@ -1,0 +1,144 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.AMENDED_FEE_CODE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.AmendmentTestData.CLAIM_ID;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openapitools.jackson.nullable.JsonNullable;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentPayload;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.mapper.ClaimStateSnapshotMapper;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.AssessmentRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.CalculatedFeeDetailRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimCaseRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimSummaryFeeRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClientRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ClaimAmendmentStateService Tests")
+class ClaimAmendmentStateServiceTest {
+
+  @Mock private ClaimRepository claimRepository;
+  @Mock private ClientRepository clientRepository;
+  @Mock private ClaimCaseRepository claimCaseRepository;
+  @Mock private ClaimSummaryFeeRepository claimSummaryFeeRepository;
+  @Mock private CalculatedFeeDetailRepository calculatedFeeDetailRepository;
+  @Mock private AssessmentRepository assessmentRepository;
+  @Mock private ClaimStateSnapshotMapper snapshotMapper;
+  @Mock private ClaimAmendmentStateBuilder amendmentStateBuilder;
+
+  @InjectMocks private ClaimAmendmentStateService service;
+
+  @Test
+  @DisplayName("returns empty when the claim does not exist and does no further work")
+  void returnsEmptyWhenClaimNotFound() {
+    when(claimRepository.findById(CLAIM_ID)).thenReturn(Optional.empty());
+
+    Optional<ClaimAmendmentState> result =
+        service.retrieveAmendmentState(CLAIM_ID, ClaimAmendmentPayload.builder().build());
+
+    assertThat(result).isEmpty();
+    verifyNoInteractions(
+        clientRepository,
+        claimCaseRepository,
+        claimSummaryFeeRepository,
+        calculatedFeeDetailRepository,
+        assessmentRepository,
+        snapshotMapper);
+    verify(amendmentStateBuilder, never()).buildAmendmentState(any(), any());
+  }
+
+  @Test
+  @DisplayName("builds amendment state from the loaded aggregate when the claim exists")
+  void buildsAmendmentStateWhenClaimExists() {
+    Claim claim = Claim.builder().id(CLAIM_ID).build();
+    when(claimRepository.findById(CLAIM_ID)).thenReturn(Optional.of(claim));
+    when(clientRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(claimCaseRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(claimSummaryFeeRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(calculatedFeeDetailRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(assessmentRepository.findFirstByClaimIdOrderByCreatedOnDesc(CLAIM_ID))
+        .thenReturn(Optional.empty());
+
+    ClaimStateSnapshot beforeState = ClaimStateSnapshot.builder().claimId(CLAIM_ID).build();
+    when(snapshotMapper.toSnapshot(
+            any(Claim.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(beforeState);
+
+    ClaimAmendmentPayload payload =
+        ClaimAmendmentPayload.builder().feeCode(JsonNullable.of(AMENDED_FEE_CODE)).build();
+    ClaimAmendmentState expected =
+        ClaimAmendmentState.builder().beforeState(beforeState).requestPayload(payload).build();
+    when(amendmentStateBuilder.buildAmendmentState(beforeState, payload)).thenReturn(expected);
+
+    Optional<ClaimAmendmentState> result = service.retrieveAmendmentState(CLAIM_ID, payload);
+
+    assertThat(result).containsSame(expected);
+    verify(snapshotMapper)
+        .toSnapshot(
+            any(Claim.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class));
+    verify(amendmentStateBuilder).buildAmendmentState(beforeState, payload);
+  }
+
+  @Test
+  @DisplayName("produces no database write, external call or event on the found path")
+  void producesNoSideEffectsOnFoundPath() {
+    Claim claim = Claim.builder().id(CLAIM_ID).build();
+    when(claimRepository.findById(CLAIM_ID)).thenReturn(Optional.of(claim));
+    when(clientRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(claimCaseRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(claimSummaryFeeRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(calculatedFeeDetailRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
+    when(assessmentRepository.findFirstByClaimIdOrderByCreatedOnDesc(CLAIM_ID))
+        .thenReturn(Optional.empty());
+
+    ClaimStateSnapshot beforeState = ClaimStateSnapshot.builder().claimId(CLAIM_ID).build();
+    when(snapshotMapper.toSnapshot(
+            any(Claim.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(beforeState);
+
+    ClaimAmendmentPayload payload = ClaimAmendmentPayload.builder().build();
+    when(amendmentStateBuilder.buildAmendmentState(beforeState, payload))
+        .thenReturn(ClaimAmendmentState.builder().beforeState(beforeState).build());
+
+    service.retrieveAmendmentState(CLAIM_ID, payload);
+
+    // no persistence: none of the repositories' save/delete methods are invoked
+    verify(claimRepository, never()).save(any());
+    verify(clientRepository, never()).save(any());
+    verify(claimCaseRepository, never()).save(any());
+    verify(claimSummaryFeeRepository, never()).save(any());
+    verify(calculatedFeeDetailRepository, never()).save(any());
+    verify(assessmentRepository, never()).save(any());
+  }
+}

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentStateServiceTest.java
@@ -73,7 +73,7 @@ class ClaimAmendmentStateServiceTest {
     when(claimSummaryFeeRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
     when(calculatedFeeDetailRepository.findFirstByClaimIdOrderByCreatedOnDescIdDesc(CLAIM_ID))
         .thenReturn(Optional.empty());
-    when(assessmentRepository.findFirstByClaimIdOrderByCreatedOnDesc(CLAIM_ID))
+    when(assessmentRepository.findFirstByClaimIdOrderByCreatedOnDescIdDesc(CLAIM_ID))
         .thenReturn(Optional.empty());
 
     ClaimStateSnapshot beforeState = ClaimStateSnapshot.builder().claimId(CLAIM_ID).build();
@@ -116,7 +116,7 @@ class ClaimAmendmentStateServiceTest {
     when(claimSummaryFeeRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
     when(calculatedFeeDetailRepository.findFirstByClaimIdOrderByCreatedOnDescIdDesc(CLAIM_ID))
         .thenReturn(Optional.empty());
-    when(assessmentRepository.findFirstByClaimIdOrderByCreatedOnDesc(CLAIM_ID))
+    when(assessmentRepository.findFirstByClaimIdOrderByCreatedOnDescIdDesc(CLAIM_ID))
         .thenReturn(Optional.empty());
 
     ClaimStateSnapshot beforeState = ClaimStateSnapshot.builder().claimId(CLAIM_ID).build();

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/AmendmentTestData.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/AmendmentTestData.java
@@ -1,0 +1,68 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.util;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Shared synthetic test data for the claim-amendment unit and serialisation tests (builder, mapper,
+ * payload and Jackson tests).
+ *
+ * <p>Centralises the "before-state" dataset, the submitted "amended" values and the serialised JSON
+ * property names so those tests assert against a single source of truth, mirroring the existing
+ * {@link ClaimsDataTestUtil} pattern.
+ */
+public final class AmendmentTestData {
+
+  private AmendmentTestData() {}
+
+  // Identity and context
+  public static final UUID CLAIM_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  public static final UUID SUBMISSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+  public static final long VERSION = 7L;
+  public static final int LINE_NUMBER = 1;
+  public static final String OFFICE_ACCOUNT_NUMBER = "OFF123";
+  public static final String SUBMISSION_PERIOD = "APR-2026";
+  public static final String CREATED_BY_USER_ID = "user";
+  public static final String PROVIDER_USER_ID = "provider";
+
+  // Before-state (stored) values
+  public static final String SCHEDULE_REFERENCE = "SCH-1";
+  public static final String CASE_REFERENCE_NUMBER = "CRN-1";
+  public static final String UNIQUE_FILE_NUMBER = "UFN-1";
+  public static final LocalDate CASE_START_DATE = LocalDate.of(2026, 1, 1);
+  public static final LocalDate CASE_CONCLUDED_DATE = LocalDate.of(2026, 2, 1);
+  public static final LocalDate REPRESENTATION_ORDER_DATE = LocalDate.of(2026, 1, 15);
+  public static final String MATTER_TYPE_CODE = "MT-1";
+  public static final String FEE_CODE = "FEE-1";
+  public static final String CATEGORY_OF_LAW = "CAT-1";
+  public static final String CLIENT_FORENAME = "Ada";
+  public static final String CLIENT_SURNAME = "Lovelace";
+  public static final LocalDate CLIENT_DATE_OF_BIRTH = LocalDate.of(1990, 5, 20);
+  public static final String UNIQUE_CLIENT_NUMBER = "UCN-1";
+  public static final String CASE_ID = "CASE-1";
+  public static final String EXEMPTION_CRITERIA_SATISFIED = "Y";
+  public static final BigDecimal NET_PROFIT_COSTS_AMOUNT = new BigDecimal("100.50");
+  public static final int CMRH_ORAL_COUNT = 2;
+  public static final BigDecimal ASSESSED_TOTAL_INCL_VAT = new BigDecimal("250.00");
+
+  // Amended (submitted) values
+  public static final String AMENDED_FEE_CODE = "FEE-2";
+  public static final String AMENDED_CLIENT_FORENAME = "Grace";
+  public static final String AMENDED_CLIENT_SURNAME = "Hopper";
+  public static final LocalDate AMENDED_CLIENT_DATE_OF_BIRTH = LocalDate.of(1985, 3, 10);
+  public static final String AMENDED_CASE_ID = "CASE-2";
+  public static final String AMENDED_UNIQUE_CLIENT_NUMBER = "UCN-2";
+  public static final String AMENDED_UNIQUE_FILE_NUMBER = "UFN-2";
+  public static final String UPDATED_SCHEDULE_REFERENCE = "SCH-2";
+
+  // Serialised JSON property names
+  public static final String FIELD_SCHEDULE_REFERENCE = "scheduleReference";
+  public static final String FIELD_UNIQUE_FILE_NUMBER = "uniqueFileNumber";
+  public static final String FIELD_CASE_REFERENCE_NUMBER = "caseReferenceNumber";
+  public static final String FIELD_HAS_ASSESSMENT = "hasAssessment";
+  public static final String FIELD_CLAIM_ID = "claimId";
+  public static final String FIELD_BEFORE_STATE = "beforeState";
+  public static final String FIELD_REQUEST_PAYLOAD = "requestPayload";
+  public static final String FIELD_POST_AMENDMENT_STATE = "postAmendmentState";
+}


### PR DESCRIPTION
## What
DSTEW-1763: Retrieve claim and build in-memory post-amendment state
[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1763)

## Describe what you did and why.

Implements the in-memory retrieve-and-build step for the synchronous claim amendment flow (child of DSTEW-1593). Given a claim id and a sparse amendment payload, it loads the current claim aggregate, captures a before-state snapshot, and builds the proposed post-amendment state. No persistence and no external calls — a missing claim is returned as Optional.empty() for the parent flow to map to INVALID_CLAIM_NOT_FOUND.

## What's included

**DTOs**: ClaimAmendmentPayload (sparse, presence-aware via JsonNullable), ClaimStateSnapshot (immutable before/after snapshot), ClaimAmendmentState (before/payload/after aggregate), plus CalculatedFeeDetailSnapshot / AssessmentSnapshot.
**Mapper**: ClaimStateSnapshotMapper (MapStruct) assembles the before-state from the claim aggregate.
**Logic**: ClaimAmendmentStateBuilder applies tri-state semantics — omitted → unchanged, explicit null → cleared, value → applied; UCN/UFN are never recomputed from name/DOB/case-id changes.
**Service**: ClaimAmendmentStateService (@Transactional(readOnly = true)) orchestrates retrieval and build.
**Jackson**: registered JsonNullableModule on the primary ObjectMapper and added @Jacksonized so the omitted / explicit-null / value distinctions survive a serialise→deserialise round trip (basis for the future requestPayload/beforeState/diff JSONB columns).
**Tri-state semantics**: JsonNullable<T> preserves omitted (undefined) ≠ explicit null ≠ value end-to-end, with @JsonInclude(NON_ABSENT) dropping omitted fields and writing explicit nulls as "field": null.
## Tests
Unit tests for the mapper, builder, service, and payload (Jackson tri-state).
Integration tests (Testcontainers Postgres): end-to-end retrieve/build, not-found path, no DB side-effects, explicit-null clear, UCN/UFN not recomputed, latest-assessment selection, and real ObjectMapper tri-state serialisation/round-trip.
Centralised shared synthetic test data in AmendmentTestData; seeded values asserted by integration tests promoted to constants in AbstractIntegrationTest so seed data and assertions share a single source of truth.
## Notes
In-memory only; persistence of the amendment history JSONB columns is owned by a follow-up ticket.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
