### PR TITLE
feat(DSTEW-1806): Added fsp message code in validation log

### DIFF
--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -2248,6 +2248,7 @@ components:
           type: string
         message_code:
           type: string
+          maxLength: 20
           description: Message code from FSP payload (e.g. WARFAM1, ERRALL1).
     validation_message_base:
       type: object

--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -2248,7 +2248,7 @@ components:
           type: string
         message_code:
           type: string
-          description: Message code from FSP payload (e.g. WARFAM1, ERRALL1). Set only when source is FSP and type is ERROR or WARNING.
+          description: Message code from FSP payload (e.g. WARFAM1, ERRALL1).
     validation_message_base:
       type: object
       description: Validation message
@@ -2270,7 +2270,8 @@ components:
           type: string
         message_code:
           type: string
-          description: Message code from FSP payload. Only present when source is FSP and type is ERROR or WARNING.
+          maxLength: 20
+          description: Message code from FSP payload.
         client_forename:
           type: string
           description: Client 1 forename from the associated claim

--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -2246,6 +2246,9 @@ components:
           type: string
         technical_message:
           type: string
+        message_code:
+          type: string
+          description: Message code from FSP payload (e.g. WARFAM1, ERRALL1). Set only when source is FSP and type is ERROR or WARNING.
     validation_message_base:
       type: object
       description: Validation message
@@ -2265,6 +2268,9 @@ components:
           type: string
         display_message:
           type: string
+        message_code:
+          type: string
+          description: Message code from FSP payload. Only present when source is FSP and type is ERROR or WARNING.
         client_forename:
           type: string
           description: Client 1 forename from the associated claim

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AbstractIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AbstractIntegrationTest.java
@@ -563,6 +563,7 @@ public abstract class AbstractIntegrationTest {
                 "SYSTEM",
                 "Missing case reference",
                 "Field `caseReferenceNumber` is required",
+                null, // messageCode - null for SYSTEM source
                 CREATED_ON,
                 null),
             new ValidationMessageLog(
@@ -573,6 +574,7 @@ public abstract class AbstractIntegrationTest {
                 "SYSTEM",
                 "Missing UFN",
                 "Field `uniqueFileNumber` is required",
+                null, // messageCode - null for SYSTEM source
                 CREATED_ON,
                 null)));
   }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ValidationMessagesControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ValidationMessagesControllerIntegrationTest.java
@@ -100,4 +100,81 @@ public class ValidationMessagesControllerIntegrationTest extends AbstractIntegra
     assertThat(msg.getUniqueClientNumber()).isEqualTo("UCN_111");
     validationMessageLogRepository.deleteAll();
   }
