### PR TITLE
feat(DSTEW-2005): Added Area-of-law based claim field amendability validation gate

### DIFF
--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationServiceIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationServiceIntegrationTest.java
@@ -23,6 +23,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnap
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.AmendmentReasonReferenceEntity;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.RequestedByReferenceEntity;
 import uk.gov.justice.laa.dstew.payments.claimsdata.helper.MockServerIntegrationTest;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.AmendmentReasonReferenceRepository;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.RequestedByReferenceRepository;
@@ -66,6 +67,7 @@ class ClaimAmendmentValidationServiceIntegrationTest extends MockServerIntegrati
   private static final String SEEDED_REASON = "PROVIDER_ERROR";
   // INCORRECT_MEANS_ASSESSMENT is seeded only for CONTRACT_MANAGEMENT / ASSURANCE, never PROVIDER.
   private static final String SEEDED_REASON_OTHER_PARTY = "INCORRECT_MEANS_ASSESSMENT";
+  public static final String NOT_A_UUID = "not-a-uuid";
 
   @Autowired private ClaimAmendmentValidationService validationService;
   @Autowired private RequestedByReferenceRepository requestedByReferenceRepository;
@@ -104,8 +106,7 @@ class ClaimAmendmentValidationServiceIntegrationTest extends MockServerIntegrati
     void voidClaimReturnsOnlyFatalAndSkipsLaterSteps() {
       // Requested-by, reason and user id are all invalid too, but the fatal status error must
       // short-circuit the flow before the reference and user-id steps run.
-      ClaimAmendmentState state =
-          stateOf(ClaimStatus.VOID, "MADE_UP", "ALSO_MADE_UP", "not-a-uuid");
+      ClaimAmendmentState state = stateOf(ClaimStatus.VOID, "MADE_UP", "ALSO_MADE_UP", NOT_A_UUID);
 
       assertThat(validationService.validateAmendmentRequest(state))
           .extracting(ClaimAmendmentValidationError::getCode)
@@ -194,7 +195,7 @@ class ClaimAmendmentValidationServiceIntegrationTest extends MockServerIntegrati
     @DisplayName("a structurally invalid user id is rejected while the metadata is valid")
     void invalidUserId() {
       ClaimAmendmentState state =
-          stateOf(ClaimStatus.VALID, SEEDED_PARTY, SEEDED_REASON, "not-a-uuid");
+          stateOf(ClaimStatus.VALID, SEEDED_PARTY, SEEDED_REASON, NOT_A_UUID);
 
       assertThat(validationService.validateAmendmentRequest(state))
           .extracting(ClaimAmendmentValidationError::getCode)
@@ -248,6 +249,57 @@ class ClaimAmendmentValidationServiceIntegrationTest extends MockServerIntegrati
                             .toString());
                 assertThat(error.isFatal()).isTrue();
               });
+    }
+  }
+
+  @Nested
+  @DisplayName("field amendability gate (Step 12 aggregation)")
+  class FieldAmendabilityGate {
+
+    @Test
+    @DisplayName("a non-amendable changed field is collected and aggregates with other errors")
+    void nonAmendableFieldAggregatesWithOtherErrors() {
+      ClaimAmendmentState state = stateWithNonAmendableChange();
+
+      assertThat(validationService.validateAmendmentRequest(state))
+          .extracting(ClaimAmendmentValidationError::getCode)
+          .contains(
+              ClaimAmendmentValidationCode.INVALID_FIELD_NOT_AMENDABLE_FOR_AREA_OF_LAW.toString(),
+              ClaimAmendmentValidationCode.INVALID_USER_IDENTIFIER_FORMAT.toString());
+    }
+
+    /**
+     * Builds a state whose requested change is not amendable for the claim's area of law, alongside
+     * a structurally invalid user id. Scheme ID is amendable for Crime Lower only, so changing it
+     * on a Legal Help claim must be rejected by the amendability gate; the invalid user id proves
+     * the gate's field-level failure aggregates with other collected errors.
+     */
+    private ClaimAmendmentState stateWithNonAmendableChange() {
+      ClaimStateSnapshot before =
+          ClaimStateSnapshot.builder()
+              .claimId(Uuid7.timeBasedUuid())
+              .areaOfLaw(AreaOfLaw.LEGAL_HELP)
+              .feeCode(CLAIM_FEE_CODE)
+              .status(ClaimStatus.VALID)
+              .lineNumber(1)
+              .netDisbursementAmount(new BigDecimal("0.00"))
+              .disbursementsVatAmount(new BigDecimal("0.00"))
+              .caseStartDate(LocalDate.ofInstant(Instant.now(), ZoneId.systemDefault()))
+              .schemeId("SCHEME-1")
+              .build();
+
+      ClaimStateSnapshot after = before.toBuilder().schemeId("SCHEME-2").build();
+
+      return ClaimAmendmentState.builder()
+          .beforeState(before)
+          .postAmendmentState(after)
+          .requestPayload(
+              ClaimAmendmentPayload.builder()
+                  .amendmentRequestedBy(JsonNullable.of(SEEDED_PARTY))
+                  .amendmentReasonCode(JsonNullable.of(SEEDED_REASON))
+                  .amendmentUserId(JsonNullable.of(NOT_A_UUID))
+                  .build())
+          .build();
     }
   }
 

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentValidationCode.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentValidationCode.java
@@ -141,6 +141,18 @@ public enum ClaimAmendmentValidationCode {
       "The user identifier must be a valid UUID",
       "Submitting user's Entra UUID is not a structurally valid UUID"),
 
