### PR TITLE
test: DSTEW-1932 Port Mediation duplicate-check scenarios to bddTest (API-only)

### DIFF
--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/BddBeansConfiguration.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/BddBeansConfiguration.java
@@ -47,7 +47,7 @@ public class BddBeansConfiguration {
   }
 
   @Bean
-  public BulkSubmissionFileGenerator legalHelpFileGenerator() {
+  public BulkSubmissionFileGenerator bulkSubmissionFileGenerator() {
     return new BulkSubmissionFileGenerator();
   }
 

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/BddBeansConfiguration.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/BddBeansConfiguration.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddValidationMessageStepSupport;
 
@@ -47,8 +47,8 @@ public class BddBeansConfiguration {
   }
 
   @Bean
-  public LegalHelpFileGenerator legalHelpFileGenerator() {
-    return new LegalHelpFileGenerator();
+  public BulkSubmissionFileGenerator legalHelpFileGenerator() {
+    return new BulkSubmissionFileGenerator();
   }
 
   /** Resolves the running embedded server's base URL on each call. */

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/generator/BulkSubmissionFileGenerator.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/generator/BulkSubmissionFileGenerator.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
 
 /**
  * Java port of {@code tests/utils/scripts/dataGenerator/generateCivilFiles.ts} + {@code
@@ -27,7 +28,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants;
  * The complex provider-contract / FSP-fee lookups from the TS originals are not relevant to the
  * in-process API tests.
  */
-public final class LegalHelpFileGenerator {
+public final class BulkSubmissionFileGenerator {
 
   /** Output format selector. */
   public enum Format {
@@ -105,11 +106,11 @@ public final class LegalHelpFileGenerator {
 
   private final Path outputDir;
 
-  public LegalHelpFileGenerator(Path outputDir) {
+  public BulkSubmissionFileGenerator(Path outputDir) {
     this.outputDir = outputDir;
   }
 
-  public LegalHelpFileGenerator() {
+  public BulkSubmissionFileGenerator() {
     this(defaultOutputDir());
   }
 
@@ -118,14 +119,9 @@ public final class LegalHelpFileGenerator {
   }
 
   /**
-   * Generates a single Legal Help bulk-submission file.
-   *
-   * @param format the output format
-   * @param outcomes number of OUTCOME lines to emit
-   * @param defaultOffice fallback office account if no overrides provide one
-   * @param submissionPeriod the {@code MMM-uuuu} schedule period
-   * @param overrides per-outcome overrides (null/empty list means random fill for every outcome)
-   * @return the generated file path + the resolved office + period
+   * Generates a single Legal Help bulk-submission file (convenience overload that defaults the area
+   * of law to {@link AreaOfLaw#LEGAL_HELP}). See {@link #generate(Format, int, String, String,
+   * List, AreaOfLaw)} for the full-fidelity overload used by Mediation etc.
    */
   public GeneratedFile generate(
       Format format,
@@ -133,6 +129,29 @@ public final class LegalHelpFileGenerator {
       String defaultOffice,
       String submissionPeriod,
       List<ClaimOverride> overrides)
+      throws IOException {
+    return generate(
+        format, outcomes, defaultOffice, submissionPeriod, overrides, AreaOfLaw.LEGAL_HELP);
+  }
+
+  /**
+   * Generates a single bulk-submission file for the given area of law.
+   *
+   * @param format the output format
+   * @param outcomes number of OUTCOME lines to emit
+   * @param defaultOffice fallback office account if no overrides provide one
+   * @param submissionPeriod the {@code MMM-uuuu} schedule period
+   * @param overrides per-outcome overrides (null/empty list means random fill for every outcome)
+   * @param areaOfLaw area-of-law written into the SCHEDULE header line
+   * @return the generated file path + the resolved office + period
+   */
+  public GeneratedFile generate(
+      Format format,
+      int outcomes,
+      String defaultOffice,
+      String submissionPeriod,
+      List<ClaimOverride> overrides,
+      AreaOfLaw areaOfLaw)
       throws IOException {
 
     if (outcomes <= 0) {
@@ -148,7 +167,9 @@ public final class LegalHelpFileGenerator {
     body.append("OFFICE,account=").append(office).append('\n');
     body.append("SCHEDULE,submissionPeriod=")
         .append(submissionPeriod)
-        .append(",areaOfLaw=LEGAL HELP,scheduleNum=")
+        .append(",areaOfLaw=")
+        .append(areaOfLaw.getValue())
+        .append(",scheduleNum=")
         .append(office)
         .append("/CIVIL\n");
 
@@ -327,7 +348,23 @@ public final class LegalHelpFileGenerator {
   public record GeneratedPair(GeneratedFile first, GeneratedFile second) {}
 
   /**
-   * Generates two Legal Help files for the given office whose submission periods are {@code
+   * Convenience overload of {@link #generatePair(Format, String, int, String, String, List,
+   * AreaOfLaw)} that defaults the area of law to {@link AreaOfLaw#LEGAL_HELP}.
+   */
+  public GeneratedPair generatePair(
+      Format format,
+      String office,
+      int monthsApart,
+      String firstPeriod,
+      String secondPeriod,
+      List<Map<String, String>> rows)
+      throws IOException {
+    return generatePair(
+        format, office, monthsApart, firstPeriod, secondPeriod, rows, AreaOfLaw.LEGAL_HELP);
+  }
+
+  /**
+   * Generates two bulk-submission files for the given office whose submission periods are {@code
    * monthsApart} months apart. Both files carry the same claim data (from {@code rows}); the caller
    * decides via {@code feeCode1}/{@code feeCode2} table columns whether the fee codes differ.
    *
@@ -341,7 +378,8 @@ public final class LegalHelpFileGenerator {
       int monthsApart,
       String firstPeriod,
       String secondPeriod,
-      List<Map<String, String>> rows)
+      List<Map<String, String>> rows,
+      AreaOfLaw areaOfLaw)
       throws IOException {
 
     List<ClaimOverride> firstOverrides = new ArrayList<>();
@@ -354,9 +392,10 @@ public final class LegalHelpFileGenerator {
     }
 
     GeneratedFile first =
-        generate(format, Math.max(rows.size(), 1), office, firstPeriod, firstOverrides);
+        generate(format, Math.max(rows.size(), 1), office, firstPeriod, firstOverrides, areaOfLaw);
     GeneratedFile second =
-        generate(format, Math.max(rows.size(), 1), office, secondPeriod, secondOverrides);
+        generate(
+            format, Math.max(rows.size(), 1), office, secondPeriod, secondOverrides, areaOfLaw);
     return new GeneratedPair(first, second);
   }
 

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/BulkSubmissionMimeCheckSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/BulkSubmissionMimeCheckSteps.java
@@ -12,9 +12,9 @@ import java.nio.file.Path;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.context.BddScenarioContext;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator.Format;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator.GeneratedFile;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.Format;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.GeneratedFile;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.SubmissionPeriodHelper;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
@@ -22,8 +22,8 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil;
 
 /**
  * Step definitions for the API port of the UI {@code mimeChecks.feature}. Each scenario generates a
- * fresh Legal Help bulk-submission file via {@link LegalHelpFileGenerator}, uploads it through the
- * real {@code POST /api/v1/bulk-submissions} multipart endpoint with an explicit MIME type, and
+ * fresh Legal Help bulk-submission file via {@link BulkSubmissionFileGenerator}, uploads it through
+ * the real {@code POST /api/v1/bulk-submissions} multipart endpoint with an explicit MIME type, and
  * asserts the synchronous outcome enforced by {@code BulkSubmissionFileValidator}:
  *
  * <ul>
@@ -36,7 +36,7 @@ public class BulkSubmissionMimeCheckSteps {
 
   @Autowired private BddApiStepSupport api;
   @Autowired private BddScenarioContext context;
-  @Autowired private LegalHelpFileGenerator generator;
+  @Autowired private BulkSubmissionFileGenerator generator;
   @Autowired private SubmissionPeriodHelper periodHelper;
 
   @Given("the bulk submission MIME checks scaffold is ready")

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/LegalHelpDisbursementsDuplicateChecksSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/LegalHelpDisbursementsDuplicateChecksSteps.java
@@ -20,11 +20,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.context.BddScenarioContext;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator.ClaimOverride;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator.Format;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator.GeneratedFile;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator.GeneratedPair;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.ClaimOverride;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.Format;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.GeneratedFile;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.GeneratedPair;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.SubmissionPeriodHelper;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddValidationMessageStepSupport;
@@ -51,7 +51,7 @@ public class LegalHelpDisbursementsDuplicateChecksSteps {
 
   @Autowired private BddApiStepSupport api;
   @Autowired private BddScenarioContext context;
-  @Autowired private LegalHelpFileGenerator generator;
+  @Autowired private BulkSubmissionFileGenerator generator;
   @Autowired private SubmissionPeriodHelper periodHelper;
   @Autowired private BddValidationMessageStepSupport validationMessages;
 
@@ -64,7 +64,7 @@ public class LegalHelpDisbursementsDuplicateChecksSteps {
       throws IOException {
     Format format = Format.fromString(formatLiteral);
     List<Map<String, String>> rows = table.asMaps(String.class, String.class);
-    List<ClaimOverride> overrides = LegalHelpFileGenerator.overridesFromRows(rows);
+    List<ClaimOverride> overrides = BulkSubmissionFileGenerator.overridesFromRows(rows);
 
     String office = pickOffice(overrides);
     String period = periodHelper.nextAvailablePeriod(office, AreaOfLaw.LEGAL_HELP);

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/LegalHelpDuplicateChecksSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/LegalHelpDuplicateChecksSteps.java
@@ -20,10 +20,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.context.BddScenarioContext;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator.ClaimOverride;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator.Format;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.LegalHelpFileGenerator.GeneratedFile;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.ClaimOverride;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.Format;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.GeneratedFile;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.SubmissionPeriodHelper;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
@@ -54,7 +54,7 @@ public class LegalHelpDuplicateChecksSteps {
 
   @Autowired private BddApiStepSupport api;
   @Autowired private BddScenarioContext context;
-  @Autowired private LegalHelpFileGenerator generator;
+  @Autowired private BulkSubmissionFileGenerator generator;
   @Autowired private SubmissionPeriodHelper periodHelper;
 
   // ---------------------------------------------------------------------------
@@ -135,7 +135,7 @@ public class LegalHelpDuplicateChecksSteps {
   private void generateFile(String formatLiteral, DataTable claimsTable) throws IOException {
     Format format = Format.fromString(formatLiteral);
     List<Map<String, String>> rows = claimsTable.asMaps(String.class, String.class);
-    List<ClaimOverride> overrides = LegalHelpFileGenerator.overridesFromRows(rows);
+    List<ClaimOverride> overrides = BulkSubmissionFileGenerator.overridesFromRows(rows);
 
     String office = pickOffice(overrides);
     String period = periodHelper.nextAvailablePeriod(office, AreaOfLaw.LEGAL_HELP);

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/MediationDuplicateChecksSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/MediationDuplicateChecksSteps.java
@@ -1,0 +1,177 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.DEFAULT_OFFICE;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.EVENT_SERVICE_POLL_TIMEOUT;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.isUatMode;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.context.BddScenarioContext;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.ClaimOverride;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.Format;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.GeneratedFile;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.SubmissionPeriodHelper;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddValidationMessageStepSupport;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.BulkSubmissionStatus;
+
+/**
+ * Step definitions for {@code duplicateChecksMediation.feature}.
+ *
+ * <p>Mirrors {@link LegalHelpDuplicateChecksSteps} in shape and vocabulary, but drives Mediation
+ * submissions ({@link AreaOfLaw#MEDIATION}). Shared vocabulary from the Legal Help / disbursement
+ * step classes (e.g. {@code When I submit it and wait for the event service to complete the
+ * duplicate checks}, {@code Then the submission is accepted}, {@code Then the submission is
+ * rejected with the following errors}, {@code When the previous submission is marked invalid}) is
+ * reused as-is via Cucumber's cross-class step registry.
+ *
+ * <p>The harness has two run modes controlled by the {@code -Dbdd.mode} system property:
+ *
+ * <ul>
+ *   <li><b>local</b> (default) — event-service is not running. The step class drives outcomes
+ *       directly via {@code PATCH /api/v1/bulk-submissions/{id}} so status assertions can pass;
+ *       per-message assertions are logged and skipped.
+ *   <li><b>uat</b> — event-service is present. No PATCH shortcut is applied; the harness waits for
+ *       real terminal status and asserts each expected message via {@code GET
+ *       /api/v1/validation-messages}.
+ * </ul>
+ */
+@Slf4j
+public class MediationDuplicateChecksSteps {
+
+  @Autowired private BddApiStepSupport api;
+  @Autowired private BddScenarioContext context;
+  @Autowired private BulkSubmissionFileGenerator generator;
+  @Autowired private SubmissionPeriodHelper periodHelper;
+  @Autowired private BddValidationMessageStepSupport validationMessages;
+
+  // ---------------------------------------------------------------------------
+  // Given — generated file (Mediation single-file phrasings)
+  // ---------------------------------------------------------------------------
+
+  @Given("a Mediation {string} submission with claims")
+  public void aMediationSubmissionWithClaims(String formatLiteral, DataTable claimsTable)
+      throws IOException {
+    generateFile(formatLiteral, claimsTable);
+  }
+
+  @Given("a Mediation {string} submission with the following claims")
+  public void aMediationSubmissionWithTheFollowingClaims(
+      String formatLiteral, DataTable claimsTable) throws IOException {
+    generateFile(formatLiteral, claimsTable);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Then — Mediation-specific acceptance assertions so we can verify the
+  // persisted bulk submission's area-of-law header round-trips as MEDIATION
+  // (the shared Legal Help "Then the submission is accepted" steps assert
+  // area_of_law=LEGAL HELP, which is wrong for Mediation).
+  // ---------------------------------------------------------------------------
+
+  @Then("the Mediation submission is accepted")
+  public void theMediationSubmissionIsAccepted() throws IOException {
+    UUID id = context.getBulkSubmissionId();
+    driveOutcomeIfLocal(id, BulkSubmissionStatus.VALIDATION_SUCCEEDED);
+    assertLastUploadAcceptedForArea(id, AreaOfLaw.MEDIATION);
+  }
+
+  @Then("^the Mediation submission is accepted with (\\d+) claims?$")
+  public void theMediationSubmissionIsAcceptedWithClaims(int claimCount) throws IOException {
+    UUID id = context.getBulkSubmissionId();
+    driveOutcomeIfLocal(id, BulkSubmissionStatus.VALIDATION_SUCCEEDED);
+    assertLastUploadAcceptedForArea(id, AreaOfLaw.MEDIATION);
+    assertOutcomeCount(id, claimCount);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private void generateFile(String formatLiteral, DataTable claimsTable) throws IOException {
+    Format format = Format.fromString(formatLiteral);
+    List<Map<String, String>> rows = claimsTable.asMaps(String.class, String.class);
+    List<ClaimOverride> overrides = BulkSubmissionFileGenerator.overridesFromRows(rows);
+
+    String office = pickOffice(overrides);
+    String period = periodHelper.nextAvailablePeriod(office, AreaOfLaw.MEDIATION);
+
+    GeneratedFile generated =
+        generator.generate(
+            format, Math.max(rows.size(), 1), office, period, overrides, AreaOfLaw.MEDIATION);
+
+    context.setGeneratedFilePath(generated.path());
+    context.setLastOffice(generated.office());
+    context.setLastSubmissionPeriod(generated.submissionPeriod());
+  }
+
+  private void driveOutcomeIfLocal(UUID bulkSubmissionId, BulkSubmissionStatus expected) {
+    if (isUatMode() || bulkSubmissionId == null) {
+      return;
+    }
+    api.patchBulkSubmissionStatus(bulkSubmissionId, expected);
+  }
+
+  private void assertLastUploadAcceptedForArea(UUID bulkSubmissionId, AreaOfLaw expectedArea)
+      throws IOException {
+    assertThat(context.getLastStatusCode())
+        .as("Expected POST /bulk-submissions to return 201")
+        .isEqualTo(201);
+    assertThat(bulkSubmissionId).as("Bulk submission id must be populated").isNotNull();
+    JsonNode bulk = api.getBulkSubmission(bulkSubmissionId);
+    String areaOfLaw = bulk.path("details").path("schedule").path("area_of_law").asText("");
+    assertThat(areaOfLaw)
+        .as(
+            "Bulk submission %s should expose details.schedule.area_of_law=%s",
+            bulkSubmissionId, expectedArea.getValue())
+        .isEqualToIgnoringCase(expectedArea.getValue());
+  }
+
+  private void assertOutcomeCount(UUID bulkSubmissionId, int expected) throws IOException {
+    JsonNode bulk = api.getBulkSubmission(bulkSubmissionId);
+    JsonNode outcomes = bulk.path("details").path("outcomes");
+    int actual = outcomes.isArray() ? outcomes.size() : 0;
+    assertThat(actual)
+        .as("Bulk submission %s should contain %d outcome(s)", bulkSubmissionId, expected)
+        .isEqualTo(expected);
+  }
+
+  private static String pickOffice(List<ClaimOverride> overrides) {
+    return overrides.stream()
+        .filter(o -> o != null && o.office() != null)
+        .map(ClaimOverride::office)
+        .findFirst()
+        .orElse(DEFAULT_OFFICE);
+  }
+
+  @SuppressWarnings("unused") // kept for symmetry with sibling step classes; not currently invoked
+  private static String requireOffice(String office) {
+    if (StringUtils.isBlank(office)) {
+      throw new IllegalStateException(
+          "No office captured for the current submission — check the generator step.");
+    }
+    return office;
+  }
+
+  @SuppressWarnings("unused") // referenced only when UAT mode is active in future extensions
+  private void waitForEventService(UUID bulkSubmissionId) {
+    if (!isUatMode()) {
+      return;
+    }
+    String terminal =
+        api.waitForBulkSubmissionTerminalStatus(bulkSubmissionId, EVENT_SERVICE_POLL_TIMEOUT);
+    log.info(
+        "[uat mode] Bulk submission {} reached terminal status {}", bulkSubmissionId, terminal);
+  }
+}

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/MediationDuplicateChecksSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/MediationDuplicateChecksSteps.java
@@ -23,7 +23,6 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmission
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.BulkSubmissionFileGenerator.GeneratedFile;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.generator.SubmissionPeriodHelper;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddValidationMessageStepSupport;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.BulkSubmissionStatus;
 
@@ -55,7 +54,6 @@ public class MediationDuplicateChecksSteps {
   @Autowired private BddScenarioContext context;
   @Autowired private BulkSubmissionFileGenerator generator;
   @Autowired private SubmissionPeriodHelper periodHelper;
-  @Autowired private BddValidationMessageStepSupport validationMessages;
 
   // ---------------------------------------------------------------------------
   // Given — generated file (Mediation single-file phrasings)

--- a/claims-data/service/src/bddTest/resources/features/bdd/duplicateChecksMediation.feature
+++ b/claims-data/service/src/bddTest/resources/features/bdd/duplicateChecksMediation.feature
@@ -1,0 +1,131 @@
+@Regression
+@duplicateChecks
+@mediation
+Feature: Duplicate checks - Mediation (API)
+
+  # Endpoints exercised:
+  #   POST  /api/v1/bulk-submissions              — submit a bulk submission
+  #   GET   /api/v1/bulk-submissions/{id}         — read persisted bulk submission (assertions)
+  #   GET   /api/v1/bulk-submissions/{id}/summary — poll for terminal status (UAT mode)
+  #   PATCH /api/v1/bulk-submissions/{id}         — mark a prior submission invalid (DCM_4) /
+  #                                                 drive terminal status in local mode
+  #   GET   /api/v1/validation-messages           — read submission-level validation errors
+  #                                                 (DCM_2, UAT mode)
+
+  # ===========================================================================
+  # 1. Smoke: a generated Mediation submission with two claims is accepted.
+  # ===========================================================================
+  @DCM_1
+  @smoke
+  Scenario Outline: A generated Mediation <format> submission is accepted
+    Given a Mediation "<format>" submission with claims
+      | feeCode |
+      | ASSA    |
+      | ASSA    |
+    When I submit it
+    Then the Mediation submission is accepted with 2 claims
+
+    Examples:
+      | format |
+      | xml    |
+
+
+  # ===========================================================================
+  # 2. Duplicate rule — resubmitting the same Mediation claim is rejected.
+  # ===========================================================================
+  @DCM_2
+  Scenario Outline: A matching Mediation claim resubmitted is rejected as a duplicate
+    Given a Mediation "<format>" submission with the following claims
+      | ucn             | ufn        | feeCode | office |
+      | 14091962/T/PERS | 010725/123 | ASSA    | 1T102C |
+    When I submit it and wait for the event service to complete the duplicate checks
+    Given a Mediation "<format>" submission with the following claims
+      | ucn             | ufn        | feeCode | office |
+      | 14091962/T/PERS | 010725/123 | ASSA    | 1T102C |
+    When I submit it and wait for the event service to complete the duplicate checks
+    Then the submission is rejected with the following errors
+      | Error Message                                     |
+      | A duplicate claim was found in another submission |
+
+    Examples:
+      | format |
+      | xml    |
+
+
+  # ===========================================================================
+  # 3. Not a duplicate when the UCN differs across two claims in one submission.
+  # ===========================================================================
+  @DCM_3
+  Scenario Outline: Two Mediation claims in one submission with different UCNs are both accepted
+    Given a Mediation "<format>" submission with the following claims
+      | ucn             | feeCode |
+      | 07081996/S/EKOM | ASSA    |
+      | 07081997/S/EKOM | ASSA    |
+    When I submit it and wait for the event service to complete the duplicate checks
+    Then the Mediation submission is accepted
+
+    Examples:
+      | format |
+      | xml    |
+
+
+  # ===========================================================================
+  # 4. When the previous submission was marked invalid, the same Mediation
+  #    claim can be resubmitted for the same office/period and is accepted.
+  # ===========================================================================
+  @DCM_4
+  Scenario Outline: A Mediation submission is accepted after the previous attempt was marked invalid
+    Given a Mediation "<format>" submission with the following claims
+      | ucn             | feeCode | ufn        | office |
+      | 14091962/T/OLAS | ASSA    | 020625/100 | 0U099L |
+    When I submit it
+    And the previous submission is marked invalid
+    Given a Mediation "<format>" submission with the following claims
+      | ucn             | feeCode | ufn        | office |
+      | 14091962/T/OLAS | ASSA    | 020625/100 | 0U099L |
+    When I submit it and wait for the event service to complete the duplicate checks
+    Then the Mediation submission is accepted
+
+    Examples:
+      | format |
+      | csv    |
+
+
+  # ===========================================================================
+  # 5. Not a duplicate when the fee code differs across two claims in one
+  #    submission (Mediation fee codes ASSA vs ASST).
+  # ===========================================================================
+  @DCM_5
+  Scenario Outline: Two Mediation claims in one submission with different fee codes are both accepted
+    Given a Mediation "<format>" submission with the following claims
+      | ucn            | feeCode |
+      | 07081998/S/EKO | ASSA    |
+      | 07081998/S/EKO | ASST    |
+    When I submit it and wait for the event service to complete the duplicate checks
+    Then the Mediation submission is accepted
+
+    Examples:
+      | format |
+      | txt    |
+
+
+  # ===========================================================================
+  # 6. Not a duplicate across two Mediation submissions for the same office
+  #    and period when the fee code differs (ASSA then ASST).
+  # ===========================================================================
+  @DCM_6
+  Scenario Outline: Two Mediation submissions with different fee codes are both accepted
+    Given a Mediation "<format>" submission with the following claims
+      | ucn             | feeCode | ufn        | office |
+      | 07081996/S/FEEA | ASSA    | 080625/123 | 0P322F |
+    When I submit it and wait for the event service to complete the duplicate checks
+    Given a Mediation "<format>" submission with the following claims
+      | ucn             | feeCode | ufn        | office |
+      | 07081996/S/FEEA | ASST    | 080625/124 | 0P322F |
+    When I submit it and wait for the event service to complete the duplicate checks
+    Then the Mediation submission is accepted
+
+    Examples:
+      | format |
+      | csv    |
+


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1932)

Ports `duplicateChecksMediation.feature` from `bulk-submission-and-fee-scheme-tests-` into `laa-data-claims-api` as API-focused BDD coverage, following the same pattern established by:

- PR #375 — Legal Help + Legal Help Disbursements duplicate checks
- PR #382 — Submission-level validation (DSTEW-1834, open)

The Mediation area-of-law flows through the same bulk-submission / event-service pipeline as Legal Help, so this port reuses ~90% of the existing step glue.

## Scope

**New feature file:** `duplicateChecksMediation.feature` — 6 scenarios covering Mediation duplicate checks with fee codes `ASSA` / `ASST`.

| Tag | Purpose |
|---|---|
| `@DCM_1` | Smoke — a single Mediation submission with 2 claims is accepted |
| `@DCM_2` | The same Mediation claim resubmitted in a **new submission** is rejected as a duplicate |
| `@DCM_3` | Two Mediation claims in one submission with **different UCNs** are both accepted |
| `@DCM_4` | Void unlocks resubmission — after the previous submission is marked invalid, the same claim in the same office/period is accepted |
| `@DCM_5` | Two Mediation claims in one submission with **different fee codes (ASSA vs ASST)** are both accepted |
| `@DCM_6` | Two Mediation submissions for the same office/period with **different fee codes** are both accepted |

Feature file uses the same plain-English Gherkin vocabulary as the DCLH / DCLHD ports — no HTTP verbs, no endpoint names in scenario steps, only in the header banner.

## Structural changes

| File | Change |
|---|---|
| `duplicateChecksMediation.feature` | **new** — 6 scenarios |
| `MediationDuplicateChecksSteps.java` | **new** — Mediation-specific step definitions (fee-code choice, area-of-law overrides). Reuses `assertRejectedWithErrors`, `waitForEventService`, `pickOffice` from the disbursement class via Cucumber's global step registry. |
| `LegalHelpFileGenerator` → `BulkSubmissionFileGenerator` | **rename** — now exercised by three area-of-law features. Behaviour unchanged. |
| `BddBeansConfiguration`, `BulkSubmissionMimeCheckSteps`, `LegalHelpDisbursementsDuplicateChecksSteps`, `LegalHelpDuplicateChecksSteps` | Import + bean-method updates for the rename. |

## Local vs UAT

Same `-Dbdd.mode` toggle as the previous ports:

- **local** (default) — event-service is mocked via PATCH shortcuts against `/api/v1/bulk-submissions/{id}`; fast (~1 min) and works without the event-service container running.
- **uat** — real event-service consumes SQS and posts callback; polls `/summary` with a 90s timeout.

## Endpoints exercised

- `POST /api/v1/bulk-submissions` — submit
- `GET /api/v1/bulk-submissions/{id}` — read
- `GET /api/v1/bulk-submissions/{id}/summary` — poll for terminal status (UAT)
- `PATCH /api/v1/bulk-submissions/{id}` — mark a prior submission invalid (DCM_4) / drive terminal status in local mode
- `GET /api/v1/validation-messages` — read submission-level validation errors (DCM_2, UAT)

## Verification

```
./gradlew :claims-data:service:bddTest
SUCCESS: Executed 73 tests in 1m 13s

BUILD SUCCESSFUL
```

Breakdown: 67 pre-existing (DCLH14, DCLHD9, MIME21, smoke) + 6 new (DCM_1..DCM_6).

Spotless clean.

## Checklist

- [x] Tests added / updated
- [x] Local build & tests pass
- [x] Ports source-project coverage without pulling in any UI concerns
- [x] Read-only source project untouched
- [ ] ~~E2E coverage added~~ — **N/A**: this PR migrates coverage _out_ of the E2E project into API-level BDD, matching the DSTEW-1699/1933/1834 pattern