+
+  @Test
+  @DisplayName(
+      "getValidationMessages returns message_code for FSP-sourced messages when present in response")
+  void getValidationMessages_shouldReturnMessageCodeForFspMessages() throws Exception {
+    // given: an FSP-sourced ERROR validation message with a messageCode
+    ValidationMessageLog fspLog = new ValidationMessageLog();
+    fspLog.setId(Uuid7.timeBasedUuid());
+    fspLog.setSubmissionId(submission1.getId());
+    fspLog.setClaimId(CLAIM_1_ID);
+    fspLog.setType(ValidationMessageType.ERROR);
+    fspLog.setSource("FSP");
+    fspLog.setDisplayMessage("Enter a valid Fee Code.");
+    fspLog.setTechnicalMessage("Fee Code is invalid");
+    fspLog.setMessageCode("ERRALL1");
+    fspLog.setCreatedOn(Instant.now());
+    validationMessageLogRepository.save(fspLog);
+
+    // when: calling GET /api/v1/validation-messages filtered by submissionId and claimId
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                get(API_URI_PREFIX + "/validation-messages")
+                    .param("submission-id", submission1.getId().toString())
+                    .param("claim-id", CLAIM_1_ID.toString())
+                    .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // then: message_code is present in the response item
+    ValidationMessagesResponse response =
+        OBJECT_MAPPER.readValue(
+            mvcResult.getResponse().getContentAsString(), ValidationMessagesResponse.class);
+    assertThat(response.getTotalElements()).isEqualTo(1);
+    ValidationMessageBase msg = response.getContent().getFirst();
+    assertThat(msg.getId()).isEqualTo(fspLog.getId());
+    assertThat(msg.getSource()).isEqualTo("FSP");
+    assertThat(msg.getType()).isEqualTo(ValidationMessageType.ERROR);
+    assertThat(msg.getMessageCode()).isEqualTo("ERRALL1");
+    validationMessageLogRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("getValidationMessages returns null message_code for non-FSP messages in response")
+  void getValidationMessages_shouldReturnNullMessageCodeForNonFspMessages() throws Exception {
+    // given: a SYSTEM-sourced validation message (no messageCode)
+    ValidationMessageLog systemLog = new ValidationMessageLog();
+    systemLog.setId(Uuid7.timeBasedUuid());
+    systemLog.setSubmissionId(submission1.getId());
+    systemLog.setClaimId(CLAIM_1_ID);
+    systemLog.setType(ValidationMessageType.ERROR);
+    systemLog.setSource("SYSTEM");
+    systemLog.setDisplayMessage("Missing case reference");
+    systemLog.setCreatedOn(Instant.now());
+    validationMessageLogRepository.save(systemLog);
+
+    // when: calling GET /api/v1/validation-messages
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                get(API_URI_PREFIX + "/validation-messages")
+                    .param("submission-id", submission1.getId().toString())
+                    .param("claim-id", CLAIM_1_ID.toString())
+                    .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // then: message_code is null for non-FSP messages
+    ValidationMessagesResponse response =
+        OBJECT_MAPPER.readValue(
+            mvcResult.getResponse().getContentAsString(), ValidationMessagesResponse.class);
+    assertThat(response.getTotalElements()).isEqualTo(1);
+    ValidationMessageBase msg = response.getContent().getFirst();
+    assertThat(msg.getSource()).isEqualTo("SYSTEM");
+    assertThat(msg.getMessageCode()).isNull();
+    validationMessageLogRepository.deleteAll();
+  }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepositoryIntegrationTest.java
@@ -5,6 +5,7 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUt
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_2_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_1_ID;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +24,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrati
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ValidationMessageLog;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ValidationMessageType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.projection.ValidationMessageWithClaimDetailsProjection;
+import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @DisplayName("ValidationMessageLogRepository Integration Test")
@@ -142,5 +144,157 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
             SUBMISSION_1_ID, null, null, null, pageable);
 
     assertThat(result.getTotalElements()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("Should persist messageCode for FSP messages with ERROR type")
+  void shouldPersistMessageCodeForFspErrorMessage() {
+    UUID submissionId = SUBMISSION_1_ID;
+    UUID claimId = CLAIM_1_ID;
+    String messageCode = "ERRALL1";
+
+    ValidationMessageLog fspErrorMessage = new ValidationMessageLog();
+    fspErrorMessage.setId(Uuid7.timeBasedUuid());
+    fspErrorMessage.setSubmissionId(submissionId);
+    fspErrorMessage.setClaimId(claimId);
+    fspErrorMessage.setType(ValidationMessageType.ERROR);
+    fspErrorMessage.setSource("FSP");
+    fspErrorMessage.setDisplayMessage("Enter a valid Fee Code.");
+    fspErrorMessage.setTechnicalMessage("Fee Code is invalid");
+    fspErrorMessage.setMessageCode(messageCode);
+
+    validationMessageLogRepository.save(fspErrorMessage);
+
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<ValidationMessageWithClaimDetailsProjection> result =
+        validationMessageLogRepository.findWithClaimDetailsByFilters(
+            submissionId, claimId, ValidationMessageType.ERROR, "FSP", pageable);
+
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    ValidationMessageWithClaimDetailsProjection retrieved = result.getContent().getFirst();
+    assertThat(retrieved.getMessageCode()).isEqualTo(messageCode);
+    assertThat(retrieved.getSource()).isEqualTo("FSP");
+    assertThat(retrieved.getType()).isEqualTo(ValidationMessageType.ERROR);
+  }
+
+  @Test
+  @DisplayName("Should persist messageCode for FSP messages with WARNING type")
+  void shouldPersistMessageCodeForFspWarningMessage() {
+    UUID submissionId = SUBMISSION_1_ID;
+    UUID claimId = CLAIM_2_ID;
+    String messageCode = "WARFAM1";
+
+    ValidationMessageLog fspWarningMessage = new ValidationMessageLog();
+    fspWarningMessage.setId(Uuid7.timeBasedUuid());
+    fspWarningMessage.setSubmissionId(submissionId);
+    fspWarningMessage.setClaimId(claimId);
+    fspWarningMessage.setType(ValidationMessageType.WARNING);
+    fspWarningMessage.setSource("FSP");
+    fspWarningMessage.setDisplayMessage(
+        "The claim exceeds the Escape Case Threshold. "
+            + "An Escape Case Claim must be submitted for further costs to be paid. ");
+    fspWarningMessage.setTechnicalMessage("Claim exceeds the Escape Case Threshold.");
+    fspWarningMessage.setMessageCode(messageCode);
+
+    validationMessageLogRepository.save(fspWarningMessage);
+
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<ValidationMessageWithClaimDetailsProjection> result =
+        validationMessageLogRepository.findWithClaimDetailsByFilters(
+            submissionId, claimId, ValidationMessageType.WARNING, "FSP", pageable);
+
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    ValidationMessageWithClaimDetailsProjection retrieved = result.getContent().getFirst();
+    assertThat(retrieved.getMessageCode()).isEqualTo(messageCode);
+    assertThat(retrieved.getSource()).isEqualTo("FSP");
+    assertThat(retrieved.getType()).isEqualTo(ValidationMessageType.WARNING);
+  }
+
+  @Test
+  @DisplayName("Should have null messageCode for non-FSP messages")
+  void shouldHaveNullMessageCodeForNonFspMessages() {
+    Pageable pageable = PageRequest.of(0, 10);
+
+    Page<ValidationMessageWithClaimDetailsProjection> result =
+        validationMessageLogRepository.findWithClaimDetailsByFilters(
+            SUBMISSION_1_ID, CLAIM_1_ID, ValidationMessageType.ERROR, "SYSTEM", pageable);
+
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    ValidationMessageWithClaimDetailsProjection retrieved = result.getContent().getFirst();
+    assertThat(retrieved.getMessageCode()).isNull();
+    assertThat(retrieved.getSource()).isEqualTo("SYSTEM");
+  }
+
+  @Test
+  @DisplayName(
+      "Should retain distinct messages with same display_message but different messageCode")
+  void shouldRetainDistinctMessagesWithSameDisplayMessageButDifferentCode() {
+    UUID submissionId = SUBMISSION_1_ID;
+    UUID claimId = CLAIM_1_ID;
+    String identicalDisplayMessage = "FSP validation issue";
+
+    // Create two FSP messages with same display text but different codes
+    ValidationMessageLog fspMessage1 = new ValidationMessageLog();
+    fspMessage1.setId(Uuid7.timeBasedUuid());
+    fspMessage1.setSubmissionId(submissionId);
+    fspMessage1.setClaimId(claimId);
+    fspMessage1.setType(ValidationMessageType.ERROR);
+    fspMessage1.setSource("FSP");
+    fspMessage1.setDisplayMessage(identicalDisplayMessage);
+    fspMessage1.setTechnicalMessage("Case start date not found");
+    fspMessage1.setMessageCode("ERRIA2");
+
+    ValidationMessageLog fspMessage2 = new ValidationMessageLog();
+    fspMessage2.setId(Uuid7.timeBasedUuid());
+    fspMessage2.setSubmissionId(submissionId);
+    fspMessage2.setClaimId(claimId);
+    fspMessage2.setType(ValidationMessageType.ERROR);
+    fspMessage2.setSource("FSP");
+    fspMessage2.setDisplayMessage(identicalDisplayMessage);
+    fspMessage2.setTechnicalMessage("Invalid Case start date");
+    fspMessage2.setMessageCode("ERRIA1");
+
+    validationMessageLogRepository.saveAll(List.of(fspMessage1, fspMessage2));
+
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<ValidationMessageWithClaimDetailsProjection> result =
+        validationMessageLogRepository.findWithClaimDetailsByFilters(
+            submissionId, claimId, ValidationMessageType.ERROR, "FSP", pageable);
+
+    // Both messages should be retrieved and distinguishable by their unique messageCode
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    var codes =
+        result.getContent().stream()
+            .map(ValidationMessageWithClaimDetailsProjection::getMessageCode)
+            .toList();
+    assertThat(codes).contains("ERRIA1", "ERRIA2");
+  }
+
+  @Test
+  @DisplayName("Should have null messageCode for FSP message with WARNING type when not provided")
+  void shouldHaveNullMessageCodeForFspMessageWhenNotProvided() {
+    UUID submissionId = SUBMISSION_1_ID;
+    UUID claimId = CLAIM_2_ID;
+
+    ValidationMessageLog fspWarningNoCode = new ValidationMessageLog();
+    fspWarningNoCode.setId(Uuid7.timeBasedUuid());
+    fspWarningNoCode.setSubmissionId(submissionId);
+    fspWarningNoCode.setClaimId(claimId);
+    fspWarningNoCode.setType(ValidationMessageType.WARNING);
+    fspWarningNoCode.setSource("FSP");
+    fspWarningNoCode.setDisplayMessage("Warning without code");
+    fspWarningNoCode.setTechnicalMessage("Technical details for FSP warning");
+    // messageCode not set, should be null
+
+    validationMessageLogRepository.save(fspWarningNoCode);
+
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<ValidationMessageWithClaimDetailsProjection> result =
+        validationMessageLogRepository.findWithClaimDetailsByFilters(
+            submissionId, claimId, ValidationMessageType.WARNING, "FSP", pageable);
+
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    ValidationMessageWithClaimDetailsProjection retrieved = result.getContent().getFirst();
+    assertThat(retrieved.getMessageCode()).isNull();
   }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepositoryIntegrationTest.java
@@ -151,6 +151,7 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
     String messageCode = "ERRALL1";
 
     ValidationMessageLog fspErrorMessage = new ValidationMessageLog();
+    fspErrorMessage.setId(UUID.randomUUID());
     fspErrorMessage.setSubmissionId(SUBMISSION_1_ID);
     fspErrorMessage.setClaimId(CLAIM_1_ID);
     fspErrorMessage.setType(ValidationMessageType.ERROR);
@@ -179,6 +180,7 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
     String messageCode = "WARFAM1";
 
     ValidationMessageLog fspWarningMessage = new ValidationMessageLog();
+    fspWarningMessage.setId(UUID.randomUUID());
     fspWarningMessage.setSubmissionId(SUBMISSION_1_ID);
     fspWarningMessage.setClaimId(CLAIM_2_ID);
     fspWarningMessage.setType(ValidationMessageType.WARNING);
@@ -226,6 +228,7 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
 
     // Create two FSP messages with same display text but different codes
     ValidationMessageLog fspMessage1 = new ValidationMessageLog();
+    fspMessage1.setId(UUID.randomUUID());
     fspMessage1.setSubmissionId(SUBMISSION_1_ID);
     fspMessage1.setClaimId(CLAIM_1_ID);
     fspMessage1.setType(ValidationMessageType.ERROR);
@@ -235,6 +238,7 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
     fspMessage1.setMessageCode("ERRIA2");
 
     ValidationMessageLog fspMessage2 = new ValidationMessageLog();
+    fspMessage2.setId(UUID.randomUUID());
     fspMessage2.setSubmissionId(SUBMISSION_1_ID);
     fspMessage2.setClaimId(CLAIM_1_ID);
     fspMessage2.setType(ValidationMessageType.ERROR);
@@ -264,6 +268,7 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
   void shouldHaveNullMessageCodeForFspMessageWhenNotProvided() {
 
     ValidationMessageLog fspWarningNoCode = new ValidationMessageLog();
+    fspWarningNoCode.setId(UUID.randomUUID());
     fspWarningNoCode.setSubmissionId(SUBMISSION_1_ID);
     fspWarningNoCode.setClaimId(CLAIM_2_ID);
     fspWarningNoCode.setType(ValidationMessageType.WARNING);

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepositoryIntegrationTest.java
@@ -24,7 +24,6 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrati
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ValidationMessageLog;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ValidationMessageType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.projection.ValidationMessageWithClaimDetailsProjection;
-import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @DisplayName("ValidationMessageLogRepository Integration Test")
@@ -149,14 +148,11 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
   @Test
   @DisplayName("Should persist messageCode for FSP messages with ERROR type")
   void shouldPersistMessageCodeForFspErrorMessage() {
-    UUID submissionId = SUBMISSION_1_ID;
-    UUID claimId = CLAIM_1_ID;
     String messageCode = "ERRALL1";
 
     ValidationMessageLog fspErrorMessage = new ValidationMessageLog();
-    fspErrorMessage.setId(Uuid7.timeBasedUuid());
-    fspErrorMessage.setSubmissionId(submissionId);
-    fspErrorMessage.setClaimId(claimId);
+    fspErrorMessage.setSubmissionId(SUBMISSION_1_ID);
+    fspErrorMessage.setClaimId(CLAIM_1_ID);
     fspErrorMessage.setType(ValidationMessageType.ERROR);
     fspErrorMessage.setSource("FSP");
     fspErrorMessage.setDisplayMessage("Enter a valid Fee Code.");
@@ -168,7 +164,7 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
     Pageable pageable = PageRequest.of(0, 10);
     Page<ValidationMessageWithClaimDetailsProjection> result =
         validationMessageLogRepository.findWithClaimDetailsByFilters(
-            submissionId, claimId, ValidationMessageType.ERROR, "FSP", pageable);
+            SUBMISSION_1_ID, CLAIM_1_ID, ValidationMessageType.ERROR, "FSP", pageable);
 
     assertThat(result.getTotalElements()).isEqualTo(1);
     ValidationMessageWithClaimDetailsProjection retrieved = result.getContent().getFirst();
@@ -180,14 +176,11 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
   @Test
   @DisplayName("Should persist messageCode for FSP messages with WARNING type")
   void shouldPersistMessageCodeForFspWarningMessage() {
-    UUID submissionId = SUBMISSION_1_ID;
-    UUID claimId = CLAIM_2_ID;
     String messageCode = "WARFAM1";
 
     ValidationMessageLog fspWarningMessage = new ValidationMessageLog();
-    fspWarningMessage.setId(Uuid7.timeBasedUuid());
-    fspWarningMessage.setSubmissionId(submissionId);
-    fspWarningMessage.setClaimId(claimId);
+    fspWarningMessage.setSubmissionId(SUBMISSION_1_ID);
+    fspWarningMessage.setClaimId(CLAIM_2_ID);
     fspWarningMessage.setType(ValidationMessageType.WARNING);
     fspWarningMessage.setSource("FSP");
     fspWarningMessage.setDisplayMessage(
@@ -201,7 +194,7 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
     Pageable pageable = PageRequest.of(0, 10);
     Page<ValidationMessageWithClaimDetailsProjection> result =
         validationMessageLogRepository.findWithClaimDetailsByFilters(
-            submissionId, claimId, ValidationMessageType.WARNING, "FSP", pageable);
+            SUBMISSION_1_ID, CLAIM_2_ID, ValidationMessageType.WARNING, "FSP", pageable);
 
     assertThat(result.getTotalElements()).isEqualTo(1);
     ValidationMessageWithClaimDetailsProjection retrieved = result.getContent().getFirst();
@@ -229,15 +222,12 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
   @DisplayName(
       "Should retain distinct messages with same display_message but different messageCode")
   void shouldRetainDistinctMessagesWithSameDisplayMessageButDifferentCode() {
-    UUID submissionId = SUBMISSION_1_ID;
-    UUID claimId = CLAIM_1_ID;
     String identicalDisplayMessage = "FSP validation issue";
 
     // Create two FSP messages with same display text but different codes
     ValidationMessageLog fspMessage1 = new ValidationMessageLog();
-    fspMessage1.setId(Uuid7.timeBasedUuid());
-    fspMessage1.setSubmissionId(submissionId);
-    fspMessage1.setClaimId(claimId);
+    fspMessage1.setSubmissionId(SUBMISSION_1_ID);
+    fspMessage1.setClaimId(CLAIM_1_ID);
     fspMessage1.setType(ValidationMessageType.ERROR);
     fspMessage1.setSource("FSP");
     fspMessage1.setDisplayMessage(identicalDisplayMessage);
@@ -245,9 +235,8 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
     fspMessage1.setMessageCode("ERRIA2");
 
     ValidationMessageLog fspMessage2 = new ValidationMessageLog();
-    fspMessage2.setId(Uuid7.timeBasedUuid());
-    fspMessage2.setSubmissionId(submissionId);
-    fspMessage2.setClaimId(claimId);
+    fspMessage2.setSubmissionId(SUBMISSION_1_ID);
+    fspMessage2.setClaimId(CLAIM_1_ID);
     fspMessage2.setType(ValidationMessageType.ERROR);
     fspMessage2.setSource("FSP");
     fspMessage2.setDisplayMessage(identicalDisplayMessage);
@@ -259,7 +248,7 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
     Pageable pageable = PageRequest.of(0, 10);
     Page<ValidationMessageWithClaimDetailsProjection> result =
         validationMessageLogRepository.findWithClaimDetailsByFilters(
-            submissionId, claimId, ValidationMessageType.ERROR, "FSP", pageable);
+            SUBMISSION_1_ID, CLAIM_1_ID, ValidationMessageType.ERROR, "FSP", pageable);
 
     // Both messages should be retrieved and distinguishable by their unique messageCode
     assertThat(result.getTotalElements()).isEqualTo(2);
@@ -273,13 +262,10 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
   @Test
   @DisplayName("Should have null messageCode for FSP message with WARNING type when not provided")
   void shouldHaveNullMessageCodeForFspMessageWhenNotProvided() {
-    UUID submissionId = SUBMISSION_1_ID;
-    UUID claimId = CLAIM_2_ID;
 
     ValidationMessageLog fspWarningNoCode = new ValidationMessageLog();
-    fspWarningNoCode.setId(Uuid7.timeBasedUuid());
-    fspWarningNoCode.setSubmissionId(submissionId);
-    fspWarningNoCode.setClaimId(claimId);
+    fspWarningNoCode.setSubmissionId(SUBMISSION_1_ID);
+    fspWarningNoCode.setClaimId(CLAIM_2_ID);
     fspWarningNoCode.setType(ValidationMessageType.WARNING);
     fspWarningNoCode.setSource("FSP");
     fspWarningNoCode.setDisplayMessage("Warning without code");
@@ -291,7 +277,7 @@ public class ValidationMessageLogRepositoryIntegrationTest extends AbstractInteg
     Pageable pageable = PageRequest.of(0, 10);
     Page<ValidationMessageWithClaimDetailsProjection> result =
         validationMessageLogRepository.findWithClaimDetailsByFilters(
-            submissionId, claimId, ValidationMessageType.WARNING, "FSP", pageable);
+            SUBMISSION_1_ID, CLAIM_2_ID, ValidationMessageType.WARNING, "FSP", pageable);
 
     assertThat(result.getTotalElements()).isEqualTo(1);
     ValidationMessageWithClaimDetailsProjection retrieved = result.getContent().getFirst();

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/ValidationMessageLog.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/ValidationMessageLog.java
@@ -53,7 +53,7 @@ public class ValidationMessageLog {
   @Column(name = "technical_message")
   private String technicalMessage;
 
-  @Column(name = "message_code")
+  @Column(name = "message_code", length = 20)
   private String messageCode;
 
   @CreationTimestamp

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/ValidationMessageLog.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/ValidationMessageLog.java
@@ -53,6 +53,9 @@ public class ValidationMessageLog {
   @Column(name = "technical_message")
   private String technicalMessage;
 
+  @Column(name = "message_code")
+  private String messageCode;
+
   @CreationTimestamp
   @Column(name = "created_on", nullable = false, updatable = false)
   private Instant createdOn;

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/AssessmentMapper.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/AssessmentMapper.java
@@ -36,6 +36,7 @@ public interface AssessmentMapper {
   @Mapping(target = "technicalMessage", source = "message.technicalMessage")
   @Mapping(target = "type", source = "message.type")
   @Mapping(target = "source", source = "message.source")
+  @Mapping(target = "messageCode", source = "message.messageCode")
   ValidationMessageLog toValidationMessageLog(
       ValidationMessagePatch message, Assessment assessment);
 

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapper.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapper.java
@@ -91,6 +91,7 @@ public interface ClaimMapper {
   @Mapping(target = "technicalMessage", source = "message.technicalMessage")
   @Mapping(target = "type", source = "message.type")
   @Mapping(target = "source", source = "message.source")
+  @Mapping(target = "messageCode", source = "message.messageCode")
   ValidationMessageLog toValidationMessageLog(ValidationMessagePatch message, Claim claim);
 
   @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapper.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapper.java
@@ -88,6 +88,7 @@ public interface SubmissionMapper {
   @Mapping(target = "technicalMessage", source = "message.technicalMessage")
   @Mapping(target = "type", source = "message.type")
   @Mapping(target = "source", source = "message.source")
+  @Mapping(target = "messageCode", source = "message.messageCode")
   @Mapping(
       target = "claimAmendment",
       ignore = true) // Ignores the optional link during base parsing

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ValidationMessageLogRepository.java
@@ -48,6 +48,7 @@ public interface ValidationMessageLogRepository extends JpaRepository<Validation
                   v.type            AS type,
                   v.source          AS source,
                   v.displayMessage  AS displayMessage,
+                  v.messageCode     AS messageCode,
                   cl.uniqueFileNumber        AS uniqueFileNumber,
                   cli.clientForename         AS clientForename,
                   cli.clientSurname          AS clientSurname,

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/projection/ValidationMessageWithClaimDetailsProjection.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/projection/ValidationMessageWithClaimDetailsProjection.java
@@ -18,6 +18,8 @@ public interface ValidationMessageWithClaimDetailsProjection {
 
   String getDisplayMessage();
 
+  String getMessageCode();
+
   // Claim fields
   String getUniqueFileNumber();
 

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimService.java
@@ -214,13 +214,6 @@ public class ClaimService
                 ValidationMessageLog validationLog =
                     claimMapper.toValidationMessageLog(message, claim);
                 validationMessageLogRepository.save(validationLog);
-                if (validationLog.getMessageCode() == null) {
-                  log.debug(
-                      "FSP message with null code detected - claim_id: {}, message_id: {}, type: {}",
-                      claim.getId(),
-                      validationLog.getId(),
-                      message.getType());
-                }
               });
     }
   }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/ClaimService.java
@@ -211,8 +211,16 @@ public class ClaimService
           .getValidationMessages()
           .forEach(
               message -> {
-                ValidationMessageLog log = claimMapper.toValidationMessageLog(message, claim);
-                validationMessageLogRepository.save(log);
+                ValidationMessageLog validationLog =
+                    claimMapper.toValidationMessageLog(message, claim);
+                validationMessageLogRepository.save(validationLog);
+                if (validationLog.getMessageCode() == null) {
+                  log.debug(
+                      "FSP message with null code detected - claim_id: {}, message_id: {}, type: {}",
+                      claim.getId(),
+                      validationLog.getId(),
+                      message.getType());
+                }
               });
     }
   }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -177,9 +177,16 @@ public class SubmissionService
           .getValidationMessages()
           .forEach(
               message -> {
-                ValidationMessageLog log =
+                ValidationMessageLog validationLog =
                     submissionMapper.toValidationMessageLog(message, submission);
-                validationMessageLogRepository.save(log);
+                validationMessageLogRepository.save(validationLog);
+                if (validationLog.getMessageCode() == null) {
+                  log.debug(
+                      "FSP message with null code detected - submission_id: {}, message_id: {}, type: {}",
+                      submission.getId(),
+                      validationLog.getId(),
+                      message.getType());
+                }
               });
     }
   }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/SubmissionService.java
@@ -180,13 +180,6 @@ public class SubmissionService
                 ValidationMessageLog validationLog =
                     submissionMapper.toValidationMessageLog(message, submission);
                 validationMessageLogRepository.save(validationLog);
-                if (validationLog.getMessageCode() == null) {
-                  log.debug(
-                      "FSP message with null code detected - submission_id: {}, message_id: {}, type: {}",
-                      submission.getId(),
-                      validationLog.getId(),
-                      message.getType());
-                }
               });
     }
   }

