### PR TITLE
chore: bump devsecop-hook to v2.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,6 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.3.0
+    rev: 53d252e406bae2bbbd0c0f3205b72870a02c9b3f # v2.0.2
     hooks:
       - id: baseline

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -12,6 +12,10 @@ curl --proto '=https' --tlsv1.2 \
 echo "\nInstalling prek within the repository"
 prek install
 
+# Install gitleaks
+echo "\nInstalling gitleaks"
+brew install gitleaks
+
 echo "Git hooks setup complete!"
 echo "The pre-commit hook will now:"
 echo "  1. Run Spotless formatting on staged Java files"


### PR DESCRIPTION
## What

Describe what you did and why.

Bumping `devsecops-hooks` version that now includes gitleaks.
Install `gitleaks` as the hook no longer runs in Docker.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
