### PR TITLE
test: DSTEW-1935 integrate BDD suite into CI (phase 1 local mode)

### DIFF
--- a/.github/actions/bdd-test/action.yml
+++ b/.github/actions/bdd-test/action.yml
@@ -1,0 +1,53 @@
+name: "BDD test"
+description: "Run the claims-data BDD (Cucumber) suite in local mode and upload reports."
+
+inputs:
+  java-version:
+    description: "JDK version to install"
+    required: false
+    default: "25"
+  java-distribution:
+    description: "JDK distribution"
+    required: false
+    default: "corretto"
+  github-actor:
+    description: "Actor used to authenticate against GitHub Packages"
+    required: true
+  github-token:
+    description: "Token used to authenticate against GitHub Packages (needs packages:read)"
+    required: true
+  artifact-name:
+    description: "Name of the uploaded reports artifact"
+    required: false
+    default: "bdd-reports"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: ${{ inputs.java-distribution }}
+
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.0.0
+
+    - name: Run BDD test suite (local mode)
+      shell: bash
+      env:
+        GITHUB_ACTOR: ${{ inputs.github-actor }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: ./gradlew :claims-data:service:bddTest --no-daemon
+
+    - name: Upload BDD reports
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          claims-data/service/build/reports/tests/bddTest/**
+          claims-data/service/build/test-results/bddTest/**
+        if-no-files-found: warn
+        retention-days: 14
+

--- a/.github/actions/bdd-test/action.yml
+++ b/.github/actions/bdd-test/action.yml
@@ -10,12 +10,6 @@ inputs:
     description: "JDK distribution"
     required: false
     default: "corretto"
-  github-actor:
-    description: "Actor used to authenticate against GitHub Packages"
-    required: true
-  github-token:
-    description: "Token used to authenticate against GitHub Packages (needs packages:read)"
-    required: true
   artifact-name:
     description: "Name of the uploaded reports artifact"
     required: false
@@ -36,8 +30,8 @@ runs:
     - name: Run BDD test suite (local mode)
       shell: bash
       env:
-        GITHUB_ACTOR: ${{ inputs.github-actor }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: ./gradlew :claims-data:service:bddTest --no-daemon
 
     - name: Upload BDD reports
@@ -50,4 +44,6 @@ runs:
           claims-data/service/build/test-results/bddTest/**
         if-no-files-found: warn
         retention-days: 14
+
+
 

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -62,31 +62,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Set up JDK
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+      - name: Run BDD test suite
+        uses: ./.github/actions/bdd-test
         with:
           java-version: *JAVA_VERSION
-          distribution: *JDK_DISTRIBUTION
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.0.0
-
-      - name: Run BDD test suite (local mode)
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew :claims-data:service:bddTest --no-daemon
-
-      - name: Upload BDD reports
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: bdd-reports
-          path: |
-            claims-data/service/build/reports/tests/bddTest/**
-            claims-data/service/build/test-results/bddTest/**
-          if-no-files-found: warn
-          retention-days: 14
+          java-distribution: *JDK_DISTRIBUTION
+          github-actor: ${{ github.actor }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   ecr-publish-image:
     needs: [ release, bdd-test ]

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -51,8 +51,45 @@ jobs:
       pact_broker_username: ${{ secrets.PACT_BROKER_USERNAME }}
       pact_broker_password: ${{ secrets.PACT_BROKER_PASSWORD }}
 
-  ecr-publish-image:
+  bdd-test:
+    runs-on: ubuntu-latest
     needs: [ release ]
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          java-version: *JAVA_VERSION
+          distribution: *JDK_DISTRIBUTION
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.0.0
+
+      - name: Run BDD test suite (local mode)
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :claims-data:service:bddTest --no-daemon
+
+      - name: Upload BDD reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bdd-reports
+          path: |
+            claims-data/service/build/reports/tests/bddTest/**
+            claims-data/service/build/test-results/bddTest/**
+          if-no-files-found: warn
+          retention-days: 14
+
+  ecr-publish-image:
+    needs: [ release, bdd-test ]
     uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/ecr-publish-image.yml@4daa796eff475c7a107e17daf4e4882b8a1b949b # v2.3.0
     permissions:
       contents: read

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -67,8 +67,6 @@ jobs:
         with:
           java-version: *JAVA_VERSION
           java-distribution: *JDK_DISTRIBUTION
-          github-actor: ${{ github.actor }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   ecr-publish-image:
     needs: [ release, bdd-test ]

--- a/.github/workflows/deploy-uat-preview.yml
+++ b/.github/workflows/deploy-uat-preview.yml
@@ -113,31 +113,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Set up JDK
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+      - name: Run BDD test suite
+        uses: ./.github/actions/bdd-test
         with:
           java-version: *JAVA_VERSION
-          distribution: *JDK_DISTRIBUTION
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.0.0
-
-      - name: Run BDD test suite (local mode)
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew :claims-data:service:bddTest --no-daemon
-
-      - name: Upload BDD reports
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: bdd-reports
-          path: |
-            claims-data/service/build/reports/tests/bddTest/**
-            claims-data/service/build/test-results/bddTest/**
-          if-no-files-found: warn
-          retention-days: 14
+          java-distribution: *JDK_DISTRIBUTION
+          github-actor: ${{ github.actor }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   helm-template-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-uat-preview.yml
+++ b/.github/workflows/deploy-uat-preview.yml
@@ -102,6 +102,43 @@ jobs:
           command: code test
           args: --severity-threshold=high
 
+  bdd-test:
+    runs-on: ubuntu-latest
+    needs: [ build-and-test ]
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          java-version: *JAVA_VERSION
+          distribution: *JDK_DISTRIBUTION
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.0.0
+
+      - name: Run BDD test suite (local mode)
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :claims-data:service:bddTest --no-daemon
+
+      - name: Upload BDD reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bdd-reports
+          path: |
+            claims-data/service/build/reports/tests/bddTest/**
+            claims-data/service/build/test-results/bddTest/**
+          if-no-files-found: warn
+          retention-days: 14
+
   helm-template-check:
     runs-on: ubuntu-latest
     needs: [ build-and-test ]
@@ -133,7 +170,7 @@ jobs:
             --set namespace="test"
 
   ecr-publish-image:
-    needs: [ build-and-test, compute-snapshot-version ]
+    needs: [ build-and-test, compute-snapshot-version, bdd-test ]
     uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/ecr-publish-image.yml@4daa796eff475c7a107e17daf4e4882b8a1b949b # v2.3.0
     permissions:
       contents: read
@@ -157,6 +194,7 @@ jobs:
       - ecr-publish-image
       - pact-test
       - vulnerability-scan-app
+      - bdd-test
     runs-on: ubuntu-latest
     environment: uat
     permissions:

--- a/.github/workflows/deploy-uat-preview.yml
+++ b/.github/workflows/deploy-uat-preview.yml
@@ -118,8 +118,6 @@ jobs:
         with:
           java-version: *JAVA_VERSION
           java-distribution: *JDK_DISTRIBUTION
-          github-actor: ${{ github.actor }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   helm-template-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Integrates the BDD (Cucumber) test suite into the CI pipeline as **Phase 1 – local mode**.

Jira: [DSTEW-1935](https://dsdmoj.atlassian.net/browse/DSTEW-1935)

## Why
The BDD suite lives in `claims-data/service` and exercises the bulk-submission and fee-scheme flows end-to-end, but until now it only ran on developer machines. This PR wires it into GitHub Actions so every PR and every push to `main` runs the full suite and blocks image publish on failure.

## How
Adds a sibling `bdd-test` job to both workflow files – it does **not** modify the shared MoJ reusable workflow.

- `.github/workflows/deploy-uat-preview.yml` – new job `needs: [build-and-test]`; added to `needs:` of `ecr-publish-image` and `deploy-uat-preview`.
- `.github/workflows/deploy-main.yml` – same job `needs: [release]`; added to `needs:` of `ecr-publish-image`.
- Runs `./gradlew :claims-data:service:bddTest` on `ubuntu-latest` (Docker preinstalled → Testcontainers Postgres works out of the box).
- `bdd.mode=local` (default) → PATCH-shortcut mock event-service. **No external network dependency, no secrets beyond `GITHUB_TOKEN`.**
- Uploads JUnit XML + HTML reports as `bdd-reports` artifact (`if: always()`, 14-day retention).

## Test evidence
Local run just before pushing:
```
./gradlew :claims-data:service:bddTest
BUILD SUCCESSFUL
76 tests, 0 failures, 0 errors
```

## Out of scope – Phase 2
Running the suite in `bdd.mode=uat` against the real event-service in UAT is deferred until:
- Runner topology decision (Peter)
- API-key header format from dev team
- Cleanup endpoints confirmed

## Files changed
- `.github/workflows/deploy-uat-preview.yml`
- `.github/workflows/deploy-main.yml`

2 files modified, 0 files created.



[DSTEW-1935]: https://dsdmoj.atlassian.net/browse/DSTEW-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