+  // ----- Field amendability gate (DSTEW-1593) -----
+
+  /**
+   * A changed field is not amendable for the claim's area of law. The message names the offending
+   * field and area of law so the failure can be attributed to the specific field.
+   */
+  INVALID_FIELD_NOT_AMENDABLE_FOR_AREA_OF_LAW(
+      ValidationSeverity.ERROR,
+      HttpStatus.BAD_REQUEST,
+      "Field '%s' is not amendable for area of law '%s'",
+      "Changed field is not in the amendable set for the claim's area of law"),
+
   // ----- Amendment metadata: technical failures (DSTEW-1765) -----
 
   /** The governed amendment metadata reference data was unavailable at submit time. */

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationService.java
@@ -16,6 +16,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.BeforeStatePresenceValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.ClaimAmendmentValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.ClaimStatusValidationStep;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.FieldAmendabilityValidationStep;
 
 /**
  * Runs the synchronous claim amendment flow as an ordered list of validation steps executed in
@@ -65,6 +66,7 @@ public class ClaimAmendmentValidationService {
           BeforeStatePresenceValidationStep.class,
           ClaimStatusValidationStep.class,
           AssessedClaimPricingValidationStep.class,
+          FieldAmendabilityValidationStep.class,
           AmendmentUserIdValidationStep.class,
           AmendmentReferenceValidationStep.class,
           // External steps sit inline with the rest (they make PDA/FSP calls but are ordinary

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/AmendableClaimFields.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/AmendableClaimFields.java
@@ -1,0 +1,243 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation;
+
+import java.util.Map;
+import java.util.Set;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers.ClaimCaseFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers.ClaimFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers.ClaimSummaryFeeFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers.ClientFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+
+/**
+ * Central, auditable registry of the claim fields a provider is permitted to amend, organised by
+ * {@link AreaOfLaw area of law}.
+ *
+ * <p>This is the single source of truth for "is a change to this claim field amendable for the
+ * claim's area of law?". It mirrors the final signed-off AaBC artefact <em>"Amend MVP - fields for
+ * amendment"</em>, which is authored per area of law. Each area's set is a flat, self-contained
+ * list of the diff field identifiers amendable for that area, so it can be reviewed line-for-line
+ * against the artefact. A field/area-of-law pair not represented here is <b>not</b> amendable.
+ *
+ * <p>Fields amendable for more than one area appear in each of those areas' sets. The identifier
+ * strings live once in {@link
+ * uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers}, so a
+ * shared field is a repeated constant reference, not a duplicated string.
+ *
+ * <p>Mapping notes for artefact labels whose recognised identifier is not a literal match:
+ *
+ * <ul>
+ *   <li>Crime Lower "Matter Type" maps to {@code claim.crimeMatterTypeCode}.
+ *   <li>Legal Help / Mediation "Matter Type 1" and "Matter Type 2" are the first and second
+ *       components of the single {@code claim.matterTypeCode} value (stored as {@code MT1:MT2}), so
+ *       both are covered by that one identifier.
+ *   <li>Crime Lower "Client Initial" maps to {@code client.clientForename} (the crime-lower client
+ *       name column).
+ *   <li>Mediation "Claim ID" maps to {@code claimCase.caseId} - the provider-facing case
+ *       identifier, not the internal {@code claim.id}.
+ *   <li>Legal Help "NIAT Disbursement Prior Authority Number" maps to {@code
+ *       claimSummaryFee.priorAuthorityReference} only.
+ *   <li>Legal Help "Clients resulting in a Legal Help matter opened" maps to {@code
+ *       claimSummaryFee.surgeryMattersCount}; "Clients seen at surgery" maps to {@code
+ *       claimSummaryFee.surgeryClientsCount}.
+ * </ul>
+ */
+public final class AmendableClaimFields {
+
+  private AmendableClaimFields() {
+    // Registry holder; no instances.
+  }
+
+  /** Fields amendable for a Crime Lower claim. */
+  private static final Set<String> CRIME_LOWER =
+      Set.of(
+          // claim.*
+          ClaimFields.FEE_CODE,
+          ClaimFields.CRIME_MATTER_TYPE_CODE,
+          ClaimFields.CASE_CONCLUDED_DATE,
+          ClaimFields.UNIQUE_FILE_NUMBER,
+          ClaimFields.REPRESENTATION_ORDER_DATE,
+          ClaimFields.SUSPECTS_DEFENDANTS_COUNT,
+          ClaimFields.POLICE_STATION_COURT_ATTENDANCES_COUNT,
+          ClaimFields.POLICE_STATION_COURT_PRISON_ID,
+          ClaimFields.DSCC_NUMBER,
+          ClaimFields.MAAT_ID,
+          ClaimFields.PRISON_LAW_PRIOR_APPROVAL_NUMBER,
+          ClaimFields.DUTY_SOLICITOR,
+          ClaimFields.YOUTH_COURT,
+          ClaimFields.SCHEME_ID,
+          // client.*
+          ClientFields.CLIENT_FORENAME,
+          ClientFields.CLIENT_SURNAME,
+          ClientFields.GENDER_CODE,
+          ClientFields.ETHNICITY_CODE,
+          ClientFields.DISABILITY_CODE,
+          // claimCase.*
+          ClaimCaseFields.OUTCOME_CODE,
+          ClaimCaseFields.STAGE_REACHED_CODE,
+          ClaimCaseFields.STANDARD_FEE_CATEGORY_CODE,
+          // claimSummaryFee.*
+          ClaimSummaryFeeFields.NET_DISBURSEMENT_AMOUNT,
+          ClaimSummaryFeeFields.IS_VAT_APPLICABLE,
+          ClaimSummaryFeeFields.DISBURSEMENTS_VAT_AMOUNT,
+          ClaimSummaryFeeFields.NET_PROFIT_COSTS_AMOUNT,
+          ClaimSummaryFeeFields.TRAVEL_WAITING_COSTS_AMOUNT,
+          ClaimSummaryFeeFields.NET_WAITING_COSTS_AMOUNT);
+
+  /** Fields amendable for a Mediation claim. */
+  private static final Set<String> MEDIATION =
+      Set.of(
+          // claim.*
+          ClaimFields.FEE_CODE,
+          ClaimFields.MATTER_TYPE_CODE,
+          ClaimFields.CASE_CONCLUDED_DATE,
+          ClaimFields.CASE_REFERENCE_NUMBER,
+          ClaimFields.CASE_START_DATE,
+          ClaimFields.SCHEDULE_REFERENCE,
+          ClaimFields.MEDIATION_SESSIONS_COUNT,
+          ClaimFields.MEDIATION_TIME_MINUTES,
+          ClaimFields.OUTREACH_LOCATION,
+          ClaimFields.REFERRAL_SOURCE,
+          // client.*
+          ClientFields.CLIENT_FORENAME,
+          ClientFields.CLIENT_SURNAME,
+          ClientFields.GENDER_CODE,
+          ClientFields.ETHNICITY_CODE,
+          ClientFields.DISABILITY_CODE,
+          ClientFields.CLIENT_DATE_OF_BIRTH,
+          ClientFields.UNIQUE_CLIENT_NUMBER,
+          ClientFields.CLIENT_POSTCODE,
+          ClientFields.IS_LEGALLY_AIDED,
+          ClientFields.CLIENT2_FORENAME,
+          ClientFields.CLIENT2_SURNAME,
+          ClientFields.CLIENT2_DATE_OF_BIRTH,
+          ClientFields.CLIENT2_UCN,
+          ClientFields.CLIENT2_POSTCODE,
+          ClientFields.CLIENT2_GENDER_CODE,
+          ClientFields.CLIENT2_ETHNICITY_CODE,
+          ClientFields.CLIENT2_DISABILITY_CODE,
+          ClientFields.CLIENT2_IS_LEGALLY_AIDED,
+          // claimCase.*
+          ClaimCaseFields.OUTCOME_CODE,
+          ClaimCaseFields.CASE_ID,
+          ClaimCaseFields.UNIQUE_CASE_ID,
+          ClaimCaseFields.IS_POSTAL_APPLICATION_ACCEPTED,
+          ClaimCaseFields.IS_CLIENT2_POSTAL_APPLICATION_ACCEPTED,
+          // claimSummaryFee.*
+          ClaimSummaryFeeFields.NET_DISBURSEMENT_AMOUNT,
+          ClaimSummaryFeeFields.IS_VAT_APPLICABLE,
+          ClaimSummaryFeeFields.DISBURSEMENTS_VAT_AMOUNT);
+
+  /** Fields amendable for a Legal Help claim. */
+  private static final Set<String> LEGAL_HELP =
+      Set.of(
+          // claim.*
+          ClaimFields.FEE_CODE,
+          ClaimFields.MATTER_TYPE_CODE,
+          ClaimFields.CASE_CONCLUDED_DATE,
+          ClaimFields.UNIQUE_FILE_NUMBER,
+          ClaimFields.CASE_REFERENCE_NUMBER,
+          ClaimFields.CASE_START_DATE,
+          ClaimFields.SCHEDULE_REFERENCE,
+          ClaimFields.ACCESS_POINT_CODE,
+          ClaimFields.DELIVERY_LOCATION,
+          ClaimFields.PROCUREMENT_AREA_CODE,
+          // client.*
+          ClientFields.CLIENT_FORENAME,
+          ClientFields.CLIENT_SURNAME,
+          ClientFields.GENDER_CODE,
+          ClientFields.ETHNICITY_CODE,
+          ClientFields.DISABILITY_CODE,
+          ClientFields.CLIENT_DATE_OF_BIRTH,
+          ClientFields.UNIQUE_CLIENT_NUMBER,
+          ClientFields.CLIENT_POSTCODE,
+          ClientFields.CLIENT_TYPE_CODE,
+          ClientFields.HOME_OFFICE_CLIENT_NUMBER,
+          ClientFields.CLA_REFERENCE_NUMBER,
+          ClientFields.CLA_EXEMPTION_CODE,
+          // claimCase.*
+          ClaimCaseFields.OUTCOME_CODE,
+          ClaimCaseFields.STAGE_REACHED_CODE,
+          ClaimCaseFields.CASE_ID,
+          ClaimCaseFields.UNIQUE_CASE_ID,
+          ClaimCaseFields.IS_POSTAL_APPLICATION_ACCEPTED,
+          ClaimCaseFields.CASE_STAGE_CODE,
+          ClaimCaseFields.DESIGNATED_ACCREDITED_REPRESENTATIVE_CODE,
+          ClaimCaseFields.EXCEPTIONAL_CASE_FUNDING_REFERENCE,
+          ClaimCaseFields.EXEMPTION_CRITERIA_SATISFIED,
+          ClaimCaseFields.FOLLOW_ON_WORK,
+          ClaimCaseFields.IS_LEGACY_CASE,
+          ClaimCaseFields.MENTAL_HEALTH_TRIBUNAL_REFERENCE,
+          ClaimCaseFields.IS_NRM_ADVICE,
+          ClaimCaseFields.TRANSFER_DATE,
+          // claimSummaryFee.*
+          ClaimSummaryFeeFields.NET_DISBURSEMENT_AMOUNT,
+          ClaimSummaryFeeFields.IS_VAT_APPLICABLE,
+          ClaimSummaryFeeFields.DISBURSEMENTS_VAT_AMOUNT,
+          ClaimSummaryFeeFields.NET_PROFIT_COSTS_AMOUNT,
+          ClaimSummaryFeeFields.TRAVEL_WAITING_COSTS_AMOUNT,
+          ClaimSummaryFeeFields.NET_COUNSEL_COSTS_AMOUNT,
+          ClaimSummaryFeeFields.IS_ADDITIONAL_TRAVEL_PAYMENT,
+          ClaimSummaryFeeFields.ADJOURNED_HEARING_FEE_AMOUNT,
+          ClaimSummaryFeeFields.ADVICE_TIME,
+          ClaimSummaryFeeFields.TRAVEL_TIME,
+          ClaimSummaryFeeFields.WAITING_TIME,
+          ClaimSummaryFeeFields.AIT_HEARING_CENTRE_CODE,
+          ClaimSummaryFeeFields.CMRH_ORAL_COUNT,
+          ClaimSummaryFeeFields.CMRH_TELEPHONE_COUNT,
+          ClaimSummaryFeeFields.COURT_LOCATION_CODE,
+          ClaimSummaryFeeFields.DETENTION_TRAVEL_WAITING_COSTS_AMOUNT,
+          ClaimSummaryFeeFields.IS_ELIGIBLE_CLIENT,
+          ClaimSummaryFeeFields.HO_INTERVIEW,
+          ClaimSummaryFeeFields.IS_IRC_SURGERY,
+          ClaimSummaryFeeFields.JR_FORM_FILLING_AMOUNT,
+          ClaimSummaryFeeFields.LOCAL_AUTHORITY_NUMBER,
+          ClaimSummaryFeeFields.IS_LONDON_RATE,
+          ClaimSummaryFeeFields.MEDICAL_REPORTS_COUNT,
+          ClaimSummaryFeeFields.MEETINGS_ATTENDED_CODE,
+          ClaimSummaryFeeFields.PRIOR_AUTHORITY_REFERENCE,
+          ClaimSummaryFeeFields.SURGERY_CLIENTS_COUNT,
+          ClaimSummaryFeeFields.SURGERY_MATTERS_COUNT,
+          ClaimSummaryFeeFields.IS_SUBSTANTIVE_HEARING,
+          ClaimSummaryFeeFields.SURGERY_DATE,
+          ClaimSummaryFeeFields.IS_TOLERANCE_APPLICABLE,
+          ClaimSummaryFeeFields.ADVICE_TYPE_CODE,
+          ClaimSummaryFeeFields.COSTS_DAMAGES_RECOVERED_AMOUNT);
+
+  private static final Map<AreaOfLaw, Set<String>> AMENDABLE_BY_AREA =
+      Map.of(
+          AreaOfLaw.CRIME_LOWER, CRIME_LOWER,
+          AreaOfLaw.MEDIATION, MEDIATION,
+          AreaOfLaw.LEGAL_HELP, LEGAL_HELP);
+
+  /**
+   * Whether the given amendment diff field identifier is amendable for the given area of law.
+   *
+   * <p>The {@code field} is a stable diff identifier as emitted by the {@code
+   * AmendmentChangeDetector} (e.g. {@code "claim.feeCode"}).
+   *
+   * <p>A {@code null} field, a {@code null} area of law (unknown/absent area), or a field not
+   * amendable for that area are all treated as not amendable.
+   *
+   * @param field the amendment diff field identifier; may be {@code null}
+   * @param areaOfLaw the claim's area of law; may be {@code null}
+   * @return {@code true} if the field is amendable for that area of law
+   */
+  public static boolean isAmendable(String field, AreaOfLaw areaOfLaw) {
+    if (field == null || areaOfLaw == null) {
+      return false;
+    }
+    return AMENDABLE_BY_AREA.getOrDefault(areaOfLaw, Set.of()).contains(field);
+  }
+
+  /**
+   * The set of field identifiers amendable for the given area of law. Package-private introspection
+   * for same-package tests only; not part of the public API. Returns an empty set for a {@code
+   * null} or unmapped area.
+   *
+   * @param areaOfLaw the area of law
+   * @return the amendable field identifiers for that area (never {@code null})
+   */
+  static Set<String> amendableFieldsFor(AreaOfLaw areaOfLaw) {
+    return AMENDABLE_BY_AREA.getOrDefault(areaOfLaw, Set.of());
+  }
+}

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/FieldAmendabilityValidationStep.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/FieldAmendabilityValidationStep.java
@@ -1,0 +1,62 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentDiff;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ChangeSource;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationCode;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.DiffEntry;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.persistence.AmendmentDiffAssembler;
+
+/**
+ * Field amendability gate (DSTEW-1593).
+ *
+ * <p>For every provider-requested changed field, checks it is amendable for the claim's {@link
+ * AreaOfLaw} against the {@link AmendableClaimFields} registry (derived from the signed-off AaBC
+ * artefact <em>"Amend MVP - fields for amendment"</em>). Each non-amendable changed field yields a
+ * {@link ClaimAmendmentValidationCode#INVALID_FIELD_NOT_AMENDABLE_FOR_AREA_OF_LAW} error whose
+ * message names the offending field so the failure is attributed to that field.
+ *
+ * <p>Only {@link ChangeSource#REQUESTED} diff entries are gated: FSP-sourced consequence changes
+ * are not provider field edits and so are out of scope for amendability. An absent/unknown area of
+ * law makes every changed field non-amendable, which the {@link AmendableClaimFields} registry
+ * enforces.
+ *
+ * <p>The errors are non-fatal so they are collected alongside every other step's findings for the
+ * downstream aggregation (Step 12); because any non-empty error set fails the amendment, a
+ * non-amendable field prevents persistence of any claim update, amendment record, calculated-fee
+ * row or event.
+ */
+@Component
+@RequiredArgsConstructor
+public class FieldAmendabilityValidationStep implements ClaimAmendmentValidationStep {
+
+  private final AmendmentDiffAssembler diffAssembler;
+
+  @Override
+  public List<ClaimAmendmentValidationError> validate(ClaimAmendmentState state) {
+    ClaimStateSnapshot beforeState = state.getBeforeState();
+    AreaOfLaw areaOfLaw = beforeState == null ? null : beforeState.getAreaOfLaw();
+
+    AmendmentDiff diff = diffAssembler.assemble(state);
+
+    return diff.changes().stream()
+        .filter(change -> change.changeSource() == ChangeSource.REQUESTED)
+        .filter(change -> !AmendableClaimFields.isAmendable(change.fieldIdentifier(), areaOfLaw))
+        .map(change -> notAmendableError(change, areaOfLaw))
+        .toList();
+  }
+
+  private static ClaimAmendmentValidationError notAmendableError(
+      DiffEntry change, AreaOfLaw areaOfLaw) {
+    return ClaimAmendmentValidationError.of(
+        ClaimAmendmentValidationCode.INVALID_FIELD_NOT_AMENDABLE_FOR_AREA_OF_LAW,
+        change.fieldIdentifier(),
+        areaOfLaw);
+  }
+}

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationServiceTest.java
@@ -37,6 +37,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.BeforeStatePresenceValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.ClaimAmendmentValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.ClaimStatusValidationStep;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.FieldAmendabilityValidationStep;
 
 /**
  * Tests for {@link ClaimAmendmentValidationService}.
@@ -128,6 +129,7 @@ class ClaimAmendmentValidationServiceTest {
                 new BeforeStatePresenceValidationStep(),
                 new ClaimStatusValidationStep(),
                 new AssessedClaimPricingValidationStep(new AmendmentChangeDetector()),
+                new FieldAmendabilityValidationStep(diffAssembler),
                 new AmendmentUserIdValidationStep(),
                 new AmendmentReferenceValidationStep(amendmentReferenceDataProvider),
                 new AmendmentExternalValidationStep(

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/AmendableClaimFieldsTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/AmendableClaimFieldsTest.java
@@ -1,0 +1,116 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers.ClaimFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers.ClaimSummaryFeeFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers.ClientFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+
+/**
+ * Tests for {@link AmendableClaimFields}, the per-area amendable-field whitelist derived from the
+ * signed-off "Amend MVP - fields for amendment" artefact.
+ */
+@DisplayName("AmendableClaimFields Tests")
+class AmendableClaimFieldsTest {
+
+  @ParameterizedTest
+  @EnumSource(AreaOfLaw.class)
+  @DisplayName("every field listed for an area is amendable for exactly that area's set")
+  void listedFieldsResolveConsistentlyWithTheAreaSet(AreaOfLaw area) {
+    for (String field : AmendableClaimFields.amendableFieldsFor(area)) {
+      assertThat(AmendableClaimFields.isAmendable(field, area))
+          .as("field %s for area %s", field, area)
+          .isTrue();
+      for (AreaOfLaw otherArea : AreaOfLaw.values()) {
+        boolean expected = AmendableClaimFields.amendableFieldsFor(otherArea).contains(field);
+        assertThat(AmendableClaimFields.isAmendable(field, otherArea))
+            .as("field %s for area %s", field, otherArea)
+            .isEqualTo(expected);
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("expectedAmendability")
+  @DisplayName("representative artefact rows resolve to the expected amendability")
+  void representativeRowsResolveAsExpected(
+      String fieldIdentifier, AreaOfLaw area, boolean amendable) {
+    assertThat(AmendableClaimFields.isAmendable(fieldIdentifier, area))
+        .as("field %s for area %s", fieldIdentifier, area)
+        .isEqualTo(amendable);
+  }
+
+  private static Stream<Arguments> expectedAmendability() {
+    return Stream.of(
+        // Fee Code is amendable for every area of law.
+        Arguments.of(ClaimFields.FEE_CODE, AreaOfLaw.CRIME_LOWER, true),
+        Arguments.of(ClaimFields.FEE_CODE, AreaOfLaw.MEDIATION, true),
+        Arguments.of(ClaimFields.FEE_CODE, AreaOfLaw.LEGAL_HELP, true),
+        // Scheme ID is Crime Lower only.
+        Arguments.of(ClaimFields.SCHEME_ID, AreaOfLaw.CRIME_LOWER, true),
+        Arguments.of(ClaimFields.SCHEME_ID, AreaOfLaw.MEDIATION, false),
+        Arguments.of(ClaimFields.SCHEME_ID, AreaOfLaw.LEGAL_HELP, false),
+        // London/Non-London rate is Legal Help only.
+        Arguments.of(ClaimSummaryFeeFields.IS_LONDON_RATE, AreaOfLaw.LEGAL_HELP, true),
+        Arguments.of(ClaimSummaryFeeFields.IS_LONDON_RATE, AreaOfLaw.CRIME_LOWER, false),
+        Arguments.of(ClaimSummaryFeeFields.IS_LONDON_RATE, AreaOfLaw.MEDIATION, false),
+        // Number of Mediation Sessions is Mediation only.
+        Arguments.of(ClaimFields.MEDIATION_SESSIONS_COUNT, AreaOfLaw.MEDIATION, true),
+        Arguments.of(ClaimFields.MEDIATION_SESSIONS_COUNT, AreaOfLaw.CRIME_LOWER, false),
+        Arguments.of(ClaimFields.MEDIATION_SESSIONS_COUNT, AreaOfLaw.LEGAL_HELP, false),
+        // Client surname is amendable for every area of law.
+        Arguments.of(ClientFields.CLIENT_SURNAME, AreaOfLaw.CRIME_LOWER, true),
+        Arguments.of(ClientFields.CLIENT_SURNAME, AreaOfLaw.MEDIATION, true),
+        Arguments.of(ClientFields.CLIENT_SURNAME, AreaOfLaw.LEGAL_HELP, true),
+        // Client 2 fields are Mediation only.
+        Arguments.of(ClientFields.CLIENT2_SURNAME, AreaOfLaw.MEDIATION, true),
+        Arguments.of(ClientFields.CLIENT2_SURNAME, AreaOfLaw.LEGAL_HELP, false),
+        // Net profit costs are amendable for Crime Lower and Legal Help, not Mediation.
+        Arguments.of(ClaimSummaryFeeFields.NET_PROFIT_COSTS_AMOUNT, AreaOfLaw.CRIME_LOWER, true),
+        Arguments.of(ClaimSummaryFeeFields.NET_PROFIT_COSTS_AMOUNT, AreaOfLaw.LEGAL_HELP, true),
+        Arguments.of(ClaimSummaryFeeFields.NET_PROFIT_COSTS_AMOUNT, AreaOfLaw.MEDIATION, false),
+        // Crime "Matter Type" maps to crimeMatterTypeCode, amendable for Crime Lower only.
+        Arguments.of(ClaimFields.CRIME_MATTER_TYPE_CODE, AreaOfLaw.CRIME_LOWER, true),
+        Arguments.of(ClaimFields.CRIME_MATTER_TYPE_CODE, AreaOfLaw.MEDIATION, false),
+        Arguments.of(ClaimFields.CRIME_MATTER_TYPE_CODE, AreaOfLaw.LEGAL_HELP, false),
+        // Legal Help / Mediation "Matter Type 1"+"Matter Type 2" are components of matterTypeCode.
+        Arguments.of(ClaimFields.MATTER_TYPE_CODE, AreaOfLaw.MEDIATION, true),
+        Arguments.of(ClaimFields.MATTER_TYPE_CODE, AreaOfLaw.LEGAL_HELP, true),
+        Arguments.of(ClaimFields.MATTER_TYPE_CODE, AreaOfLaw.CRIME_LOWER, false));
+  }
+
+  @ParameterizedTest
+  @EnumSource(AreaOfLaw.class)
+  @DisplayName("a null field identifier is never amendable")
+  void nullFieldNeverAmendable(AreaOfLaw area) {
+    assertThat(AmendableClaimFields.isAmendable(null, area)).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("everyAmendableField")
+  @DisplayName("a null area of law is never amendable, even for a registered field")
+  void nullAreaNeverAmendable(String field) {
+    assertThat(AmendableClaimFields.isAmendable(field, null)).isFalse();
+  }
+
+  private static Stream<String> everyAmendableField() {
+    return Stream.of(AreaOfLaw.values())
+        .flatMap(area -> AmendableClaimFields.amendableFieldsFor(area).stream())
+        .distinct();
+  }
+
+  @ParameterizedTest
+  @EnumSource(AreaOfLaw.class)
+  @DisplayName("a field absent from the registry is never amendable")
+  void unregisteredFieldNeverAmendable(AreaOfLaw area) {
+    // line_number is tracked by the change detector but is not a provider-amendable field.
+    assertThat(AmendableClaimFields.isAmendable(ClaimFields.LINE_NUMBER, area)).isFalse();
+  }
+}

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/FieldAmendabilityValidationStepTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/FieldAmendabilityValidationStepTest.java
@@ -1,0 +1,175 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentDiff;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers.ClaimFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.AmendmentFieldIdentifiers.ClaimSummaryFeeFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ChangeSource;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationCode;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.DiffEntry;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ValidationSeverity;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.persistence.AmendmentDiffAssembler;
+
+/**
+ * Tests for {@link FieldAmendabilityValidationStep}, the field amendability gate.
+ *
+ * <p>The step is a pure function over the assembled diff and the before-state area of law: the
+ * {@link AmendmentDiffAssembler} is stubbed so each test drives an exact set of changed fields. The
+ * step makes no external calls and persists nothing, so the "no write on rejection" guarantee holds
+ * by construction and is proven at the pipeline level elsewhere.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FieldAmendabilityValidationStep Tests")
+class FieldAmendabilityValidationStepTest {
+
+  @Mock private AmendmentDiffAssembler diffAssembler;
+
+  private FieldAmendabilityValidationStep step;
+
+  private static final String NOT_AMENDABLE_CODE =
+      ClaimAmendmentValidationCode.INVALID_FIELD_NOT_AMENDABLE_FOR_AREA_OF_LAW.toString();
+
+  private ClaimAmendmentState stateWith(AreaOfLaw areaOfLaw, DiffEntry... changes) {
+    step = new FieldAmendabilityValidationStep(diffAssembler);
+    ClaimAmendmentState state =
+        ClaimAmendmentState.builder()
+            .beforeState(ClaimStateSnapshot.builder().areaOfLaw(areaOfLaw).build())
+            .build();
+    when(diffAssembler.assemble(any())).thenReturn(AmendmentDiff.of(List.of(changes)));
+    return state;
+  }
+
+  private static DiffEntry requested(String fieldIdentifier) {
+    return new DiffEntry(fieldIdentifier, ChangeSource.REQUESTED, "before", "after");
+  }
+
+  @Test
+  @DisplayName("a non-amendable changed field collects the not-amendable error for that field")
+  void nonAmendableFieldCollectsError() {
+    // Scheme ID is amendable for Crime Lower only, so it is not amendable for Legal Help.
+    ClaimAmendmentState state = stateWith(AreaOfLaw.LEGAL_HELP, requested(ClaimFields.SCHEME_ID));
+
+    List<ClaimAmendmentValidationError> errors = step.validate(state);
+
+    assertThat(errors).hasSize(1);
+    ClaimAmendmentValidationError error = errors.getFirst();
+    assertThat(error.getCode()).isEqualTo(NOT_AMENDABLE_CODE);
+    assertThat(error.getMessage())
+        .contains(ClaimFields.SCHEME_ID)
+        .contains(AreaOfLaw.LEGAL_HELP.toString());
+  }
+
+  @Test
+  @DisplayName("a field amendable for the claim's area of law produces no error")
+  void amendableFieldProducesNoError() {
+    // Fee Code is amendable for every area of law.
+    ClaimAmendmentState state = stateWith(AreaOfLaw.CRIME_LOWER, requested(ClaimFields.FEE_CODE));
+
+    assertThat(step.validate(state)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a changed field absent from the registry is never amendable and is gated")
+  void unregisteredFieldIsGated() {
+    // line_number is tracked by the change detector but is not a provider-amendable field.
+    ClaimAmendmentState state =
+        stateWith(AreaOfLaw.CRIME_LOWER, requested(ClaimFields.LINE_NUMBER));
+
+    List<ClaimAmendmentValidationError> errors = step.validate(state);
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.getFirst().getCode()).isEqualTo(NOT_AMENDABLE_CODE);
+  }
+
+  @Test
+  @DisplayName("the not-amendable error is non-fatal so it aggregates with later findings")
+  void notAmendableErrorIsNonFatal() {
+    ClaimAmendmentState state = stateWith(AreaOfLaw.MEDIATION, requested(ClaimFields.SCHEME_ID));
+
+    ClaimAmendmentValidationError error = step.validate(state).getFirst();
+
+    assertThat(error.isFatal()).isFalse();
+    assertThat(error.getSeverity()).isEqualTo(ValidationSeverity.ERROR);
+  }
+
+  @Test
+  @DisplayName("only the non-amendable fields are reported when some changed fields are amendable")
+  void reportsOnlyNonAmendableFields() {
+    ClaimAmendmentState state =
+        stateWith(
+            AreaOfLaw.LEGAL_HELP,
+            requested(ClaimFields.FEE_CODE), // amendable everywhere
+            requested(ClaimFields.SCHEME_ID), // crime lower only
+            requested(ClaimSummaryFeeFields.NET_WAITING_COSTS_AMOUNT)); // crime lower only
+
+    List<ClaimAmendmentValidationError> errors = step.validate(state);
+
+    assertThat(errors)
+        .extracting(ClaimAmendmentValidationError::getMessage)
+        .hasSize(2)
+        .anySatisfy(message -> assertThat(message).contains(ClaimFields.SCHEME_ID))
+        .anySatisfy(
+            message ->
+                assertThat(message).contains(ClaimSummaryFeeFields.NET_WAITING_COSTS_AMOUNT));
+  }
+
+  @Test
+  @DisplayName("FSP-sourced changes are not gated, even for non-amendable fields")
+  void fspSourcedChangesAreIgnored() {
+    // Scheme ID is not amendable for Legal Help, but an FSP-sourced change is out of the gate's
+    // scope (only provider-requested changes are policed).
+    DiffEntry fspChange = new DiffEntry(ClaimFields.SCHEME_ID, ChangeSource.FSP, "before", "after");
+    ClaimAmendmentState state = stateWith(AreaOfLaw.LEGAL_HELP, fspChange);
+
+    assertThat(step.validate(state)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("no changed fields produces no error")
+  void emptyDiffProducesNoError() {
+    ClaimAmendmentState state = stateWith(AreaOfLaw.CRIME_LOWER);
+
+    assertThat(step.validate(state)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a missing area of law makes every requested changed field non-amendable")
+  void missingAreaOfLawRejectsAllChangedFields() {
+    ClaimAmendmentState state =
+        stateWith(null, requested(ClaimFields.FEE_CODE), requested(ClaimFields.SCHEME_ID));
+
+    List<ClaimAmendmentValidationError> errors = step.validate(state);
+
+    assertThat(errors)
+        .hasSize(2)
+        .allSatisfy(error -> assertThat(error.getCode()).isEqualTo(NOT_AMENDABLE_CODE));
+  }
+
+  @Test
+  @DisplayName("each non-amendable field is attributed to its own field in a distinct error")
+  void eachNonAmendableFieldAttributedIndividually() {
+    ClaimAmendmentState state =
+        stateWith(
+            AreaOfLaw.MEDIATION,
+            requested(ClaimFields.SCHEME_ID),
+            requested(ClaimFields.REPRESENTATION_ORDER_DATE));
+
+    assertThat(step.validate(state))
+        .extracting(ClaimAmendmentValidationError::getMessage)
+        .anySatisfy(message -> assertThat(message).contains(ClaimFields.SCHEME_ID))
+        .anySatisfy(message -> assertThat(message).contains(ClaimFields.REPRESENTATION_ORDER_DATE));
+  }
+}


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2005)

Implements the field amendability gate from the parent ticket (DSTEW-1593). For every provider-requested changed field, the gate checks whether that field is amendable for the claim's Area of Law and collects a field-level validation error for any field that is not.
## How

- AmendableClaimFields — a new, auditable registry of the amendable claim fields, organised per Area of Law (CRIME_LOWER, MEDIATION, LEGAL_HELP) as three flat whitelists behind an AreaOfLaw → Set<fieldIdentifier> map. Structured to mirror the signed-off AaBC artefact "Amend MVP - fields for amendment" one line at a time for reviewability. Exposes isAmendable(field, areaOfLaw).
- FieldAmendabilityValidationStep — new validation step. Reads the claim's Area of Law from the before-state, filters the assembled diff to REQUESTED changes, and emits INVALID_FIELD_NOT_AMENDABLE_FOR_AREA_OF_LAW (severity ERROR, non-fatal) for each non-amendable field, naming the field in the message so the failure is attributed to it.
- ClaimAmendmentValidationCode — new INVALID_FIELD_NOT_AMENDABLE_FOR_AREA_OF_LAW code.
- ClaimAmendmentValidationService — registers the step in STEP_ORDER at the amendability slot (after assessed-pricing, before the external steps), so its findings aggregate into the Step 12 outcome alongside other steps.
## Behaviour

- Non-amendable changed field → error collected and attributed to that field.
- Non-fatal, so it aggregates with other validation messages rather than short-circuiting.
- Absent/unknown Area of Law → every changed field is treated as non-amendable.
- FSP-sourced (consequential) changes are out of scope; only provider-requested edits are gated.
- The step is side-effect-free; any resulting error prevents the amendment being applied (no claim update, amendment record, calculated-fee row or event), consistent with the existing pipeline.

## Tests

- AmendableClaimFieldsTest — per-area membership consistency, representative artefact rows, and edge cases (null field, null area, unregistered field).
- FieldAmendabilityValidationStepTest — amendable vs non-amendable outcomes, correct code/attribution, non-fatal severity, mixed changed fields (only non-amendable reported), unregistered field, FSP-change exclusion, empty diff, and missing Area of Law.
- ClaimAmendmentValidationServiceIntegrationTest — assembled-chain test proving a non-amendable field aggregates with another error through the real wiring (Step 12).

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
