### PR TITLE
chore(DSTEW-1991): bump log4j to 2.25.5 to fix the vulnerability reported by Snyk

### DIFF
--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -61,6 +61,9 @@ dependencyManagement {
         // Force jackson-core 2.x to fix Snyk vulnerability
         dependency "com.fasterxml.jackson.core:jackson-core:2.21.5"
         dependency "com.fasterxml.jackson.core:jackson-databind:2.21.5"
+        // Bump Log4j API to resolve Snyk issue (upgrade from 2.25.4 -> 2.25.5)
+        dependency "org.apache.logging.log4j:log4j-api:2.25.5"
+        dependency "org.apache.logging.log4j:log4j-to-slf4j:2.25.5"
         // Force jackson-core 3.x to fix Snyk vulnerability (AWS SDK pulls tools.jackson)
         dependency 'tools.jackson.core:jackson-core:3.1.4'
         dependency 'tools.jackson.core:jackson-databind:3.1.4'


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1991)

Describe what you did and why.

DSTEW-1991: bump log4j to 2.25.5 to fix the vulnerability reported by Snyk

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
