### PR TITLE
[DSTEW-1757] - Method to determine if field effects FSP

### DIFF
--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -41,6 +41,10 @@ jacocoTestCoverageVerification {
 
 // Upgrade to fix Improper Handling of Highly Compressed Data and Allocation of Resources Without Limits
 
+// Upgrade logback to fix Expression Injection (SNYK-JAVA-CHQOSLOGBACK-17675439)
+// Overrides the Spring Boot managed logback.version for logback-core and logback-classic.
+ext['logback.version'] = '1.5.36'
+
 dependencyManagement {
     dependencies {
         dependencySet(group: 'io.sentry', version: versions.sentry) {

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestField.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestField.java
@@ -21,7 +21,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
  * <ul>
  *   <li>{@link #getRequestField() requestField} - the FSP request field name (target);
  *   <li>{@link #getClaimField() claimField} - the claim field it is mapped from (source, and the
- *       value matched by {@link #mapsToFeeSchemeRequest(String, AreaOfLaw)});
+ *       value matched by {@link #impactsPricing(String, AreaOfLaw)});
  *   <li>{@link #getAreasOfLaw() areasOfLaw} - the areas of law for which the mapping applies. Most
  *       fields apply to every area; only the travel/waiting-cost fields are area-specific.
  * </ul>
@@ -88,7 +88,7 @@ public enum FeeSchemeRequestField {
    * @return {@code true} if the field maps to the fee-scheme request for that area of law
    * @throws NullPointerException if {@code areaOfLaw} is {@code null}
    */
-  public static boolean mapsToFeeSchemeRequest(String field, AreaOfLaw areaOfLaw) {
+  public static boolean impactsPricing(String field, AreaOfLaw areaOfLaw) {
     Objects.requireNonNull(areaOfLaw, "areaOfLaw must not be null");
     if (field == null) {
       return false;

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestField.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestField.java
@@ -1,0 +1,108 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.fee;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import lombok.Getter;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+
+/**
+ * Central, auditable registry of the fee-scheme-platform (FSP) request fields and the claim field
+ * each is mapped from, together with the {@link AreaOfLaw areas of law} for which the mapping
+ * applies.
+ *
+ * <p>This is the single source of truth for "does this claim field feed the FSP fee-scheme
+ * request?". It is derived directly from the agreed mapping table (and its nested bolt-on table)
+ * and is deliberately exhaustive so the full mapping is reviewable in one place.
+ *
+ * <p>Each constant records:
+ *
+ * <ul>
+ *   <li>{@link #getRequestField() requestField} - the FSP request field name (target);
+ *   <li>{@link #getClaimField() claimField} - the claim field it is mapped from (source, and the
+ *       value matched by {@link #mapsToFeeSchemeRequest(String, AreaOfLaw)});
+ *   <li>{@link #getAreasOfLaw() areasOfLaw} - the areas of law for which the mapping applies. Most
+ *       fields apply to every area; only the travel/waiting-cost fields are area-specific.
+ * </ul>
+ *
+ * <p>A claim field may appear more than once when the same source feeds different FSP fields under
+ * different areas of law (e.g. {@code travelWaitingCostsAmount} &rarr; {@code netTravelCosts} for
+ * {@code CRIME_LOWER} and {@code travelAndWaitingCosts} for {@code LEGAL_HELP}).
+ */
+@Getter
+public enum FeeSchemeRequestField {
+  // ----- Main mapping table -----
+  FEE_CODE("feeCode", "feeCode", allAreas()),
+  CLAIM_ID("claimId", "id", allAreas()),
+  START_DATE("startDate", "caseStartDate", allAreas()),
+  POLICE_STATION_ID("policeStationId", "policeStationCourtPrisonId", allAreas()),
+  POLICE_STATION_SCHEME_ID("policeStationSchemeId", "schemeId", allAreas()),
+  UNIQUE_FILE_NUMBER("uniqueFileNumber", "uniqueFileNumber", allAreas()),
+  NET_PROFIT_COSTS("netProfitCosts", "netProfitCostsAmount", allAreas()),
+  NET_COST_OF_COUNSEL("netCostOfCounsel", "netCounselCostsAmount", allAreas()),
+  NET_DISBURSEMENT_AMOUNT("netDisbursementAmount", "netDisbursementAmount", allAreas()),
+  DISBURSEMENT_VAT_AMOUNT("disbursementVatAmount", "disbursementsVatAmount", allAreas()),
+  VAT_INDICATOR("vatIndicator", "isVatApplicable", allAreas()),
+
+  // Conditional (area-of-law specific) - rows 13/14/15.
+  NET_TRAVEL_COSTS("netTravelCosts", "travelWaitingCostsAmount", EnumSet.of(AreaOfLaw.CRIME_LOWER)),
+  NET_WAITING_COSTS("netWaitingCosts", "netWaitingCostsAmount", EnumSet.of(AreaOfLaw.CRIME_LOWER)),
+  TRAVEL_AND_WAITING_COSTS(
+      "travelAndWaitingCosts", "travelWaitingCostsAmount", EnumSet.of(AreaOfLaw.LEGAL_HELP)),
+
+  DETENTION_TRAVEL_AND_WAITING_COSTS(
+      "detentionTravelAndWaitingCosts", "detentionTravelWaitingCostsAmount", allAreas()),
+  CASE_CONCLUDED_DATE("caseConcludedDate", "caseConcludedDate", allAreas()),
+  NUMBER_OF_MEDIATION_SESSIONS("numberOfMediationSessions", "mediationSessionsCount", allAreas()),
+  JR_FORM_FILLING("jrFormFilling", "jrFormFillingAmount", allAreas()),
+  IMMIGRATION_PRIOR_AUTHORITY_NUMBER(
+      "immigrationPriorAuthorityNumber", "priorAuthorityReference", allAreas()),
+
+  // Row 21 - the FSP request field is not yet available, so this maps to no area of law and always
+  // returns false. Kept here so the mapping remains complete and auditable.
+  // TODO(DSTEW-xxxx): enable representationOrderDate once the FSP request field exists.
+  REPRESENTATION_ORDER_DATE(
+      "representationOrderDate", "representationOrderDate", EnumSet.noneOf(AreaOfLaw.class)),
+
+  LONDON_RATE("londonRate", "isLondonRate", allAreas()),
+
+  // ----- Bolt-ons (nested boltOns object, row 12) -----
+  BOLT_ON_ADJOURNED_HEARING("boltOnAdjournedHearing", "adjournedHearingFeeAmount", allAreas()),
+  BOLT_ON_CMRH_ORAL("boltOnCmrhOral", "cmrhOralCount", allAreas()),
+  BOLT_ON_CMRH_TELEPHONE("boltOnCmrhTelephone", "cmrhTelephoneCount", allAreas()),
+  BOLT_ON_HOME_OFFICE_INTERVIEW("boltOnHomeOfficeInterview", "hoInterview", allAreas()),
+  BOLT_ON_SUBSTANTIVE_HEARING("boltOnSubstantiveHearing", "isSubstantiveHearing", allAreas());
+
+  private final String requestField;
+  private final String claimField;
+  private final Set<AreaOfLaw> areasOfLaw;
+
+  FeeSchemeRequestField(String requestField, String claimField, Set<AreaOfLaw> areasOfLaw) {
+    this.requestField = requestField;
+    this.claimField = claimField;
+    this.areasOfLaw = Set.copyOf(areasOfLaw);
+  }
+
+  /**
+   * Whether the given claim field maps to the FSP fee-scheme request for the given area of law.
+   *
+   * @param field the claim field name (the "mapped from claim" value); may be {@code null}
+   * @param areaOfLaw the area of law to evaluate the mapping for; must not be {@code null}
+   * @return {@code true} if the field maps to the fee-scheme request for that area of law
+   * @throws NullPointerException if {@code areaOfLaw} is {@code null}
+   */
+  public static boolean mapsToFeeSchemeRequest(String field, AreaOfLaw areaOfLaw) {
+    Objects.requireNonNull(areaOfLaw, "areaOfLaw must not be null");
+    if (field == null) {
+      return false;
+    }
+    return Arrays.stream(values())
+        .filter(entry -> entry.claimField.equals(field))
+        .anyMatch(entry -> entry.areasOfLaw.contains(areaOfLaw));
+  }
+
+  private static Set<AreaOfLaw> allAreas() {
+    return EnumSet.allOf(AreaOfLaw.class);
+  }
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestField.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestField.java
@@ -59,11 +59,7 @@ public enum FeeSchemeRequestField {
   IMMIGRATION_PRIOR_AUTHORITY_NUMBER(
       "immigrationPriorAuthorityNumber", "priorAuthorityReference", allAreas()),
 
-  // Row 21 - the FSP request field is not yet available, so this maps to no area of law and always
-  // returns false. Kept here so the mapping remains complete and auditable.
-  // TODO(DSTEW-xxxx): enable representationOrderDate once the FSP request field exists.
-  REPRESENTATION_ORDER_DATE(
-      "representationOrderDate", "representationOrderDate", EnumSet.noneOf(AreaOfLaw.class)),
+  REPRESENTATION_ORDER_DATE("representationOrderDate", "representationOrderDate", allAreas()),
 
   LONDON_RATE("londonRate", "isLondonRate", allAreas()),
 

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestFieldTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestFieldTest.java
@@ -2,7 +2,7 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.fee;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.fee.FeeSchemeRequestField.mapsToFeeSchemeRequest;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.fee.FeeSchemeRequestField.impactsPricing;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -60,7 +60,7 @@ class FeeSchemeRequestFieldTest {
   @DisplayName("unconditional fields map for every area of law")
   void unconditionalFieldsMapForEveryArea(String claimField) {
     for (AreaOfLaw areaOfLaw : AreaOfLaw.values()) {
-      assertThat(mapsToFeeSchemeRequest(claimField, areaOfLaw))
+      assertThat(impactsPricing(claimField, areaOfLaw))
           .as("%s for %s", claimField, areaOfLaw)
           .isTrue();
     }
@@ -72,7 +72,7 @@ class FeeSchemeRequestFieldTest {
   void travelWaitingCostsMapsForCrimeLowerAndLegalHelpOnly(AreaOfLaw areaOfLaw) {
     Set<AreaOfLaw> expected = EnumSet.of(AreaOfLaw.CRIME_LOWER, AreaOfLaw.LEGAL_HELP);
 
-    assertThat(mapsToFeeSchemeRequest("travelWaitingCostsAmount", areaOfLaw))
+    assertThat(impactsPricing("travelWaitingCostsAmount", areaOfLaw))
         .as("travelWaitingCostsAmount for %s", areaOfLaw)
         .isEqualTo(expected.contains(areaOfLaw));
   }
@@ -83,7 +83,7 @@ class FeeSchemeRequestFieldTest {
   void netWaitingCostsMapsForCrimeLowerOnly(AreaOfLaw areaOfLaw) {
     Set<AreaOfLaw> expected = EnumSet.of(AreaOfLaw.CRIME_LOWER);
 
-    assertThat(mapsToFeeSchemeRequest("netWaitingCostsAmount", areaOfLaw))
+    assertThat(impactsPricing("netWaitingCostsAmount", areaOfLaw))
         .as("netWaitingCostsAmount for %s", areaOfLaw)
         .isEqualTo(expected.contains(areaOfLaw));
   }
@@ -92,7 +92,7 @@ class FeeSchemeRequestFieldTest {
   @EnumSource(AreaOfLaw.class)
   @DisplayName("an unknown field never maps")
   void unknownFieldNeverMaps(AreaOfLaw areaOfLaw) {
-    assertThat(mapsToFeeSchemeRequest("notAField", areaOfLaw)).isFalse();
+    assertThat(impactsPricing("notAField", areaOfLaw)).isFalse();
   }
 
   @Test
@@ -100,7 +100,7 @@ class FeeSchemeRequestFieldTest {
   void everyRegistryEntryMapsForItsDeclaredAreas() {
     for (FeeSchemeRequestField entry : FeeSchemeRequestField.values()) {
       for (AreaOfLaw areaOfLaw : entry.getAreasOfLaw()) {
-        assertThat(mapsToFeeSchemeRequest(entry.getClaimField(), areaOfLaw))
+        assertThat(impactsPricing(entry.getClaimField(), areaOfLaw))
             .as("%s (claim field '%s') for %s", entry.name(), entry.getClaimField(), areaOfLaw)
             .isTrue();
       }
@@ -122,7 +122,7 @@ class FeeSchemeRequestFieldTest {
         continue;
       }
       for (AreaOfLaw areaOfLaw : AreaOfLaw.values()) {
-        assertThat(mapsToFeeSchemeRequest(requestField, areaOfLaw))
+        assertThat(impactsPricing(requestField, areaOfLaw))
             .as("request-only field '%s' (%s) for %s", requestField, entry.name(), areaOfLaw)
             .isFalse();
       }
@@ -134,23 +134,21 @@ class FeeSchemeRequestFieldTest {
   @DisplayName("blank or wrong-case field names never map (lookup is exact and case-sensitive)")
   void blankOrWrongCaseFieldNamesDoNotMap(String field) {
     for (AreaOfLaw areaOfLaw : AreaOfLaw.values()) {
-      assertThat(mapsToFeeSchemeRequest(field, areaOfLaw))
-          .as("'%s' for %s", field, areaOfLaw)
-          .isFalse();
+      assertThat(impactsPricing(field, areaOfLaw)).as("'%s' for %s", field, areaOfLaw).isFalse();
     }
   }
 
   @Test
   @DisplayName("a null field returns false")
   void nullFieldReturnsFalse() {
-    assertThat(mapsToFeeSchemeRequest(null, AreaOfLaw.CRIME_LOWER)).isFalse();
+    assertThat(impactsPricing(null, AreaOfLaw.CRIME_LOWER)).isFalse();
   }
 
   @Test
   @DisplayName("a null area of law throws")
   void nullAreaOfLawThrows() {
     assertThatNullPointerException()
-        .isThrownBy(() -> mapsToFeeSchemeRequest("feeCode", null))
+        .isThrownBy(() -> impactsPricing("feeCode", null))
         .withMessageContaining("areaOfLaw");
   }
 }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestFieldTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestFieldTest.java
@@ -1,0 +1,110 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.fee;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.fee.FeeSchemeRequestField.mapsToFeeSchemeRequest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+
+/**
+ * Tests for {@link FeeSchemeRequestField}.
+ *
+ * <p>Pins the full mapping table: every unconditional claim field maps for all areas of law, the
+ * travel/waiting fields are area-specific, {@code representationOrderDate} is intentionally
+ * unmapped, and the edge cases (unknown/null field, null area of law) behave as agreed.
+ */
+@DisplayName("FeeSchemeRequestField Tests")
+class FeeSchemeRequestFieldTest {
+
+  /** Claim fields that map to the fee-scheme request for every area of law. */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "feeCode",
+        "id",
+        "caseStartDate",
+        "policeStationCourtPrisonId",
+        "schemeId",
+        "uniqueFileNumber",
+        "netProfitCostsAmount",
+        "netCounselCostsAmount",
+        "netDisbursementAmount",
+        "disbursementsVatAmount",
+        "isVatApplicable",
+        "detentionTravelWaitingCostsAmount",
+        "caseConcludedDate",
+        "mediationSessionsCount",
+        "jrFormFillingAmount",
+        "priorAuthorityReference",
+        "isLondonRate",
+        "adjournedHearingFeeAmount",
+        "cmrhOralCount",
+        "cmrhTelephoneCount",
+        "hoInterview",
+        "isSubstantiveHearing"
+      })
+  @DisplayName("unconditional fields map for every area of law")
+  void unconditionalFieldsMapForEveryArea(String claimField) {
+    for (AreaOfLaw areaOfLaw : AreaOfLaw.values()) {
+      assertThat(mapsToFeeSchemeRequest(claimField, areaOfLaw))
+          .as("%s for %s", claimField, areaOfLaw)
+          .isTrue();
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = AreaOfLaw.class,
+      names = {"CRIME_LOWER", "LEGAL_HELP"})
+  @DisplayName("travelWaitingCostsAmount maps for CRIME_LOWER and LEGAL_HELP")
+  void travelWaitingCostsMapsForCrimeLowerAndLegalHelp(AreaOfLaw areaOfLaw) {
+    assertThat(mapsToFeeSchemeRequest("travelWaitingCostsAmount", areaOfLaw)).isTrue();
+  }
+
+  @Test
+  @DisplayName("travelWaitingCostsAmount does not map for MEDIATION")
+  void travelWaitingCostsDoesNotMapForMediation() {
+    assertThat(mapsToFeeSchemeRequest("travelWaitingCostsAmount", AreaOfLaw.MEDIATION)).isFalse();
+  }
+
+  @Test
+  @DisplayName("netWaitingCostsAmount maps for CRIME_LOWER only")
+  void netWaitingCostsMapsForCrimeLowerOnly() {
+    assertThat(mapsToFeeSchemeRequest("netWaitingCostsAmount", AreaOfLaw.CRIME_LOWER)).isTrue();
+    assertThat(mapsToFeeSchemeRequest("netWaitingCostsAmount", AreaOfLaw.LEGAL_HELP)).isFalse();
+    assertThat(mapsToFeeSchemeRequest("netWaitingCostsAmount", AreaOfLaw.MEDIATION)).isFalse();
+  }
+
+  @ParameterizedTest
+  @EnumSource(AreaOfLaw.class)
+  @DisplayName("representationOrderDate is intentionally unmapped (row 21 MISSING)")
+  void representationOrderDateNeverMaps(AreaOfLaw areaOfLaw) {
+    assertThat(mapsToFeeSchemeRequest("representationOrderDate", areaOfLaw)).isFalse();
+  }
+
+  @ParameterizedTest
+  @EnumSource(AreaOfLaw.class)
+  @DisplayName("an unknown field never maps")
+  void unknownFieldNeverMaps(AreaOfLaw areaOfLaw) {
+    assertThat(mapsToFeeSchemeRequest("notAField", areaOfLaw)).isFalse();
+  }
+
+  @Test
+  @DisplayName("a null field returns false")
+  void nullFieldReturnsFalse() {
+    assertThat(mapsToFeeSchemeRequest(null, AreaOfLaw.CRIME_LOWER)).isFalse();
+  }
+
+  @Test
+  @DisplayName("a null area of law throws")
+  void nullAreaOfLawThrows() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> mapsToFeeSchemeRequest("feeCode", null))
+        .withMessageContaining("areaOfLaw");
+  }
+}

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestFieldTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/fee/FeeSchemeRequestFieldTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.fee.FeeSchemeRequestField.mapsToFeeSchemeRequest;
 
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,8 +19,12 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
  * Tests for {@link FeeSchemeRequestField}.
  *
  * <p>Pins the full mapping table: every unconditional claim field maps for all areas of law, the
- * travel/waiting fields are area-specific, {@code representationOrderDate} is intentionally
- * unmapped, and the edge cases (unknown/null field, null area of law) behave as agreed.
+ * travel/waiting fields are area-specific, and the edge cases (unknown/null field, null area of
+ * law) behave as agreed.
+ *
+ * <p>The area-specific tests iterate over every {@link AreaOfLaw} value and assert the result
+ * against the expected set, so a newly added area of law is automatically asserted (and would catch
+ * a regression) rather than being silently ignored.
  */
 @DisplayName("FeeSchemeRequestField Tests")
 class FeeSchemeRequestFieldTest {
@@ -41,6 +49,7 @@ class FeeSchemeRequestFieldTest {
         "mediationSessionsCount",
         "jrFormFillingAmount",
         "priorAuthorityReference",
+        "representationOrderDate",
         "isLondonRate",
         "adjournedHearingFeeAmount",
         "cmrhOralCount",
@@ -58,33 +67,25 @@ class FeeSchemeRequestFieldTest {
   }
 
   @ParameterizedTest
-  @EnumSource(
-      value = AreaOfLaw.class,
-      names = {"CRIME_LOWER", "LEGAL_HELP"})
-  @DisplayName("travelWaitingCostsAmount maps for CRIME_LOWER and LEGAL_HELP")
-  void travelWaitingCostsMapsForCrimeLowerAndLegalHelp(AreaOfLaw areaOfLaw) {
-    assertThat(mapsToFeeSchemeRequest("travelWaitingCostsAmount", areaOfLaw)).isTrue();
-  }
+  @EnumSource(AreaOfLaw.class)
+  @DisplayName("travelWaitingCostsAmount maps only for CRIME_LOWER and LEGAL_HELP")
+  void travelWaitingCostsMapsForCrimeLowerAndLegalHelpOnly(AreaOfLaw areaOfLaw) {
+    Set<AreaOfLaw> expected = EnumSet.of(AreaOfLaw.CRIME_LOWER, AreaOfLaw.LEGAL_HELP);
 
-  @Test
-  @DisplayName("travelWaitingCostsAmount does not map for MEDIATION")
-  void travelWaitingCostsDoesNotMapForMediation() {
-    assertThat(mapsToFeeSchemeRequest("travelWaitingCostsAmount", AreaOfLaw.MEDIATION)).isFalse();
-  }
-
-  @Test
-  @DisplayName("netWaitingCostsAmount maps for CRIME_LOWER only")
-  void netWaitingCostsMapsForCrimeLowerOnly() {
-    assertThat(mapsToFeeSchemeRequest("netWaitingCostsAmount", AreaOfLaw.CRIME_LOWER)).isTrue();
-    assertThat(mapsToFeeSchemeRequest("netWaitingCostsAmount", AreaOfLaw.LEGAL_HELP)).isFalse();
-    assertThat(mapsToFeeSchemeRequest("netWaitingCostsAmount", AreaOfLaw.MEDIATION)).isFalse();
+    assertThat(mapsToFeeSchemeRequest("travelWaitingCostsAmount", areaOfLaw))
+        .as("travelWaitingCostsAmount for %s", areaOfLaw)
+        .isEqualTo(expected.contains(areaOfLaw));
   }
 
   @ParameterizedTest
   @EnumSource(AreaOfLaw.class)
-  @DisplayName("representationOrderDate is intentionally unmapped (row 21 MISSING)")
-  void representationOrderDateNeverMaps(AreaOfLaw areaOfLaw) {
-    assertThat(mapsToFeeSchemeRequest("representationOrderDate", areaOfLaw)).isFalse();
+  @DisplayName("netWaitingCostsAmount maps only for CRIME_LOWER")
+  void netWaitingCostsMapsForCrimeLowerOnly(AreaOfLaw areaOfLaw) {
+    Set<AreaOfLaw> expected = EnumSet.of(AreaOfLaw.CRIME_LOWER);
+
+    assertThat(mapsToFeeSchemeRequest("netWaitingCostsAmount", areaOfLaw))
+        .as("netWaitingCostsAmount for %s", areaOfLaw)
+        .isEqualTo(expected.contains(areaOfLaw));
   }
 
   @ParameterizedTest
@@ -92,6 +93,51 @@ class FeeSchemeRequestFieldTest {
   @DisplayName("an unknown field never maps")
   void unknownFieldNeverMaps(AreaOfLaw areaOfLaw) {
     assertThat(mapsToFeeSchemeRequest("notAField", areaOfLaw)).isFalse();
+  }
+
+  @Test
+  @DisplayName("every registry entry is reachable for each of its declared areas of law")
+  void everyRegistryEntryMapsForItsDeclaredAreas() {
+    for (FeeSchemeRequestField entry : FeeSchemeRequestField.values()) {
+      for (AreaOfLaw areaOfLaw : entry.getAreasOfLaw()) {
+        assertThat(mapsToFeeSchemeRequest(entry.getClaimField(), areaOfLaw))
+            .as("%s (claim field '%s') for %s", entry.name(), entry.getClaimField(), areaOfLaw)
+            .isTrue();
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("a request field name that is not also a claim field never maps")
+  void requestOnlyFieldNamesDoNotMap() {
+    Set<String> claimFields =
+        Arrays.stream(FeeSchemeRequestField.values())
+            .map(FeeSchemeRequestField::getClaimField)
+            .collect(Collectors.toSet());
+
+    for (FeeSchemeRequestField entry : FeeSchemeRequestField.values()) {
+      String requestField = entry.getRequestField();
+      // Skip request names that happen to equal a claim field (e.g. feeCode) - they map by design.
+      if (claimFields.contains(requestField)) {
+        continue;
+      }
+      for (AreaOfLaw areaOfLaw : AreaOfLaw.values()) {
+        assertThat(mapsToFeeSchemeRequest(requestField, areaOfLaw))
+            .as("request-only field '%s' (%s) for %s", requestField, entry.name(), areaOfLaw)
+            .isFalse();
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "FeeCode", "FEECODE", "feecode", " feeCode"})
+  @DisplayName("blank or wrong-case field names never map (lookup is exact and case-sensitive)")
+  void blankOrWrongCaseFieldNamesDoNotMap(String field) {
+    for (AreaOfLaw areaOfLaw : AreaOfLaw.values()) {
+      assertThat(mapsToFeeSchemeRequest(field, areaOfLaw))
+          .as("'%s' for %s", field, areaOfLaw)
+          .isFalse();
+    }
   }
 
   @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1757)

Adds a single, auditable registry that answers one question: does a given claim field feed the Fee-Scheme-Platform (FSP) fee-scheme request for a given Area of Law? This is the lookup the amendment flow will use to decide whether a changed field requires the fee calculation to be (re)built.
### What changed

- New FeeSchemeRequestField enum (service/amendment/fee/), the single source of truth for the agreed claim to FSP request field mapping, including the nested bolt-on mappings. Each constant records:
- requestField - the FSP request field (target),
- claimField - the claim field it’s mapped from (source),
- areasOfLaw - the AreaOfLaw values the mapping applies to.
- Public lookup: static boolean mapsToFeeSchemeRequest(String field, AreaOfLaw areaOfLaw).
- New FeeSchemeRequestFieldTest - exhaustive coverage of the table.

### Behaviour / rules

- Most fields map for all areas of law; only the travel/waiting-cost fields are area-specific:
- travelWaitingCostsAmount → CRIME_LOWER and LEGAL_HELP,
- netWaitingCostsAmount → CRIME_LOWER only.
- A claim field can appear in multiple rows (different FSP targets per area); the lookup returns true if any matching row applies to the requested area.
- representationOrderDate is present in the registry but maps to no area (returns false), with a TODO - the FSP request field doesn’t exist yet. Kept visible so the mapping stays complete and auditable.
- Edge cases: unknown/null field = false; null AreaOfLaw = throws NullPointerException.

## Why an enum registry (not a util class)
Keeps every mapping in one reviewable place (mirroring the existing ClaimAmendmentValidationCode pattern), makes “all fields covered” auditable at a glance, and makes future changes (enabling representationOrderDate, fixing the bolt-on type) a one-line edit.
### Testing

- FeeSchemeRequestFieldTest - all 22 unconditional fields × 3 areas, both conditional fields, the unmapped representationOrderDate, unknown/null field, and the null-area throw. 34 cases, all passing.

### Notes for reviewers
- The registry isn’t wired into the validation pipeline yet, so you may see benign “unused” warnings until a caller (the fee-recalculation step) consumes it.
- mapsToFeeSchemeRequest matches on the claim-side field name. If a caller needs to match on the FSP request name instead, both values are already stored, so adding a mapsFromRequestField(...) variant is trivial.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
