### PR TITLE
test: DSTEW-1834 Port submission-level validation scenarios to bddTest (API-only)

### DIFF
--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/context/BddScenarioContext.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/context/BddScenarioContext.java
@@ -30,6 +30,14 @@ public class BddScenarioContext {
   private String lastOffice;
   private String lastSubmissionPeriod;
 
+  /**
+   * Set by steps that mutate a fixture's {@code submissionPeriod=} header at upload time (e.g.
+   * {@code SubmissionValidationSteps}). Used by rejection-message assertions to substitute the
+   * literal {@code <CURRENT_MONTH>} placeholder in expected error text with the actual month label
+   * written into the fixture.
+   */
+  private String resolvedSubmissionMonth;
+
   // ---------------------------------------------------------------------------
   // Paired-submission state (used by scenarios that upload two related files:
   // "first"/"second" naming mirrors the disbursement duplicate-check feature).
@@ -64,6 +72,7 @@ public class BddScenarioContext {
     generatedFileName = null;
     lastOffice = null;
     lastSubmissionPeriod = null;
+    resolvedSubmissionMonth = null;
     firstGeneratedFilePath = null;
     secondGeneratedFilePath = null;
     firstOffice = null;

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/generator/SubmissionPeriodHelper.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/generator/SubmissionPeriodHelper.java
@@ -75,6 +75,17 @@ public class SubmissionPeriodHelper {
     issued.clear();
   }
 
+  /**
+   * Returns the {@code MMM-YYYY} label for the current calendar month plus the given offset. Used
+   * by {@code SubmissionValidationSteps} to substitute {@code submissionPeriod=} with either the
+   * current month ({@code offset=0}) or a future month ({@code offset>0}) — both of which are
+   * rejected by the event-service's submission-period validator.
+   */
+  public static String monthLabel(int monthsOffset) {
+    LocalDate date = LocalDate.now().plusMonths(monthsOffset);
+    return formatPeriod(date);
+  }
+
   private static String formatPeriod(LocalDate date) {
     return BddTestConstants.MONTHS.get(date.getMonthValue() - 1) + "-" + date.getYear();
   }

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/LegalHelpDisbursementsDuplicateChecksSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/LegalHelpDisbursementsDuplicateChecksSteps.java
@@ -297,9 +297,22 @@ public class LegalHelpDisbursementsDuplicateChecksSteps {
     // UAT mode — verify each expected message actually shows up on the submission's claims.
     List<Map<String, String>> rows = table.asMaps(String.class, String.class);
     for (Map<String, String> row : rows) {
-      String expectedMessage = row.get("Error Message");
+      String expectedMessage = resolvePlaceholders(row.get("Error Message"));
       validationMessages.assertSubmissionErrorExists(bulkSubmissionId, expectedMessage);
     }
+  }
+
+  /**
+   * Substitutes context-provided placeholders in an expected error message. Currently supports
+   * {@code <CURRENT_MONTH>} — set by steps that mutate the fixture's {@code submissionPeriod=}
+   * header to the current or a future month (see {@code SubmissionValidationSteps}).
+   */
+  private String resolvePlaceholders(String message) {
+    if (message == null) {
+      return null;
+    }
+    String resolvedMonth = context.getResolvedSubmissionMonth();
+    return resolvedMonth == null ? message : message.replace("<CURRENT_MONTH>", resolvedMonth);
   }
 
   private void capturePair(

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/SubmissionValidationSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/SubmissionValidationSteps.java
@@ -1,0 +1,157 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.DEFAULT_OFFICE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.EVENT_SERVICE_POLL_TIMEOUT;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.isUatMode;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.context.BddScenarioContext;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.SubmissionPeriodHelper;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
+import uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil;
+
+/**
+ * Step definitions for {@code submissionValidation.feature}.
+ *
+ * <p>These scenarios exercise <b>submission-level</b> (not claim-level) rejections triggered by an
+ * invalid {@code submissionPeriod} header. The fixture is a minimal, zero-claim TXT — the
+ * event-service parses the SCHEDULE header, validates the period, and posts a callback carrying one
+ * of the {@code Submissions for …} error messages listed in the feature file.
+ *
+ * <p>The harness has two run modes controlled by the {@code -Dbdd.mode} system property:
+ *
+ * <ul>
+ *   <li><b>local</b> (default) — event-service is not running. The submit-and-wait step drives the
+ *       bulk submission into {@code VALIDATION_FAILED} directly via {@code PATCH
+ *       /api/v1/bulk-submissions/{id}} so status assertions can pass; the error-text assertion is
+ *       logged and skipped (see {@code assertRejectedWithErrors}).
+ *   <li><b>uat</b> — event-service is present. No PATCH shortcut is applied; the harness waits for
+ *       the real terminal status and asserts each expected message via {@code GET
+ *       /api/v1/validation-messages}. The literal {@code <CURRENT_MONTH>} placeholder in the
+ *       feature file is substituted with the actual month written into the fixture (see {@link
+ *       BddScenarioContext#getResolvedSubmissionMonth()}).
+ * </ul>
+ */
+@Slf4j
+public class SubmissionValidationSteps {
+
+  private static final Pattern SUBMISSION_PERIOD_PATTERN =
+      Pattern.compile("submissionPeriod=([A-Z]{3}-\\d{4})");
+  private static final Pattern OFFICE_ACCOUNT_PATTERN = Pattern.compile("account=([A-Za-z0-9]+)");
+
+  @Autowired private BddApiStepSupport api;
+  @Autowired private BddScenarioContext context;
+
+  // ---------------------------------------------------------------------------
+  // Given — load fixture (with optional period mutation)
+  // ---------------------------------------------------------------------------
+
+  @Given("a submission fixture {string}")
+  public void aSubmissionFixture(String classpathFile) throws IOException {
+    loadFixture(classpathFile, null);
+  }
+
+  @Given("a submission fixture {string} with the submission period set to the {string}")
+  public void aSubmissionFixtureWithPeriodOverride(String classpathFile, String periodKind)
+      throws IOException {
+    String replacement = resolvePeriodKind(periodKind);
+    loadFixture(classpathFile, replacement);
+    context.setResolvedSubmissionMonth(replacement);
+  }
+
+  // ---------------------------------------------------------------------------
+  // When — submit + wait
+  // ---------------------------------------------------------------------------
+
+  @When("I submit it and wait for the event service to validate it")
+  public void iSubmitItAndWaitForValidation() throws IOException {
+    String office = requireOffice(context.getLastOffice());
+    api.postBulkSubmissionFromPath(
+        context.getGeneratedFilePath(), office, ClaimsDataTestUtil.API_USER_ID);
+    UUID id = context.getBulkSubmissionId();
+    assertThat(id).as("Bulk submission id must be captured after POST").isNotNull();
+
+    if (isUatMode()) {
+      String terminal = api.waitForBulkSubmissionTerminalStatus(id, EVENT_SERVICE_POLL_TIMEOUT);
+      log.info("[uat mode] Bulk submission {} reached terminal status {}", id, terminal);
+    }
+    // In local mode the "Then the submission is rejected" step drives the outcome via PATCH.
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Copies the classpath fixture to a temp file, optionally rewriting the {@code submissionPeriod=}
+   * header, and captures the fixture office in the scenario context so the subsequent POST uses the
+   * right {@code offices=} query parameter.
+   */
+  private void loadFixture(String classpathFile, String periodOverride) throws IOException {
+    ClassPathResource resource = new ClassPathResource(classpathFile);
+    String content;
+    try (var in = resource.getInputStream()) {
+      content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    if (periodOverride != null) {
+      Matcher matcher = SUBMISSION_PERIOD_PATTERN.matcher(content);
+      if (!matcher.find()) {
+        throw new IllegalStateException(
+            "Fixture "
+                + classpathFile
+                + " does not contain a submissionPeriod=MMM-YYYY header to override.");
+      }
+      content = matcher.replaceFirst("submissionPeriod=" + periodOverride);
+    }
+
+    String filename = resource.getFilename() != null ? resource.getFilename() : "bdd-fixture";
+    Path tempPath = Files.createTempFile("bdd-fixture-", "-" + filename);
+    // Best-effort cleanup so long BDD runs don't leave copies of the classpath fixture in /tmp.
+    tempPath.toFile().deleteOnExit();
+    Files.writeString(tempPath, content, StandardCharsets.UTF_8);
+
+    context.setGeneratedFilePath(tempPath);
+    context.setLastOffice(extractOffice(content));
+  }
+
+  private static String extractOffice(String fixtureContent) {
+    Matcher matcher = OFFICE_ACCOUNT_PATTERN.matcher(fixtureContent);
+    return matcher.find() ? matcher.group(1) : DEFAULT_OFFICE;
+  }
+
+  private static String resolvePeriodKind(String periodKind) {
+    String normalised = periodKind.toLowerCase(Locale.ROOT).trim();
+    return switch (normalised) {
+      case "current month" -> SubmissionPeriodHelper.monthLabel(0);
+      case "future month", "future date" -> SubmissionPeriodHelper.monthLabel(1);
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown period kind '"
+                  + periodKind
+                  + "' — expected 'current month' or 'future month'.");
+    };
+  }
+
+  private static String requireOffice(String office) {
+    if (StringUtils.isBlank(office)) {
+      throw new IllegalStateException(
+          "No office captured for the current submission — check the fixture-loader step.");
+    }
+    return office;
+  }
+}

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/SubmissionValidationSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/SubmissionValidationSteps.java
@@ -138,7 +138,7 @@ public class SubmissionValidationSteps {
     String normalised = periodKind.toLowerCase(Locale.ROOT).trim();
     return switch (normalised) {
       case "current month" -> SubmissionPeriodHelper.monthLabel(0);
-      case "future month", "future date" -> SubmissionPeriodHelper.monthLabel(1);
+      case "future month" -> SubmissionPeriodHelper.monthLabel(1);
       default ->
           throw new IllegalArgumentException(
               "Unknown period kind '"

--- a/claims-data/service/src/bddTest/resources/features/bdd/submissionValidation.feature
+++ b/claims-data/service/src/bddTest/resources/features/bdd/submissionValidation.feature
@@ -1,0 +1,45 @@
+@Regression
+@validationChecks
+Feature: Submission-level validation (API)
+
+  # Endpoints exercised:
+  #   POST  /api/v1/bulk-submissions             — submit a bulk submission
+  #   GET   /api/v1/bulk-submissions/{id}/summary — poll for terminal status (UAT mode)
+  #   PATCH /api/v1/bulk-submissions/{id}        — drive terminal status in local mode
+  #   GET   /api/v1/validation-messages          — read submission-level validation errors
+  #                                                (UAT mode)
+
+  # ===========================================================================
+  # 1. Submissions for periods before JAN-2015 are rejected outright.
+  #    Fixture is a minimal, zero-claim TXT with submissionPeriod=AUG-2014.
+  # ===========================================================================
+  @SV_1
+  @smoke
+  Scenario: A submission for a period before JAN-2015 is rejected
+    Given a submission fixture "test_upload_files/txt/invalid_submission_period_pre2015.txt"
+    When I submit it and wait for the event service to validate it
+    Then the submission is rejected with the following errors
+      | Error Message                                                                                             |
+      | Submissions for periods before JAN-2015 are not accepted. Please submit for a period on or after JAN-2015. |
+
+
+  # ===========================================================================
+  # 2. Submissions for the current month, or any future month, are rejected.
+  #    The step mutates submissionPeriod=... in the fixture to the current
+  #    month (MMM-YYYY) or one month ahead before uploading. The literal
+  #    <CURRENT_MONTH> placeholder in the expected error text is resolved to
+  #    the actual month label at assertion time.
+  # ===========================================================================
+  @SV_2
+  Scenario Outline: A submission for the <periodKind> is rejected
+    Given a submission fixture "test_upload_files/txt/invalid_submission_period_pre2015.txt" with the submission period set to the "<periodKind>"
+    When I submit it and wait for the event service to validate it
+    Then the submission is rejected with the following errors
+      | Error Message  |
+      | <errorMessage> |
+
+    Examples:
+      | periodKind    | errorMessage                                                                                                    |
+      | current month | Submissions for the current month (<CURRENT_MONTH>) are not accepted. Please submit for a previous month.       |
+      | future month  | Submissions for after the current month (<CURRENT_MONTH>) are not accepted. Please submit for a previous month. |
+

--- a/claims-data/service/src/bddTest/resources/test_upload_files/txt/invalid_submission_period_pre2015.txt
+++ b/claims-data/service/src/bddTest/resources/test_upload_files/txt/invalid_submission_period_pre2015.txt
@@ -1,0 +1,3 @@
+OFFICE,account=0P322F
+SCHEDULE,submissionPeriod=AUG-2014,areaOfLaw=LEGAL HELP,scheduleNum=0P322F/MEDIAUG24/01
+


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1834)

Ports `submissionValidation.feature` from the UI-driven `bulk-submission-and-fee-scheme-tests-` E2E project into `laa-data-claims-api` as **API-only** BDD tests. Provides like-for-like functional coverage of **submission-level** (not claim-level) rejections triggered by an invalid `submissionPeriod` header, while excluding the browser layer.

### Scope

One feature file, three test rows total, running under the existing Cucumber-Spring harness introduced in #375.

| Tag | Scenario | Why |
|---|---|---|
| `@SV_1 @smoke` | A submission for a period before JAN-2015 is rejected | Static fixture (`submissionPeriod=AUG-2014`) asserts the exact pre-2015 error text. |
| `@SV_2` (Outline) | Current-month submission is rejected | Fixture is rewritten in-flight to the current calendar month before upload. |
| `@SV_2` (Outline) | Future-month submission is rejected | Fixture is rewritten to the next calendar month before upload. |

Coverage matches the source feature exactly (same fixture data, same expected error strings) — see the like-for-like comparison in the branch commit body.

### How outcomes are driven

Same `-Dbdd.mode` toggle as DCLH/DCLHD:

| Mode | Behaviour |
|---|---|
| `local` (default) | After `POST /api/v1/bulk-submissions` the step class drives terminal status via `PATCH /api/v1/bulk-submissions/{id}` to mimic the event-service callback. The per-message assertion is logged and skipped (real messages are produced by the event-service). |
| `uat` (CI) | No PATCH shortcut. The harness waits for the real terminal status via `GET /api/v1/bulk-submissions/{id}/summary` (with the 90 s `EVENT_SERVICE_POLL_TIMEOUT` added in #375) and asserts each expected message via `GET /api/v1/validation-messages`. |

The literal `<CURRENT_MONTH>` placeholder in the feature file is resolved at assertion time to the actual month label written into the fixture, via a new small `resolvePlaceholders(...)` helper on the shared `assertRejectedWithErrors` step.

### Endpoints exercised

- `POST  /api/v1/bulk-submissions`
- `GET   /api/v1/bulk-submissions/{id}/summary` (UAT mode — poll for terminal status)
- `PATCH /api/v1/bulk-submissions/{id}` (local-mode outcome driver)
- `GET   /api/v1/validation-messages` (UAT mode — per-message assertion)

### Structural changes

- New feature: `features/bdd/submissionValidation.feature`
- New fixture: `test_upload_files/txt/invalid_submission_period_pre2015.txt` — verbatim copy of source fixture (2-line TXT, zero claims)
- New step class: `steps/SubmissionValidationSteps.java` — fixture-loader, period mutator, submit-and-wait; uses `deleteOnExit()` on temp files
- `context/BddScenarioContext` — new `resolvedSubmissionMonth` field (Lombok-generated accessors)
- `generator/SubmissionPeriodHelper` — new static `monthLabel(int offset)` returning `MMM-YYYY`
- `steps/LegalHelpDisbursementsDuplicateChecksSteps` — shared assertion helper now substitutes context-provided placeholders; no behaviour change for existing DCLHD scenarios

### Verification

```
./gradlew :claims-data:service:bddTest
SUCCESS: Executed 70 tests in 41.9s

tests="70" skipped="0" failures="0" errors="0"
```

Breakdown: 3 new SV rows + 12 DCLH scenarios + 9 DCLHD scenarios + 21 MIME-check scenarios + 25 example rows = 70 tests. No regressions in the existing 67.

`./gradlew :claims-data:service:spotlessCheck` — clean.

Source E2E project (`bulk-submission-and-fee-scheme-tests-`) is untouched — read-only reference for coverage parity.

## Checklist

- [x] Tests passing: `./gradlew :claims-data:service:bddTest` (70/70)
- [x] Rebased on latest `main` (includes squash-merge of #375)
- [x] No whitespace-only churn mixed with code changes
- [x] Diff reviewed against `main`; only bddTest additions plus a tiny substitution hook on the shared DCLHD assertion
- [x] Single commit with a descriptive message explaining the reason for each change
- [ ] E2E tests in `bulk-submission-and-fee-scheme-tests-` — **N/A**, this PR ports coverage _out_ of that repo; the source scenarios remain green there.
