### PR TITLE
feat(DSTEW-1779): validate surgery counts within inclusive ranges

### DIFF
--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ExportControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ExportControllerIntegrationTest.java
@@ -64,6 +64,21 @@ class ExportControllerIntegrationTest extends AbstractIntegrationTest {
   }
 
   @Test
+  void exportsLegalHelpCsvPreservesExplicitZeroForSurgeryMattersCount() throws Exception {
+    claimSummaryFee1.setSurgeryMattersCount(0);
+    claimSummaryFeeRepository.saveAndFlush(claimSummaryFee1);
+
+    MvcResult response =
+        exportCsv(LEGAL_HELP_ENDPOINT, submission1.getId(), submission1.getOfficeAccountNumber());
+
+    Map<String, String> firstRow =
+        firstDataRowByHeader(response.getResponse().getContentAsString());
+
+    assertThat(firstRow.get("No of clients resulting in a Legal Help matter opened"))
+        .isEqualTo("0");
+  }
+
+  @Test
   void exportsCrimeLowerCsvWithDefinitionHeadersAndSeededRowValues() throws Exception {
     UUID crimeSubmissionId = createCrimeLowerExportData(CRIME_OFFICE);
     MvcResult response = exportCsv(CRIME_LOWER_ENDPOINT, crimeSubmissionId, CRIME_OFFICE);

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/BulkSubmissionMapper.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/BulkSubmissionMapper.java
@@ -29,6 +29,14 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.xml.XmlSubmission;
 /** Mapping interface for the mapping of bulk submission objects. */
 @Mapper(componentModel = "spring")
 public interface BulkSubmissionMapper {
+  String SURGERY_CLIENTS_COUNT_RANGE_MESSAGE = "Surgery Clients Count must be between 1 and 20";
+  int SURGERY_CLIENTS_COUNT_MIN = 1;
+  int SURGERY_CLIENTS_COUNT_MAX = 20;
+
+  String SURGERY_MATTERS_COUNT_RANGE_MESSAGE = "Surgery Matters Count must be between 0 and 99";
+  int SURGERY_MATTERS_COUNT_MIN = 0;
+  int SURGERY_MATTERS_COUNT_MAX = 99;
+
   /**
    * Maps the given {@code FileSubmission} to a {@code GetBulkSubmission200ResponseDetails}.
    *
@@ -236,11 +244,15 @@ public interface BulkSubmissionMapper {
   @Mapping(
       target = "noOfClients",
       expression =
-          "java(parseIntegerField(outcome.noOfClients(), \"Surgery Clients Count must be between 1 and 20\"))")
+          "java(parseIntegerFieldInInclusiveRange(outcome.noOfClients(),"
+              + " SURGERY_CLIENTS_COUNT_RANGE_MESSAGE,"
+              + " SURGERY_CLIENTS_COUNT_MIN, SURGERY_CLIENTS_COUNT_MAX))")
   @Mapping(
       target = "noOfSurgeryClients",
       expression =
-          "java(parseIntegerField(outcome.noOfSurgeryClients(), \"Surgery Matters Count must be between 1 and 20\"))")
+          "java(parseIntegerFieldInInclusiveRange(outcome.noOfSurgeryClients(),"
+              + " SURGERY_MATTERS_COUNT_RANGE_MESSAGE,"
+              + " SURGERY_MATTERS_COUNT_MIN, SURGERY_MATTERS_COUNT_MAX))")
   @Mapping(
       target = "noOfSuspects",
       expression =
@@ -400,11 +412,15 @@ public interface BulkSubmissionMapper {
   @Mapping(
       target = "noOfClients",
       expression =
-          "java(parseIntegerField(outcome.noOfClients(), \"Surgery Clients Count must be between 1 and 20\"))")
+          "java(parseIntegerFieldInInclusiveRange(outcome.noOfClients(),"
+              + " SURGERY_CLIENTS_COUNT_RANGE_MESSAGE,"
+              + " SURGERY_CLIENTS_COUNT_MIN, SURGERY_CLIENTS_COUNT_MAX))")
   @Mapping(
       target = "noOfSurgeryClients",
       expression =
-          "java(parseIntegerField(outcome.noOfSurgeryClients(), \"Surgery Matters Count must be between 1 and 20\"))")
+          "java(parseIntegerFieldInInclusiveRange(outcome.noOfSurgeryClients(),"
+              + " SURGERY_MATTERS_COUNT_RANGE_MESSAGE,"
+              + " SURGERY_MATTERS_COUNT_MIN, SURGERY_MATTERS_COUNT_MAX))")
   @Mapping(
       target = "noOfSuspects",
       expression =
@@ -471,6 +487,29 @@ public interface BulkSubmissionMapper {
     } catch (NumberFormatException ex) {
       throw new BulkSubmissionFieldConversionException(fieldName, value, ex);
     }
+  }
+
+  /**
+   * Map to an {@link Integer} within an inclusive range.
+   *
+   * @param value the value to map.
+   * @param fieldName the name of the field being mapped.
+   * @param minInclusive the minimum accepted value.
+   * @param maxInclusive the maximum accepted value.
+   * @return a validated Integer representation of the field.
+   */
+  default Integer parseIntegerFieldInInclusiveRange(
+      String value, String fieldName, int minInclusive, int maxInclusive) {
+    Integer parsedValue = parseIntegerField(value, fieldName);
+    if (parsedValue == null) {
+      return null;
+    }
+
+    if (parsedValue < minInclusive || parsedValue > maxInclusive) {
+      throw new BulkSubmissionFieldConversionException(fieldName, value);
+    }
+
+    return parsedValue;
   }
 
   /**

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/BulkSubmissionMapper.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/BulkSubmissionMapper.java
@@ -493,20 +493,20 @@ public interface BulkSubmissionMapper {
    * Map to an {@link Integer} within an inclusive range.
    *
    * @param value the value to map.
-   * @param fieldName the name of the field being mapped.
+   * @param exceptionMessage the validation message to use if conversion or range validation fails.
    * @param minInclusive the minimum accepted value.
    * @param maxInclusive the maximum accepted value.
    * @return a validated Integer representation of the field.
    */
   default Integer parseIntegerFieldInInclusiveRange(
-      String value, String fieldName, int minInclusive, int maxInclusive) {
-    Integer parsedValue = parseIntegerField(value, fieldName);
+      String value, String exceptionMessage, int minInclusive, int maxInclusive) {
+    Integer parsedValue = parseIntegerField(value, exceptionMessage);
     if (parsedValue == null) {
       return null;
     }
 
     if (parsedValue < minInclusive || parsedValue > maxInclusive) {
-      throw new BulkSubmissionFieldConversionException(fieldName, value);
+      throw new BulkSubmissionFieldConversionException(exceptionMessage, value);
     }
 
     return parsedValue;

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/BulkSubmissionMapperTests.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/BulkSubmissionMapperTests.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.AREA_OF_LAW;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -119,7 +120,7 @@ class BulkSubmissionMapperTests {
     "medicalReportsClaimed, notANumber,Medical Reports Count must be between 0 and 10",
     "desiAccRep, notANumber,Designated Accredited Representative Code must be a number from 1 to 5",
     "noOfClients, notANumber,Surgery Clients Count must be between 1 and 20",
-    "noOfSurgeryClients, notANumber,Surgery Matters Count must be between 1 and 20",
+    "noOfSurgeryClients, notANumber,Surgery Matters Count must be between 0 and 99",
     "noOfSuspects, notANumber,Suspects Defendants Count must be less than 100",
     "noOfPoliceStation, notANumber,Police Station Court Attendances Count must be between 0 and 99",
     "numberOfMediationSessions, notANumber,Mediation Sessions Count must be less than 100",
@@ -189,7 +190,7 @@ class BulkSubmissionMapperTests {
     "hoInterview, notANumber,HO Interview must be between 0 and 9",
     "medicalReportsClaimed, notANumber,Medical Reports Count must be between 0 and 10",
     "noOfClients, notANumber,Surgery Clients Count must be between 1 and 20",
-    "noOfSurgeryClients, notANumber,Surgery Matters Count must be between 1 and 20",
+    "noOfSurgeryClients, notANumber,Surgery Matters Count must be between 0 and 99",
     "noOfSuspects, notANumber,Suspects Defendants Count must be less than 100",
     "noOfPoliceStation, notANumber,Police Station Court Attendances Count must be between 0 and 99",
     "numberOfMediationSessions, notANumber,Mediation Sessions Count must be less than 100",
@@ -207,6 +208,130 @@ class BulkSubmissionMapperTests {
 
     assertEquals(expectedExceptionMessage, actualException.getMessage());
     assertEquals(invalidValue, actualException.getRejectedValue());
+  }
+
+  @ParameterizedTest(name = "Should map CSV Surgery Matters Count value {0}")
+  @CsvSource({"0", "1", "20", "21", "99"})
+  void shouldMapCsvOutcomeSurgeryMattersCountWithinRange(int surgeryMattersCount) {
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("noOfSurgeryClients", String.valueOf(surgeryMattersCount));
+
+    FileSubmission submission = createCsvSubmission(createCsvOutcome(overrides, "Y"));
+
+    GetBulkSubmission200ResponseDetails expected = getExpectedBulkSubmissionDetails(true);
+    expected.outcomes(
+        List.of(
+            ClaimsDataTestUtil.getBulkSubmissionOutcome(true)
+                .noOfSurgeryClients(surgeryMattersCount)));
+
+    assertEquals(expected, bulkSubmissionMapper.toBulkSubmissionDetails(submission));
+  }
+
+  @ParameterizedTest(name = "Should map XML Surgery Matters Count value {0}")
+  @CsvSource({"0", "1", "20", "21", "99"})
+  void shouldMapXmlOutcomeSurgeryMattersCountWithinRange(int surgeryMattersCount) {
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("noOfSurgeryClients", String.valueOf(surgeryMattersCount));
+
+    XmlOutcome outcome = createXmlOutcome(overrides, "Y");
+
+    assertEquals(
+        ClaimsDataTestUtil.getBulkSubmissionOutcome(true).noOfSurgeryClients(surgeryMattersCount),
+        bulkSubmissionMapper.toBulkSubmissionOutcome(outcome));
+  }
+
+  @ParameterizedTest(name = "Should reject CSV Surgery Matters Count value {0}")
+  @CsvSource({"100", "-1", "1.5", "notANumber"})
+  void shouldRejectCsvOutcomeSurgeryMattersCountOutsideRange(String invalidValue) {
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("noOfSurgeryClients", invalidValue);
+
+    FileSubmission submission = createCsvSubmission(createCsvOutcome(overrides, "Y"));
+
+    BulkSubmissionFieldConversionException exception =
+        assertThrows(
+            BulkSubmissionFieldConversionException.class,
+            () -> bulkSubmissionMapper.toBulkSubmissionDetails(submission));
+
+    assertEquals("Surgery Matters Count must be between 0 and 99", exception.getExceptionMessage());
+    assertEquals(invalidValue, exception.getRejectedValue());
+  }
+
+  @ParameterizedTest(name = "Should reject XML Surgery Matters Count value {0}")
+  @CsvSource({"100", "-1", "1.5", "notANumber"})
+  void shouldRejectXmlOutcomeSurgeryMattersCountOutsideRange(String invalidValue) {
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("noOfSurgeryClients", invalidValue);
+
+    XmlOutcome outcome = createXmlOutcome(overrides, "Y");
+
+    BulkSubmissionFieldConversionException exception =
+        assertThrows(
+            BulkSubmissionFieldConversionException.class,
+            () -> bulkSubmissionMapper.toBulkSubmissionOutcome(outcome));
+
+    assertEquals("Surgery Matters Count must be between 0 and 99", exception.getMessage());
+    assertEquals(invalidValue, exception.getRejectedValue());
+  }
+
+  @Test
+  void shouldTreatBlankCsvSurgeryMattersCountAsOptional() {
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("noOfSurgeryClients", "");
+
+    FileSubmission submission = createCsvSubmission(createCsvOutcome(overrides, "Y"));
+
+    GetBulkSubmission200ResponseDetails expected = getExpectedBulkSubmissionDetails(true);
+    expected.outcomes(
+        List.of(ClaimsDataTestUtil.getBulkSubmissionOutcome(true).noOfSurgeryClients(null)));
+
+    assertEquals(expected, bulkSubmissionMapper.toBulkSubmissionDetails(submission));
+  }
+
+  @Test
+  void shouldTreatOmittedXmlSurgeryMattersCountAsOptional() {
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("noOfSurgeryClients", null);
+
+    XmlOutcome outcome = createXmlOutcome(overrides, "Y");
+
+    assertEquals(
+        ClaimsDataTestUtil.getBulkSubmissionOutcome(true).noOfSurgeryClients(null),
+        bulkSubmissionMapper.toBulkSubmissionOutcome(outcome));
+  }
+
+  @ParameterizedTest(name = "Should reject CSV Surgery Clients Count value {0}")
+  @CsvSource({"0", "21"})
+  void shouldRejectCsvOutcomeSurgeryClientsCountOutsideRange(int invalidValue) {
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("noOfClients", String.valueOf(invalidValue));
+
+    FileSubmission submission = createCsvSubmission(createCsvOutcome(overrides, "Y"));
+
+    BulkSubmissionFieldConversionException exception =
+        assertThrows(
+            BulkSubmissionFieldConversionException.class,
+            () -> bulkSubmissionMapper.toBulkSubmissionDetails(submission));
+
+    assertEquals("Surgery Clients Count must be between 1 and 20", exception.getExceptionMessage());
+    assertEquals(String.valueOf(invalidValue), exception.getRejectedValue());
+  }
+
+  @ParameterizedTest(name = "Should reject XML Surgery Clients Count value {0}")
+  @CsvSource({"0", "21"})
+  void shouldRejectXmlOutcomeSurgeryClientsCountOutsideRange(int invalidValue) {
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("noOfClients", String.valueOf(invalidValue));
+
+    XmlOutcome outcome = createXmlOutcome(overrides, "Y");
+
+    BulkSubmissionFieldConversionException exception =
+        assertThrows(
+            BulkSubmissionFieldConversionException.class,
+            () -> bulkSubmissionMapper.toBulkSubmissionOutcome(outcome));
+
+    assertEquals("Surgery Clients Count must be between 1 and 20", exception.getMessage());
+    assertEquals(String.valueOf(invalidValue), exception.getRejectedValue());
   }
 
   private static List<XmlMatterStarts> getXmlMatterStarts() {
@@ -368,8 +493,8 @@ class BulkSubmissionMapperTests {
     String costsDamagesRecovered = overrides.getOrDefault("costsDamagesRecovered", "56.78");
     String medicalReportsClaimed = overrides.getOrDefault("medicalReportsClaimed", "4");
     String desiAccRep = overrides.getOrDefault("desiAccRep", "5");
-    String noOfClients = overrides.getOrDefault("noOfClients", "6");
-    String noOfSurgeryClients = overrides.getOrDefault("noOfSurgeryClients", "7");
+    String noOfClients = getOverrideValue(overrides, "noOfClients", "6");
+    String noOfSurgeryClients = getOverrideValue(overrides, "noOfSurgeryClients", "7");
     String noOfSuspects = overrides.getOrDefault("noOfSuspects", "8");
     String noOfPoliceStation = overrides.getOrDefault("noOfPoliceStation", "9");
     String numberOfMediationSessions = overrides.getOrDefault("numberOfMediationSessions", "10");
@@ -515,8 +640,8 @@ class BulkSubmissionMapperTests {
     String costsDamagesRecovered = overrides.getOrDefault("costsDamagesRecovered", "56.78");
     String medicalReportsClaimed = overrides.getOrDefault("medicalReportsClaimed", "4");
     String desiAccRep = overrides.getOrDefault("desiAccRep", "5");
-    String noOfClients = overrides.getOrDefault("noOfClients", "6");
-    String noOfSurgeryClients = overrides.getOrDefault("noOfSurgeryClients", "7");
+    String noOfClients = getOverrideValue(overrides, "noOfClients", "6");
+    String noOfSurgeryClients = getOverrideValue(overrides, "noOfSurgeryClients", "7");
     String noOfSuspects = overrides.getOrDefault("noOfSuspects", "8");
     String noOfPoliceStation = overrides.getOrDefault("noOfPoliceStation", "9");
     String numberOfMediationSessions = overrides.getOrDefault("numberOfMediationSessions", "10");
@@ -662,5 +787,10 @@ class BulkSubmissionMapperTests {
         .outcomes(List.of(expectedBulkSubmissionOutcome))
         .matterStarts(expectedMatterStarts)
         .immigrationClr(expectedImmigrationClrRows);
+  }
+
+  private static String getOverrideValue(
+      Map<String, String> overrides, String key, String defaultValue) {
+    return overrides.containsKey(key) ? overrides.get(key) : defaultValue;
   }
 }


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1779)

- add parseIntegerFieldInInclusiveRange method to BulkSubmissionMapper to enforce min/max bounds
- fix surgeryMattersCount (noOfSurgeryClients) range from 1–20 to 0–99(to allow zero value)
- related changes in integration and unit test cases

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