--- a/claims-data/service/src/main/resources/db/migration/V42__add_message_code_to_validation_message_log.sql
+++ b/claims-data/service/src/main/resources/db/migration/V42__add_message_code_to_validation_message_log.sql
@@ -1,4 +1,4 @@
 -- Add nullable message_code column to validation_message_log table
--- Stores the message code from FSP payloads when source is FSP and type is ERROR or WARNING
+-- Stores message codes from validation payloads (e.g. FSP) when provided
 ALTER TABLE claims.validation_message_log
     ADD COLUMN message_code VARCHAR(20) NULL;

--- a/claims-data/service/src/main/resources/db/migration/V42__add_message_code_to_validation_message_log.sql
+++ b/claims-data/service/src/main/resources/db/migration/V42__add_message_code_to_validation_message_log.sql
@@ -1,0 +1,4 @@
+-- Add nullable message_code column to validation_message_log table
+-- Stores the message code from FSP payloads when source is FSP and type is ERROR or WARNING
+ALTER TABLE claims.validation_message_log
+    ADD COLUMN message_code VARCHAR(50) NULL;

--- a/claims-data/service/src/main/resources/db/migration/V42__add_message_code_to_validation_message_log.sql
+++ b/claims-data/service/src/main/resources/db/migration/V42__add_message_code_to_validation_message_log.sql
@@ -1,4 +1,4 @@
 -- Add nullable message_code column to validation_message_log table
 -- Stores the message code from FSP payloads when source is FSP and type is ERROR or WARNING
 ALTER TABLE claims.validation_message_log
