### PR TITLE
fix(DSTEW-1966): Increment Jackson version due to snyk issue

### DIFF
--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -145,10 +145,10 @@ dependencies {
     testRuntimeOnly "org.flywaydb:flyway-database-postgresql"
 
     constraints {
-        implementation('com.fasterxml.jackson.core:jackson-databind:2.21.5') {
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.22.1') {
             because 'fixes Snyk vulnerability in 2.21.4 without touching Jackson 3 dependencies'
         }
-        implementation('com.fasterxml.jackson.core:jackson-core:2.21.5') {
+        implementation('com.fasterxml.jackson.core:jackson-core:2.22.1') {
             because 'fixes Snyk vulnerability in 2.21.4 without touching Jackson 3 dependencies'
         }
     }

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -63,7 +63,7 @@ dependencyManagement {
         dependency "com.fasterxml.jackson.core:jackson-databind:2.21.5"
 
         // Force jackson-core 3.x to fix Snyk vulnerability (AWS SDK pulls tools.jackson)
-        dependency 'tools.jackson.core:jackson-core:3.1.1'
+        dependency 'tools.jackson.core:jackson-core:3.1.4'
         dependency 'tools.jackson.core:jackson-databind:3.1.4'
     }
 }

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -231,7 +231,6 @@ configurations.all {
     }
 }
 
-
 dependencies {
     // Source: https://mvnrepository.com/artifact/au.com.dius.pact.provider/spring7
     pactTestImplementation 'au.com.dius.pact.provider:spring7:4.7.1'

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -60,8 +60,10 @@ dependencyManagement {
         // === INSERT YOUR OVERRIDES HERE ===
         // Force jackson-core 2.x to fix Snyk vulnerability
         dependency "com.fasterxml.jackson.core:jackson-core:2.21.5"
+        dependency "com.fasterxml.jackson.core:jackson-databind:2.21.5"
         // Force jackson-core 3.x to fix Snyk vulnerability (AWS SDK pulls tools.jackson)
         dependency 'tools.jackson.core:jackson-core:3.1.4'
+        dependency 'tools.jackson.core:jackson-databind:3.1.4'
     }
 }
 

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -144,7 +144,6 @@ dependencies {
 
     testRuntimeOnly "org.flywaydb:flyway-database-postgresql"
 
-    // Add this targeted constraint block right here:
     constraints {
         implementation('com.fasterxml.jackson.core:jackson-databind:2.21.5') {
             because 'fixes Snyk vulnerability in 2.21.4 without touching Jackson 3 dependencies'

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -68,9 +68,6 @@ dependencyManagement {
 }
 
 dependencies {
-    // Fixes SNYK-JAVA-TOOLSJACKSONCORE-15907550
-    implementation 'tools.jackson.core:jackson-core:3.1.1'
-
     implementation project(':claims-data:api')
     implementation 'uk.gov.justice.laa.dstew.payments.claims.validation:claims-validation-core:1.0.24'
 
@@ -120,7 +117,7 @@ dependencies {
     implementation 'software.amazon.awssdk:sts'
     implementation "software.amazon.awssdk:sns"
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.1.0'
-    implementation(platform("tools.jackson:jackson-bom:3.1.1"))
+    implementation(platform("tools.jackson:jackson-bom:3.1.4"))
 
     // Sentry
     implementation platform("io.sentry:sentry-bom:$versions.sentry")

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -143,6 +143,19 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     testRuntimeOnly "org.flywaydb:flyway-database-postgresql"
+
+    // Add this targeted constraint block right here:
+    constraints {
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.21.5') {
+            because 'fixes Snyk vulnerability in 2.21.4 without touching Jackson 3 dependencies'
+        }
+        implementation('com.fasterxml.jackson.core:jackson-core:2.21.5') {
+            because 'fixes Snyk vulnerability in 2.21.4 without touching Jackson 3 dependencies'
+        }
+    }
+
+    // Fixes SNYK-JAVA-TOOLSJACKSONCORE-15907550
+    implementation 'tools.jackson.core:jackson-core:3.1.1'
 }
 
 bootRun {

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -60,11 +60,8 @@ dependencyManagement {
         // === INSERT YOUR OVERRIDES HERE ===
         // Force jackson-core 2.x to fix Snyk vulnerability
         dependency "com.fasterxml.jackson.core:jackson-core:2.21.5"
-        dependency "com.fasterxml.jackson.core:jackson-databind:2.21.5"
-
         // Force jackson-core 3.x to fix Snyk vulnerability (AWS SDK pulls tools.jackson)
         dependency 'tools.jackson.core:jackson-core:3.1.4'
-        dependency 'tools.jackson.core:jackson-databind:3.1.4'
     }
 }
 

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -56,6 +56,15 @@ dependencyManagement {
             entry 'sentry-spring-boot-starter'
             entry 'sentry-logback'
         }
+
+        // === INSERT YOUR OVERRIDES HERE ===
+        // Force jackson-core 2.x to fix Snyk vulnerability
+        dependency "com.fasterxml.jackson.core:jackson-core:2.21.5"
+        dependency "com.fasterxml.jackson.core:jackson-databind:2.21.5"
+
+        // Force jackson-core 3.x to fix Snyk vulnerability (AWS SDK pulls tools.jackson)
+        dependency 'tools.jackson.core:jackson-core:3.1.1'
+        dependency 'tools.jackson.core:jackson-databind:3.1.1'
     }
 }
 
@@ -143,18 +152,6 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     testRuntimeOnly "org.flywaydb:flyway-database-postgresql"
-
-    constraints {
-        implementation('com.fasterxml.jackson.core:jackson-databind:2.22.1') {
-            because 'fixes Snyk vulnerability in 2.21.4 without touching Jackson 3 dependencies'
-        }
-        implementation('com.fasterxml.jackson.core:jackson-core:2.22.1') {
-            because 'fixes Snyk vulnerability in 2.21.4 without touching Jackson 3 dependencies'
-        }
-    }
-
-    // Fixes SNYK-JAVA-TOOLSJACKSONCORE-15907550
-    implementation 'tools.jackson.core:jackson-core:3.1.1'
 }
 
 bootRun {

--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -64,7 +64,7 @@ dependencyManagement {
 
         // Force jackson-core 3.x to fix Snyk vulnerability (AWS SDK pulls tools.jackson)
         dependency 'tools.jackson.core:jackson-core:3.1.1'
-        dependency 'tools.jackson.core:jackson-databind:3.1.1'
+        dependency 'tools.jackson.core:jackson-databind:3.1.4'
     }
 }
 


### PR DESCRIPTION
Increment Jackson version due to snyk 

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1966)

There is a snyk issue in laa-data-claims-api
com.fasterxml.jackson.core:jackson-core:2.21.4
Needs upgrading to com.fasterxml.jackson.core:jackson-core:2.21.5
laa-spring-coot-common is already on the latest version of Spring Boot (4.1.0) so we will need to wait until a new version is released before we can update common.
This wasn't straightforward as Jackson have moved the repository to a new home - https://mvnrepository.com/artifact/tools.jackson.core

So ext['jackson.version'] = "2.21.5" doesn't work.


## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [x] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
