### PR TITLE
chore(DSTEW-1812):  Add test coverage for Assessment & Void timeline events

### DIFF
--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimHistoryControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimHistoryControllerIntegrationTest.java
@@ -6,12 +6,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.AUTHORIZATION_HEADER;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.AUTHORIZATION_TOKEN;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_SUMMARY_FEE_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.USER_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.getAssessmentBuilder;
 
+import java.math.BigDecimal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -19,6 +27,8 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 public class ClaimHistoryControllerIntegrationTest extends AbstractIntegrationTest {
 
   private static final String HISTORY_URI = "/api/v1/claims/{claimId}/history";
+
+  @Autowired private PlatformTransactionManager transactionManager;
 
   @BeforeEach
   void setUp() {
@@ -52,5 +62,67 @@ public class ClaimHistoryControllerIntegrationTest extends AbstractIntegrationTe
             get(HISTORY_URI, Uuid7.timeBasedUuid())
                 .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("Surfaces an ESCAPE_CASE_ASSESSMENT row as an ASSESSMENT timeline event")
+  void returnsAssessmentEventInTimeline() throws Exception {
+    // Assessment is inserted with the current timestamp, so it is newer than the seeded submission
+    // (dated in the past) and appears first in the reverse-chronological timeline.
+    persistAssessment(
+        AssessmentType.ESCAPE_CASE_ASSESSMENT,
+        AssessmentOutcome.REDUCED_TO_FIXED_FEE,
+        "Escape fee case assessment");
+
+    mockMvc
+        .perform(get(HISTORY_URI, CLAIM_1_ID).header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.events.length()").value(2))
+        .andExpect(jsonPath("$.events[0].event_type").value("ASSESSMENT"))
+        .andExpect(jsonPath("$.events[0].actor_id").value(USER_ID))
+        .andExpect(jsonPath("$.events[0].event_timestamp").exists())
+        .andExpect(jsonPath("$.events[0].metadata.assessment_type").value("ESCAPE_CASE_ASSESSMENT"))
+        .andExpect(
+            jsonPath("$.events[0].metadata.assessment_outcome").value("REDUCED_TO_FIXED_FEE"))
+        .andExpect(
+            jsonPath("$.events[0].metadata.assessment_reason").value("Escape fee case assessment"))
+        .andExpect(jsonPath("$.events[1].event_type").value("SUBMISSION"));
+  }
+
+  @Test
+  @DisplayName("Surfaces an assessment_type = 'VOID' row as a VOID timeline event")
+  void returnsVoidEventInTimeline() throws Exception {
+    persistAssessment(AssessmentType.VOID, null, "Voided in error");
+
+    mockMvc
+        .perform(get(HISTORY_URI, CLAIM_1_ID).header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.events.length()").value(2))
+        .andExpect(jsonPath("$.events[0].event_type").value("VOID"))
+        .andExpect(jsonPath("$.events[0].metadata.assessment_type").value("VOID"))
+        .andExpect(jsonPath("$.events[0].metadata.assessment_reason").value("Voided in error"))
+        // A VOID event never carries an assessment outcome.
+        .andExpect(jsonPath("$.events[0].metadata.assessment_outcome").doesNotExist())
+        .andExpect(jsonPath("$.events[1].event_type").value("SUBMISSION"));
+  }
+
+  private void persistAssessment(AssessmentType type, AssessmentOutcome outcome, String reason) {
+    // Seed inside a committed transaction so the fetched claim/summary-fee stay attached for the
+    // save and the data is visible to the subsequent (separate) HTTP request.
+    new TransactionTemplate(transactionManager)
+        .executeWithoutResult(
+            status ->
+                assessmentRepository.save(
+                    getAssessmentBuilder()
+                        .id(Uuid7.timeBasedUuid())
+                        .claim(claimRepository.getReferenceById(CLAIM_1_ID))
+                        .claimSummaryFee(
+                            claimSummaryFeeRepository.getReferenceById(CLAIM_1_SUMMARY_FEE_ID))
+                        .assessmentType(type)
+                        .assessmentOutcome(outcome)
+                        .assessmentReason(reason)
+                        .allowedTotalVat(new BigDecimal("100.00"))
+                        .allowedTotalInclVat(new BigDecimal("120.00"))
+                        .build()));
   }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepositoryIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.projection.ClaimHistoryEventRow;
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
@@ -116,6 +117,181 @@ class JdbcClaimHistoryRepositoryIntegrationTest extends AbstractIntegrationTest 
     UUID higher = idA.compareTo(idB) > 0 ? idA : idB;
     UUID lower = idA.compareTo(idB) > 0 ? idB : idA;
     assertThat(assessmentOrder).containsExactly(higher, lower);
+  }
+
+  @Test
+  @DisplayName("Maps an ESCAPE_CASE_ASSESSMENT row into an ASSESSMENT event with full metadata")
+  void mapsEscapeCaseAssessment_toAssessmentEvent() {
+    UUID assessmentId = Uuid7.timeBasedUuid();
+    persistAssessment(
+        assessmentId,
+        AssessmentType.ESCAPE_CASE_ASSESSMENT,
+        AssessmentOutcome.REDUCED_TO_FIXED_FEE,
+        "Escape fee case assessment");
+
+    ClaimHistoryEventRow event = findAssessmentEvent(assessmentId);
+
+    assertThat(event.eventType()).isEqualTo("ASSESSMENT");
+    assertThat(event.actorId()).isEqualTo(USER_ID);
+    assertThat(event.eventTimestamp()).isNotNull();
+    assertThat(event.metadata().get("assessment_type").asText())
+        .isEqualTo("ESCAPE_CASE_ASSESSMENT");
+    assertThat(event.metadata().get("assessment_outcome").asText())
+        .isEqualTo("REDUCED_TO_FIXED_FEE");
+    assertThat(event.metadata().get("assessment_reason").asText())
+        .isEqualTo("Escape fee case assessment");
+  }
+
+  @Test
+  @DisplayName("Maps a STAGE_DISBURSEMENT_ASSESSMENT row into an ASSESSMENT event")
+  void mapsStageDisbursementAssessment_toAssessmentEvent() {
+    UUID assessmentId = Uuid7.timeBasedUuid();
+    persistAssessment(
+        assessmentId,
+        AssessmentType.STAGE_DISBURSEMENT_ASSESSMENT,
+        AssessmentOutcome.PAID_IN_FULL,
+        "Stage disbursement assessment");
+
+    ClaimHistoryEventRow event = findAssessmentEvent(assessmentId);
+
+    assertThat(event.eventType()).isEqualTo("ASSESSMENT");
+    assertThat(event.metadata().get("assessment_type").asText())
+        .isEqualTo("STAGE_DISBURSEMENT_ASSESSMENT");
+    assertThat(event.metadata().get("assessment_outcome").asText()).isEqualTo("PAID_IN_FULL");
+    assertThat(event.metadata().get("assessment_reason").asText())
+        .isEqualTo("Stage disbursement assessment");
+  }
+
+  @Test
+  @DisplayName("Maps an assessment_type = 'VOID' row into a VOID event without an outcome")
+  void mapsVoidAssessment_toVoidEvent() {
+    UUID assessmentId = Uuid7.timeBasedUuid();
+    // A void carries no outcome; assessment_reason holds the void reason.
+    persistAssessment(assessmentId, AssessmentType.VOID, null, "Voided in error");
+
+    ClaimHistoryEventRow event = findAssessmentEvent(assessmentId);
+
+    assertThat(event.eventType()).isEqualTo("VOID");
+    assertThat(event.metadata().get("assessment_type").asText()).isEqualTo("VOID");
+    assertThat(event.metadata().get("assessment_reason").asText()).isEqualTo("Voided in error");
+    // VOID metadata intentionally omits the outcome key entirely.
+    assertThat(event.metadata().has("assessment_outcome")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Maps a legacy row with a null assessment_type into an ASSESSMENT event")
+  void mapsLegacyNullAssessmentType_toAssessmentEvent() {
+    UUID assessmentId = Uuid7.timeBasedUuid();
+    persistAssessment(
+        assessmentId,
+        AssessmentType.ESCAPE_CASE_ASSESSMENT,
+        AssessmentOutcome.NILLED,
+        "Legacy assessment");
+
+    // assessment_type is NOT NULL in the schema; relax it for this rolled-back transaction so we
+    // can
+    // reproduce a genuine legacy row whose type was never populated.
+    jdbcClient
+        .sql("ALTER TABLE claims.assessment ALTER COLUMN assessment_type DROP NOT NULL")
+        .update();
+    jdbcClient
+        .sql("UPDATE claims.assessment SET assessment_type = NULL WHERE id = :id")
+        .param("id", assessmentId)
+        .update();
+
+    ClaimHistoryEventRow event = findAssessmentEvent(assessmentId);
+
+    // A null type falls through the CASE to ASSESSMENT; no fabricated type value is invented.
+    assertThat(event.eventType()).isEqualTo("ASSESSMENT");
+    assertThat(event.metadata().get("assessment_type").isNull()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Retains a null assessment_outcome as an explicit JSON null (no fabricated value)")
+  void retainsNullAssessmentOutcome_asJsonNull() {
+    UUID assessmentId = Uuid7.timeBasedUuid();
+    persistAssessment(assessmentId, AssessmentType.ESCAPE_CASE_ASSESSMENT, null, "Outcome pending");
+
+    ClaimHistoryEventRow event = findAssessmentEvent(assessmentId);
+
+    assertThat(event.eventType()).isEqualTo("ASSESSMENT");
+    // The key is present but null - no default or placeholder is substituted.
+    assertThat(event.metadata().get("assessment_outcome").isNull()).isTrue();
+    assertThat(event.metadata().get("assessment_reason").asText()).isEqualTo("Outcome pending");
+  }
+
+  @Test
+  @DisplayName("Interleaves assessment and void events chronologically with the submission event")
+  void interleavesAssessmentAndVoidEventsChronologicallyWithSubmission() {
+    Instant submissionTimestamp =
+        claimHistoryRepository.findHistory(CLAIM_1_ID, 50).getFirst().eventTimestamp();
+
+    UUID earlierAssessmentId = Uuid7.timeBasedUuid();
+    UUID laterVoidId = Uuid7.timeBasedUuid();
+    persistAssessment(
+        earlierAssessmentId,
+        AssessmentType.ESCAPE_CASE_ASSESSMENT,
+        AssessmentOutcome.PAID_IN_FULL,
+        "Before submission");
+    persistAssessment(laterVoidId, AssessmentType.VOID, null, "After submission");
+
+    // Position the assessment before, and the void after, the submission event (created_on is set
+    // by
+    // @CreationTimestamp on insert, so force deterministic timestamps with a raw update).
+    forceCreatedOn(earlierAssessmentId, submissionTimestamp.minusSeconds(60));
+    forceCreatedOn(laterVoidId, submissionTimestamp.plusSeconds(60));
+
+    List<ClaimHistoryEventRow> events = claimHistoryRepository.findHistory(CLAIM_1_ID, 50);
+
+    // Newest first: VOID (after) -> SUBMISSION -> ASSESSMENT (before).
+    assertThat(events).hasSize(3);
+    assertThat(events)
+        .extracting(ClaimHistoryEventRow::eventType)
+        .containsExactly("VOID", "SUBMISSION", "ASSESSMENT");
+    assertThat(events)
+        .extracting(ClaimHistoryEventRow::sourceId)
+        .containsExactly(laterVoidId, CLAIM_1_ID, earlierAssessmentId);
+  }
+
+  @Test
+  @DisplayName("Returns no assessment or void events when the claim has no assessment rows")
+  void returnsNoAssessmentOrVoidEvents_whenClaimHasNoAssessments() {
+    List<ClaimHistoryEventRow> events = claimHistoryRepository.findHistory(CLAIM_1_ID, 50);
+
+    assertThat(events)
+        .extracting(ClaimHistoryEventRow::eventType)
+        .doesNotContain("ASSESSMENT", "VOID");
+  }
+
+  private ClaimHistoryEventRow findAssessmentEvent(UUID assessmentId) {
+    return claimHistoryRepository.findHistory(CLAIM_1_ID, 50).stream()
+        .filter(event -> assessmentId.equals(event.sourceId()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private void persistAssessment(
+      UUID id, AssessmentType type, AssessmentOutcome outcome, String reason) {
+    assessmentRepository.save(
+        getAssessmentBuilder()
+            .id(id)
+            .claim(claimRepository.getReferenceById(CLAIM_1_ID))
+            .claimSummaryFee(claimSummaryFeeRepository.getReferenceById(CLAIM_1_SUMMARY_FEE_ID))
+            .assessmentType(type)
+            .assessmentOutcome(outcome)
+            .assessmentReason(reason)
+            .allowedTotalVat(new BigDecimal("100.00"))
+            .allowedTotalInclVat(new BigDecimal("120.00"))
+            .build());
+    assessmentRepository.flush();
+  }
+
+  private void forceCreatedOn(UUID assessmentId, Instant createdOn) {
+    jdbcClient
+        .sql("UPDATE claims.assessment SET created_on = :ts WHERE id = :id")
+        .param("ts", OffsetDateTime.ofInstant(createdOn, ZoneOffset.UTC))
+        .param("id", assessmentId)
+        .update();
   }
 
   private Assessment sameTimestampAssessment(UUID id) {

--- a/claims-data/service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/DataClaimsApiProviderTests.java
+++ b/claims-data/service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/DataClaimsApiProviderTests.java
@@ -266,6 +266,17 @@ public class DataClaimsApiProviderTests extends AbstractProviderPactTests {
     when(claimRepository.existsById(any())).thenReturn(false);
   }
 
+  @State("a claim history with assessment and void events exists")
+  public void aClaimHistoryWithAssessmentAndVoidEventsExists() {
+    log.info("Setting up state: a claim history with assessment and void events exists");
+    when(claimRepository.existsById(any())).thenReturn(true);
+    // Reverse-chronological order: VOID (newest) -> ASSESSMENT -> SUBMISSION (oldest).
+    when(claimHistoryRepository.findHistory(any(), anyInt()))
+        .thenReturn(
+            List.of(
+                getVoidHistoryEvent(), getAssessmentHistoryEvent(), getSubmissionHistoryEvent()));
+  }
+
   @State("a matter start exists")
   public void aMatterStartExists() {
     log.info("Setting up state: a matter start exists");

--- a/claims-data/service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/ClaimsDataTestUtil.java
+++ b/claims-data/service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/util/ClaimsDataTestUtil.java
@@ -624,4 +624,34 @@ public class ClaimsDataTestUtil {
     return new ClaimHistoryEventRow(
         "SUBMISSION", SUBMITTED_DATE.toInstant(), PROVIDER_USER_ID, CLAIM_1_ID, metadata);
   }
+
+  /** A single ASSESSMENT history event mirroring the unified claim-history read model. */
+  public static ClaimHistoryEventRow getAssessmentHistoryEvent() {
+    ObjectNode metadata = JsonNodeFactory.instance.objectNode();
+    metadata.put("assessment_type", "ESCAPE_CASE_ASSESSMENT");
+    metadata.put("assessment_outcome", "REDUCED_TO_FIXED_FEE");
+    metadata.put("assessment_reason", "Escape fee case assessment");
+    return new ClaimHistoryEventRow(
+        "ASSESSMENT",
+        SUBMITTED_DATE.plusHours(1).toInstant(),
+        PROVIDER_USER_ID,
+        Uuid7.timeBasedUuid(),
+        metadata);
+  }
+
+  /**
+   * A single VOID history event mirroring the unified claim-history read model. A void carries only
+   * the type and reason - never an outcome.
+   */
+  public static ClaimHistoryEventRow getVoidHistoryEvent() {
+    ObjectNode metadata = JsonNodeFactory.instance.objectNode();
+    metadata.put("assessment_type", "VOID");
+    metadata.put("assessment_reason", "Voided in error");
+    return new ClaimHistoryEventRow(
+        "VOID",
+        SUBMITTED_DATE.plusHours(2).toInstant(),
+        PROVIDER_USER_ID,
+        Uuid7.timeBasedUuid(),
+        metadata);
+  }
 }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimHistoryEventRowMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimHistoryEventRowMapperTest.java
@@ -41,6 +41,48 @@ class ClaimHistoryEventRowMapperTest {
   }
 
   @Test
+  void mapsAssessmentEvent_withFullMetadata() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getObject("event_timestamp", OffsetDateTime.class))
+        .thenReturn(OffsetDateTime.parse("2026-04-22T11:26:00Z"));
+    when(rs.getObject("source_id", UUID.class)).thenReturn(UUID.randomUUID());
+    when(rs.getString("event_type")).thenReturn("ASSESSMENT");
+    when(rs.getString("actor_id")).thenReturn("assessor-user-id");
+    when(rs.getString("metadata"))
+        .thenReturn(
+            "{\"assessment_type\":\"ESCAPE_CASE_ASSESSMENT\","
+                + "\"assessment_outcome\":\"REDUCED_TO_FIXED_FEE\","
+                + "\"assessment_reason\":\"Escape fee case assessment\"}");
+
+    ClaimHistoryEventRow row = mapper.mapRow(rs, 0);
+
+    assertThat(row.eventType()).isEqualTo("ASSESSMENT");
+    assertThat(row.metadata().get("assessment_type").asText()).isEqualTo("ESCAPE_CASE_ASSESSMENT");
+    assertThat(row.metadata().get("assessment_outcome").asText()).isEqualTo("REDUCED_TO_FIXED_FEE");
+    assertThat(row.metadata().get("assessment_reason").asText())
+        .isEqualTo("Escape fee case assessment");
+  }
+
+  @Test
+  void mapsVoidEvent_withoutOutcome() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getObject("event_timestamp", OffsetDateTime.class))
+        .thenReturn(OffsetDateTime.parse("2026-04-22T11:26:00Z"));
+    when(rs.getObject("source_id", UUID.class)).thenReturn(UUID.randomUUID());
+    when(rs.getString("event_type")).thenReturn("VOID");
+    when(rs.getString("actor_id")).thenReturn("assessor-user-id");
+    when(rs.getString("metadata"))
+        .thenReturn("{\"assessment_type\":\"VOID\",\"assessment_reason\":\"Voided in error\"}");
+
+    ClaimHistoryEventRow row = mapper.mapRow(rs, 0);
+
+    assertThat(row.eventType()).isEqualTo("VOID");
+    assertThat(row.metadata().get("assessment_type").asText()).isEqualTo("VOID");
+    assertThat(row.metadata().get("assessment_reason").asText()).isEqualTo("Voided in error");
+    assertThat(row.metadata().has("assessment_outcome")).isFalse();
+  }
+
+  @Test
   void mapsNullTimestamp_toNullInstant() throws SQLException {
     ResultSet rs = mock(ResultSet.class);
     when(rs.getObject("event_timestamp", OffsetDateTime.class)).thenReturn(null);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1812)

Adds unit, integration, and contract test coverage for the ASSESSMENT and VOID events on the Claim History Timeline API. The implementation already existed (JdbcClaimHistoryRepository); this PR proves it against the ticket's acceptance criteria - - no production code was changed.
### Tests added

- Repository integration (JdbcClaimHistoryRepositoryIntegrationTest) - verified against real PostgreSQL:
- ESCAPE_CASE_ASSESSMENT / STAGE_DISBURSEMENT_ASSESSMENT → ASSESSMENT with full metadata (AC1)
- assessment_type = 'VOID' → VOID, with assessment_outcome omitted (AC2)
- Legacy assessment_type = null → ASSESSMENT, no fabricated value (AC3)
- Null assessment_outcome retained as explicit JSON null (AC4)
- Assessment/void events interleaved chronologically with the submission event (AC5)
- Claims with no assessment rows return no assessment/void events (AC6)
- Endpoint integration (ClaimHistoryControllerIntegrationTest):
- ASSESSMENT and VOID events over HTTP, asserting JSON envelope, metadata, and outcome omission for VOID
- Mapper unit (ClaimHistoryEventRowMapperTest):
- ASSESSMENT/VOID metadata parsing

### Contract (Pact):

- Reusable getAssessmentHistoryEvent() / getVoidHistoryEvent() builders and new provider state "a claim history with assessment and void events exists"

### Notes

- Controller test seeds assessments inside a committed TransactionTemplate (class is non-transactional) so data is visible to the subsequent request.
- The new Pact provider state is exercised once a consumer publishes a matching interaction (consumer-repo change).
- 

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