-    ADD COLUMN message_code VARCHAR(50) NULL;
+    ADD COLUMN message_code VARCHAR(20) NULL;

--- a/claims-data/service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/ClaimsDataTestUtil.java
+++ b/claims-data/service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/ClaimsDataTestUtil.java
@@ -273,6 +273,11 @@ public class ClaimsDataTestUtil {
       }
 
       @Override
+      public String getMessageCode() {
+        return null;
+      }
+
+      @Override
       public String getUniqueFileNumber() {
         return null;
       }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/AssessmentMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/AssessmentMapperTest.java
@@ -98,6 +98,34 @@ class AssessmentMapperTest {
     assertEquals("SYSTEM", log.getSource());
     assertEquals("A display message", log.getDisplayMessage());
     assertEquals("A technical message", log.getTechnicalMessage());
+    assertNull(log.getMessageCode());
+  }
+
+  @Test
+  void toValidationMessageLog_mapsMessageCodeForFspMessages() {
+    final Submission submission = Submission.builder().id(Uuid7.timeBasedUuid()).build();
+    final Claim claim = Claim.builder().id(Uuid7.timeBasedUuid()).submission(submission).build();
+    final Assessment assessment =
+        Assessment.builder().id(Uuid7.timeBasedUuid()).claim(claim).build();
+
+    final ValidationMessagePatch patch =
+        new ValidationMessagePatch()
+            .type(ValidationMessageType.WARNING)
+            .source("FSP")
+            .displayMessage("A display message")
+            .technicalMessage("A technical message")
+            .messageCode("WARFAM1");
+
+    final ValidationMessageLog log = mapper.toValidationMessageLog(patch, assessment);
+
+    assertNotNull(log.getId());
+    assertEquals(submission.getId(), log.getSubmissionId());
+    assertEquals(claim.getId(), log.getClaimId());
+    assertEquals(ValidationMessageType.WARNING, log.getType());
+    assertEquals("FSP", log.getSource());
+    assertEquals("A display message", log.getDisplayMessage());
+    assertEquals("A technical message", log.getTechnicalMessage());
+    assertEquals("WARFAM1", log.getMessageCode());
   }
 
   @Test

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
@@ -345,7 +345,7 @@ class ClaimMapperTest {
     final ValidationMessagePatch patch =
         new ValidationMessagePatch()
             .type(ValidationMessageType.ERROR)
-            .source("Data-Claims-Event-Service")
+            .source("FSP")
             .displayMessage("FSP error message")
             .technicalMessage("FSP technical details")
             .messageCode("ERRALL1");
@@ -356,7 +356,7 @@ class ClaimMapperTest {
     assertEquals(submission.getId(), log.getSubmissionId());
     assertEquals(claim.getId(), log.getClaimId());
     assertEquals(ValidationMessageType.ERROR, log.getType());
-    assertEquals("Data-Claims-Event-Service", log.getSource());
+    assertEquals("FSP", log.getSource());
     assertEquals("FSP error message", log.getDisplayMessage());
     assertEquals("FSP technical details", log.getTechnicalMessage());
     assertEquals("ERRALL1", log.getMessageCode());

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
@@ -338,6 +338,31 @@ class ClaimMapperTest {
   }
 
   @Test
+  void toValidationMessageLog_mapsMessageCodeForFspMessages() {
+    final Submission submission = Submission.builder().id(Uuid7.timeBasedUuid()).build();
+    final Claim claim = Claim.builder().id(Uuid7.timeBasedUuid()).submission(submission).build();
+
+    final ValidationMessagePatch patch =
+        new ValidationMessagePatch()
+            .type(ValidationMessageType.ERROR)
+            .source("Data-Claims-Event-Service")
+            .displayMessage("FSP error message")
+            .technicalMessage("FSP technical details")
+            .messageCode("ERRALL1");
+
+    final ValidationMessageLog log = mapper.toValidationMessageLog(patch, claim);
+
+    assertNotNull(log.getId());
+    assertEquals(submission.getId(), log.getSubmissionId());
+    assertEquals(claim.getId(), log.getClaimId());
+    assertEquals(ValidationMessageType.ERROR, log.getType());
+    assertEquals("Data-Claims-Event-Service", log.getSource());
+    assertEquals("FSP error message", log.getDisplayMessage());
+    assertEquals("FSP technical details", log.getTechnicalMessage());
+    assertEquals("ERRALL1", log.getMessageCode());
+  }
+
+  @Test
   void toClaimSummaryFee_mapsAllFields() {
     final ClaimPost post = ClaimsDataTestUtil.getClaimPost(CASE_REFERENCE);
 

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapperTest.java
@@ -155,19 +155,21 @@ class SubmissionMapperTest {
 
     final ValidationMessagePatch patch =
         new ValidationMessagePatch()
-            .type(ValidationMessageType.ERROR)
-            .source("SYSTEM")
+            .type(ValidationMessageType.WARNING)
+            .source("FSP")
             .displayMessage("A display message")
-            .technicalMessage("A technical message");
+            .technicalMessage("A technical message")
+            .messageCode("WARFAM1");
 
     ValidationMessageLog log = submissionMapper.toValidationMessageLog(patch, submission);
 
     assertThat(log.getId()).isNotNull();
     Assertions.assertEquals(submission.getId(), log.getSubmissionId());
     assertThat(log.getClaimId()).isNull();
-    Assertions.assertEquals(ValidationMessageType.ERROR, log.getType());
-    Assertions.assertEquals("SYSTEM", log.getSource());
+    Assertions.assertEquals(ValidationMessageType.WARNING, log.getType());
+    Assertions.assertEquals("FSP", log.getSource());
     Assertions.assertEquals("A display message", log.getDisplayMessage());
     Assertions.assertEquals("A technical message", log.getTechnicalMessage());
+    Assertions.assertEquals("WARFAM1", log.getMessageCode());
   }
 }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/SubmissionMapperTest.java
@@ -148,4 +148,26 @@ class SubmissionMapperTest {
     Assertions.assertEquals("A display message", log.getDisplayMessage());
     Assertions.assertEquals("A technical message", log.getTechnicalMessage());
   }
+
+  @Test
+  void toValidationMessageLog_mapsMessageCodeForFspMessages() {
+    Submission submission = Submission.builder().id(Uuid7.timeBasedUuid()).build();
+
+    final ValidationMessagePatch patch =
+        new ValidationMessagePatch()
+            .type(ValidationMessageType.ERROR)
+            .source("SYSTEM")
+            .displayMessage("A display message")
+            .technicalMessage("A technical message");
+
+    ValidationMessageLog log = submissionMapper.toValidationMessageLog(patch, submission);
+
+    assertThat(log.getId()).isNotNull();
+    Assertions.assertEquals(submission.getId(), log.getSubmissionId());
+    assertThat(log.getClaimId()).isNull();
+    Assertions.assertEquals(ValidationMessageType.ERROR, log.getType());
+    Assertions.assertEquals("SYSTEM", log.getSource());
+    Assertions.assertEquals("A display message", log.getDisplayMessage());
+    Assertions.assertEquals("A technical message", log.getTechnicalMessage());
+  }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1806)

- Added nullable message_code column via Flyway migration V42
- Added messageCode field to ValidationMessageLog entity
- Exposed messageCode in ValidationMessageWithClaimDetailsProjection
- Map messageCode to various mapper classes
- Add integration tests

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
