### PR TITLE
chore(DSTEW-1813): Return 204 and skip persistence for no-op amendments

### DIFF
--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/claim/amendments/ClaimAmendmentHistoryE2eIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/claim/amendments/ClaimAmendmentHistoryE2eIntegrationTest.java
@@ -1,0 +1,353 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.controller.claim.amendments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.API_URI_PREFIX;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.AUTHORIZATION_HEADER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.AUTHORIZATION_TOKEN;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_1_ID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockserver.model.ClearType;
+import org.mockserver.model.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.justice.laa.dstew.payments.claimsdata.config.ClaimsApiProperties;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.CalculatedFeeDetail;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimAmendment;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
+import uk.gov.justice.laa.dstew.payments.claimsdata.helper.MockServerIntegrationTest;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
+
+/**
+ * End-to-end coverage for the claim-history AMENDMENT event (DSTEW-1813 / DSTEW-1814).
+ *
+ * <p>This is the top of the test pyramid: it drives a <b>real</b> amendment through the public HTTP
+ * PATCH endpoint (with the PDA and FSP external calls stubbed via MockServer), then reads the
+ * public {@code GET /history} endpoint and asserts the AMENDMENT event that the full pipeline
+ * produced. Unlike {@code JdbcClaimHistoryRepositoryIntegrationTest} - which writes a fabricated
+ * {@code diff} JSON directly - nothing here is hand-crafted: the {@code changes} shape is produced
+ * by the genuine {@code AmendmentChangeDetector} / {@code AmendmentDiffAssembler} pipeline,
+ * persisted, and read back through the history SQL. It therefore also guards the end-to-end {@code
+ * change_source} casing ("REQUESTED" / "FSP").
+ *
+ * <p>It is deliberately a separate class from {@code ClaimAmendmentRepricingIntegrationTest}: that
+ * suite owns the repricing/commit behaviour; this suite owns the history read-back assertions.
+ *
+ * <p><b>Explicit-null (field cleared) is intentionally NOT exercised here.</b> A cleared field
+ * (before=value, after=explicit null) cannot currently be driven through the PATCH endpoint: {@code
+ * ClaimPatch} models fields as plain {@code @Nullable String} (so a JSON explicit null and an
+ * omitted field both deserialize to {@code null}), and {@code ClaimMapper.map(String)} collapses
+ * {@code null -> JsonNullable.undefined()} - i.e. "no change". Empirically, PATCHing {@code
+ * client2Surname: null} returns 204, leaves the field unchanged and records an empty diff. The
+ * null-in-history presence semantics (DSTEW-1814) are therefore proven where they are expressible:
+ * {@code JdbcClaimHistoryRepositoryIntegrationTest.retainsClearedClient2SurnameAsExplicitNull}.
+ * TODO(DSTEW write-side): once the amendment PATCH contract carries an explicit null (e.g. {@code
+ * JsonNullable} fields on {@code ClaimPatch} or raw-body presence detection), add an end-to-end
+ * cleared-field scenario here.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("Claim Amendment History E2E (DSTEW-1813 / DSTEW-1814) Integration Test")
+class ClaimAmendmentHistoryE2eIntegrationTest extends MockServerIntegrationTest {
+
+  private static final String PATCH_A_CLAIM_ENDPOINT =
+      API_URI_PREFIX + "/submissions/{submissionId}/claims/{claimId}";
+  private static final String HISTORY_ENDPOINT = API_URI_PREFIX + "/claims/{claimId}/history";
+
+  private static final String AMENDMENT_USER_ID = "00000000-0000-0000-0000-000000000001";
+  private static final String REQUESTED_BY_PROVIDER = "PROVIDER";
+  private static final String REASON_PROVIDER_ERROR = "PROVIDER_ERROR";
+
+  @SuppressWarnings("java:S1075")
+  private static final String FEE_CALCULATION_PATH = "/api/v1/fee-calculation";
+
+  @Autowired private ClaimsApiProperties claimsApiProperties;
+
+  private boolean originalAmendmentFlag;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    originalAmendmentFlag = claimsApiProperties.getAmendments().isEnabled();
+    claimsApiProperties.getAmendments().setEnabled("true");
+
+    seedClaimsData();
+
+    // Let the genuine AmendmentExternalValidationStep run against controlled external responses.
+    stubExternalValidationEndpoints();
+    // CLAIM_1 belongs to a LEGAL_HELP submission; keep the fee-code Area-of-Law gate happy.
+    stubFeeDetailsAreaOfLaw("LEGAL_HELP");
+
+    // Put CLAIM_1 into an amendable state and give it the baseline calculated fee the repricing
+    // path requires (otherwise the amendment is rejected with CFD_MISSING before any diff is
+    // built).
+    Claim claim1 = claimRepository.findById(CLAIM_1_ID).orElseThrow();
+    claim1.setStatus(ClaimStatus.VALID);
+    claimRepository.saveAndFlush(claim1);
+    createBaselineCalculatedFeeDetail(claim1);
+
+    // Each test controls (and asserts on) the fee-calculation stub itself.
+    mockServerClient.clear(request().withPath(FEE_CALCULATION_PATH), ClearType.EXPECTATIONS);
+  }
+
+  @AfterEach
+  void tearDown() {
+    claimsApiProperties.getAmendments().setEnabled(String.valueOf(originalAmendmentFlag));
+  }
+
+  @Test
+  @DisplayName(
+      "A repricing amendment surfaces an AMENDMENT history event with the requested change and FSP consequence")
+  void repricingAmendmentSurfacesAmendmentHistoryEvent() throws Exception {
+    // A pricing-impacting requested change: it produces a REQUESTED diff entry AND triggers the FSP
+    // recalculation whose fee delta is recorded as FSP-sourced diff entries.
+    ClaimPatch patch = basePatch();
+    patch.setNetProfitCostsAmount(BigDecimal.valueOf(9999.00));
+
+    // FSP returns a total that differs from the baseline (100.00), so the recalculation is a
+    // genuine
+    // consequence of the requested change.
+    String fspResponse =
+        "{\"feeCode\":\"FEE-123\",\"schemeId\":\"SCHEME-TEST\",\"escapeCaseFlag\":false,"
+            + "\"feeCalculation\":{\"totalAmount\":650.00,\"netProfitCostsAmount\":450.00,"
+            + "\"vatIndicator\":true}}";
+    mockServerClient
+        .when(request().withMethod("POST").withPath(FEE_CALCULATION_PATH))
+        .respond(
+            response()
+                .withStatusCode(200)
+                .withContentType(MediaType.APPLICATION_JSON)
+                .withBody(fspResponse));
+
+    // --- Act 1: submit the amendment through the public PATCH endpoint ---
+    mockMvc
+        .perform(
+            patch(PATCH_A_CLAIM_ENDPOINT, SUBMISSION_1_ID, CLAIM_1_ID)
+                .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
+                .content(OBJECT_MAPPER.writeValueAsString(patch))
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+
+    // The amendment is committed; grab its id so we can assert the event's source_id.
+    List<ClaimAmendment> amendments =
+        claimAmendmentRepository.findByClaimIdOrderByIdDesc(CLAIM_1_ID);
+    assertThat(amendments).hasSize(1);
+    UUID amendmentId = amendments.getFirst().getId();
+
+    // --- Act 2: read the public history endpoint ---
+    String body =
+        mockMvc
+            .perform(
+                get(HISTORY_ENDPOINT, CLAIM_1_ID).header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    JsonNode events = OBJECT_MAPPER.readTree(body).get("events");
+    JsonNode amendmentEvent = firstEventOfType(events, "AMENDMENT");
+
+    // --- Assert: envelope + metadata (DSTEW-1813) ---
+    assertThat(amendmentEvent).as("an AMENDMENT event is present in the timeline").isNotNull();
+    assertThat(amendmentEvent.get("actor_id").asText()).isEqualTo(AMENDMENT_USER_ID);
+    assertThat(amendmentEvent.get("source_id").asText()).isEqualTo(amendmentId.toString());
+    assertThat(amendmentEvent.get("event_timestamp").isNull()).isFalse();
+
+    JsonNode metadata = amendmentEvent.get("metadata");
+    assertThat(metadata.get("requested_by_code").asText()).isEqualTo(REQUESTED_BY_PROVIDER);
+    assertThat(metadata.get("amendment_reason_code").asText()).isEqualTo(REASON_PROVIDER_ERROR);
+
+    // --- Assert: change detail (DSTEW-1814) ---
+    JsonNode changes = metadata.get("changes");
+    assertThat(changes).as("changes array is present").isNotNull();
+
+    // Every entry is well-formed: field_identifier + change_source present, before/after keys
+    // exist.
+    for (JsonNode change : changes) {
+      assertThat(change.hasNonNull("field_identifier")).isTrue();
+      assertThat(change.hasNonNull("change_source")).isTrue();
+      assertThat(change.has("before")).isTrue();
+      assertThat(change.has("after")).isTrue();
+      assertThat(change.get("change_source").asText()).isIn("REQUESTED", "FSP");
+    }
+
+    // This repricing amendment produces exactly one REQUESTED change and the FSP fee consequences.
+    assertThat(changes).hasSize(5);
+    assertThat(countByChangeSource(changes, "REQUESTED")).isEqualTo(1);
+    assertThat(countByChangeSource(changes, "FSP")).isEqualTo(4);
+
+    // --- REQUESTED change: the provider's edit, with its actual before/after values ---
+    // Seeded claimSummaryFee net profit costs (250) -> the amended value (9999.00).
+    JsonNode requested = changeByField(changes, "claimSummaryFee.netProfitCostsAmount");
+    assertThat(requested.get("change_source").asText()).isEqualTo("REQUESTED");
+    assertThat(requested.get("before").decimalValue()).isEqualByComparingTo("250");
+    assertThat(requested.get("after").decimalValue()).isEqualByComparingTo("9999.00");
+
+    // --- FSP consequences: the recalculated fee values returned by the stubbed FSP response ---
+    // Total fee recalculated from the baseline (100.00) to the FSP-returned total (650.00).
+    JsonNode fspTotal = changeByField(changes, "fee.totalAmount");
+    assertThat(fspTotal.get("change_source").asText()).isEqualTo("FSP");
+    assertThat(fspTotal.get("before").decimalValue()).isEqualByComparingTo("100.00");
+    assertThat(fspTotal.get("after").decimalValue()).isEqualByComparingTo("650.00");
+
+    // Fee net profit costs: previously unset on the baseline (explicit null) -> FSP value (450.00).
+    JsonNode fspNetProfitCosts = changeByField(changes, "fee.netProfitCostsAmount");
+    assertThat(fspNetProfitCosts.get("change_source").asText()).isEqualTo("FSP");
+    assertThat(fspNetProfitCosts.get("before").isNull()).isTrue();
+    assertThat(fspNetProfitCosts.get("after").decimalValue()).isEqualByComparingTo("450.00");
+
+    // VAT indicator: previously unset (explicit null) -> FSP value (true).
+    JsonNode fspVatIndicator = changeByField(changes, "fee.vatIndicator");
+    assertThat(fspVatIndicator.get("change_source").asText()).isEqualTo("FSP");
+    assertThat(fspVatIndicator.get("before").isNull()).isTrue();
+    assertThat(fspVatIndicator.get("after").asBoolean()).isTrue();
+
+    // Scheme id: previously unset (explicit null) -> FSP value ("SCHEME-TEST").
+    JsonNode fspSchemeId = changeByField(changes, "fee.schemeId");
+    assertThat(fspSchemeId.get("change_source").asText()).isEqualTo("FSP");
+    assertThat(fspSchemeId.get("before").isNull()).isTrue();
+    assertThat(fspSchemeId.get("after").asText()).isEqualTo("SCHEME-TEST");
+
+    // TODO(DSTEW-1762 / DSTEW-1815): the FSP consequence FLAGS (pricing_recalculated,
+    // price_changed,
+    //  escape_case_logged) are intentionally NOT asserted here. They derive from
+    //  calculated_fee_detail.claim_amendment_id, and AmendmentCalculatedFeeWriter.attach() is
+    //  currently a no-op stub, so the LEFT JOIN in the history SQL will not match and the flags
+    // stay
+    //  false. Add flag assertions once DSTEW-1762 links the calculated_fee_detail row to the
+    //  amendment (and DSTEW-1815 formalises the flags in this story's scope).
+  }
+
+  @Test
+  @DisplayName(
+      "A non-pricing amendment surfaces an AMENDMENT event whose changes are all REQUESTED (no FSP)")
+  void nonPricingAmendmentSurfacesRequestedOnlyChanges() throws Exception {
+    // A non-pricing requested change must not trigger FSP, so every diff entry is
+    // REQUESTED-sourced.
+    String amendedForename = "NewForename";
+    ClaimPatch patch = basePatch();
+    patch.setClientForename(amendedForename);
+
+    mockMvc
+        .perform(
+            patch(PATCH_A_CLAIM_ENDPOINT, SUBMISSION_1_ID, CLAIM_1_ID)
+                .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
+                .content(OBJECT_MAPPER.writeValueAsString(patch))
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+
+    String body =
+        mockMvc
+            .perform(
+                get(HISTORY_ENDPOINT, CLAIM_1_ID).header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    JsonNode events = OBJECT_MAPPER.readTree(body).get("events");
+    JsonNode amendmentEvent = firstEventOfType(events, "AMENDMENT");
+    assertThat(amendmentEvent).as("an AMENDMENT event is present in the timeline").isNotNull();
+
+    JsonNode changes = amendmentEvent.get("metadata").get("changes");
+    assertThat(changes).isNotNull();
+
+    // Exactly the one provider-requested field change, with its actual before/after values, and no
+    // FSP consequence (a forename change does not impact pricing). "Alice" is the seeded baseline.
+    assertThat(changes).hasSize(1);
+    JsonNode nameChange = changeByField(changes, "client.clientForename");
+    assertThat(nameChange.get("change_source").asText()).isEqualTo("REQUESTED");
+    assertThat(nameChange.get("before").asText()).isEqualTo(SEEDED_CLIENT_FORENAME);
+    assertThat(nameChange.get("after").asText()).isEqualTo(amendedForename);
+
+    // FSP must never be called for a non-pricing amendment.
+    mockServerClient.verify(
+        request().withPath(FEE_CALCULATION_PATH),
+        org.mockserver.verify.VerificationTimes.exactly(0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private ClaimPatch basePatch() {
+    ClaimPatch patch = new ClaimPatch();
+    patch.setVersion(1L);
+    patch.setAmendmentUserId(UUID.fromString(AMENDMENT_USER_ID));
+    patch.setAmendmentRequestedBy(REQUESTED_BY_PROVIDER);
+    patch.setAmendmentReasonCode(REASON_PROVIDER_ERROR);
+    return patch;
+  }
+
+  private void createBaselineCalculatedFeeDetail(Claim claim) {
+    ClaimSummaryFee summaryFee =
+        claimSummaryFeeRepository
+            .findByClaimId(claim.getId())
+            .orElseGet(
+                () ->
+                    claimSummaryFeeRepository.saveAndFlush(
+                        ClaimSummaryFee.builder()
+                            .id(Uuid7.timeBasedUuid())
+                            .claim(claim)
+                            .createdByUserId("Test")
+                            .build()));
+
+    CalculatedFeeDetail cfd = new CalculatedFeeDetail();
+    cfd.setId(Uuid7.timeBasedUuid());
+    cfd.setClaim(claim);
+    cfd.setClaimSummaryFee(summaryFee);
+    cfd.setEscapeCaseFlag(false);
+    cfd.setFeeCode("FEE-123");
+    cfd.setTotalAmount(BigDecimal.valueOf(100.00));
+    cfd.setCreatedByUserId("Test");
+    cfd.setCreatedOn(OffsetDateTime.now().minusDays(1));
+    calculatedFeeDetailRepository.saveAndFlush(cfd);
+  }
+
+  private static JsonNode firstEventOfType(JsonNode events, String eventType) {
+    for (JsonNode event : events) {
+      if (eventType.equals(event.path("event_type").asText())) {
+        return event;
+      }
+    }
+    return null;
+  }
+
+  /** Returns the single change with the given field identifier, failing if it is absent. */
+  private static JsonNode changeByField(JsonNode changes, String fieldIdentifier) {
+    for (JsonNode change : changes) {
+      if (fieldIdentifier.equals(change.path("field_identifier").asText())) {
+        return change;
+      }
+    }
+    throw new AssertionError("No change found for field_identifier '" + fieldIdentifier + "'");
+  }
+
+  private static long countByChangeSource(JsonNode changes, String changeSource) {
+    long count = 0;
+    for (JsonNode change : changes) {
+      if (changeSource.equals(change.path("change_source").asText())) {
+        count++;
+      }
+    }
+    return count;
+  }
+}

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/claim/amendments/ClaimAmendmentIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/claim/amendments/ClaimAmendmentIntegrationTest.java
@@ -99,4 +99,34 @@ class ClaimAmendmentIntegrationTest extends AbstractAmendmentPatchIntegrationTes
     assertThat(amendedClient.getClientForename()).isEqualTo(AMENDED_CLIENT_FORENAME);
     assertThat(amendedClient.getClientSurname()).isEqualTo(AMENDED_CLIENT_SURNAME);
   }
+
+  @Test
+  @DisplayName("a no-op amendment (no field changes) returns 204 and writes no claim_amendment row")
+  void noOpAmendmentReturns204AndWritesNoRow() throws Exception {
+    // Deliberately do NOT stub the PDA /schedules call: a no-op amendment must short-circuit at the
+    // no-change guard, before the PDA/FSP steps run, so no external call is made. A clean 204 here
+    // therefore also proves the guard runs early in the pipeline.
+
+    // Put the seeded claim into the amendable state.
+    Claim seeded = claimRepository.findById(CLAIM_1_ID).orElseThrow();
+    seeded.setStatus(ClaimStatus.VALID);
+    claimRepository.saveAndFlush(seeded);
+
+    // Metadata-only patch: carries the required requested-by/reason/user id but changes no field.
+    ClaimPatch patch = metadataPatch();
+
+    MvcResult result = performPatch(SUBMISSION_1_ID, CLAIM_1_ID, patch);
+
+    // A no-op amendment is accepted with 204 No Content - the same success status a genuine
+    // amendment returns - and the response body is empty.
+    assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    assertThat(result.getResponse().getContentAsString()).isEmpty();
+
+    // No phantom history row: nothing was persisted.
+    assertThat(claimAmendmentRepository.findByClaimIdOrderByIdDesc(CLAIM_1_ID)).isEmpty();
+
+    // The claim itself is untouched: the amended flag is not set by a no-op.
+    Claim afterClaim = claimRepository.findById(CLAIM_1_ID).orElseThrow();
+    assertThat(afterClaim.isAmended()).isFalse();
+  }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepositoryIntegrationTest.java
@@ -269,7 +269,8 @@ class JdbcClaimHistoryRepositoryIntegrationTest extends AbstractIntegrationTest 
   // ---------- AMENDMENT events (DSTEW-1813 / DSTEW-1814) ----------
 
   @Test
-  @DisplayName("Maps a single claim_amendment row into an AMENDMENT event with metadata and changes")
+  @DisplayName(
+      "Maps a single claim_amendment row into an AMENDMENT event with metadata and changes")
   void mapsSingleAmendmentToAmendmentEvent() {
     UUID amendmentId = Uuid7.timeBasedUuid();
     persistAmendment(
@@ -315,18 +316,25 @@ class JdbcClaimHistoryRepositoryIntegrationTest extends AbstractIntegrationTest 
   }
 
   @Test
-  @DisplayName("Retains an explicitly cleared field as an explicit JSON null after value")
-  void retainsExplicitNullAfterAsJsonNull() {
+  @DisplayName("Retains a cleared client-2 surname as an explicit JSON null after value")
+  void retainsClearedClient2SurnameAsExplicitNull() {
+    // Mirrors "patch client 2 name to null": a provider-requested clear of client.client2Surname
+    // must surface in history as before=<previous value>, after=explicit JSON null (a cleared
+    // value, distinguishable from an absent key). change_source is REQUESTED (provider-driven).
     UUID amendmentId = Uuid7.timeBasedUuid();
     persistAmendment(
         amendmentId,
-        diff(change("client_surname", "\"Smith\"", "null", "REQUESTED")),
+        diff(change("client.client2Surname", "\"Bloggs\"", "null", "REQUESTED")),
         Instant.parse("2026-05-02T09:14:00Z"));
 
     ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
 
     var change = event.metadata().get("changes").get(0);
-    // The key is present but null - a cleared value, distinguishable from an absent key.
+    assertThat(change.get("field_identifier").asText()).isEqualTo("client.client2Surname");
+    assertThat(change.get("change_source").asText()).isEqualTo("REQUESTED");
+    // before carries the previous value...
+    assertThat(change.get("before").asText()).isEqualTo("Bloggs");
+    // ...and after is an explicit JSON null: the key is present and null, not omitted.
     assertThat(change.has("after")).isTrue();
     assertThat(change.get("after").isNull()).isTrue();
   }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepositoryIntegrationTest.java
@@ -1,6 +1,8 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.AmendmentTestFixtures.REASON_PROVIDER_ERROR;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.AmendmentTestFixtures.REQUESTED_BY_PROVIDER;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_SUMMARY_FEE_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.USER_ID;
@@ -22,6 +24,7 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimAmendment;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.projection.ClaimHistoryEventRow;
@@ -261,6 +264,211 @@ class JdbcClaimHistoryRepositoryIntegrationTest extends AbstractIntegrationTest 
     assertThat(events)
         .extracting(ClaimHistoryEventRow::eventType)
         .doesNotContain("ASSESSMENT", "VOID");
+  }
+
+  // ---------- AMENDMENT events (DSTEW-1813 / DSTEW-1814) ----------
+
+  @Test
+  @DisplayName("Maps a single claim_amendment row into an AMENDMENT event with metadata and changes")
+  void mapsSingleAmendmentToAmendmentEvent() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    persistAmendment(
+        amendmentId,
+        diff(change("client_surname", "\"Smyth\"", "\"Smith\"", "REQUESTED")),
+        Instant.parse("2026-05-02T09:14:00Z"));
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.eventType()).isEqualTo("AMENDMENT");
+    assertThat(event.sourceId()).isEqualTo(amendmentId);
+    assertThat(event.actorId()).isEqualTo(USER_ID);
+    assertThat(event.eventTimestamp()).isEqualTo(Instant.parse("2026-05-02T09:14:00Z"));
+    assertThat(event.metadata().get("requested_by_code").asText()).isEqualTo(REQUESTED_BY_PROVIDER);
+    assertThat(event.metadata().get("amendment_reason_code").asText())
+        .isEqualTo(REASON_PROVIDER_ERROR);
+
+    var changes = event.metadata().get("changes");
+    assertThat(changes).hasSize(1);
+    assertThat(changes.get(0).get("field_identifier").asText()).isEqualTo("client_surname");
+    assertThat(changes.get(0).get("before").asText()).isEqualTo("Smyth");
+    assertThat(changes.get(0).get("after").asText()).isEqualTo("Smith");
+    assertThat(changes.get(0).get("change_source").asText()).isEqualTo("REQUESTED");
+  }
+
+  @Test
+  @DisplayName("Distinguishes REQUESTED changes from FSP consequences in the changes list")
+  void distinguishesRequestedAndFspChanges() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    persistAmendment(
+        amendmentId,
+        diff(
+            change("client_surname", "\"Smyth\"", "\"Smith\"", "REQUESTED"),
+            change("calculated_fee_detail.total_amount", "\"100.00\"", "\"125.00\"", "FSP")),
+        Instant.parse("2026-05-02T09:14:00Z"));
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    var changes = event.metadata().get("changes");
+    assertThat(changes).hasSize(2);
+    assertThat(changes.get(0).get("change_source").asText()).isEqualTo("REQUESTED");
+    assertThat(changes.get(1).get("change_source").asText()).isEqualTo("FSP");
+  }
+
+  @Test
+  @DisplayName("Retains an explicitly cleared field as an explicit JSON null after value")
+  void retainsExplicitNullAfterAsJsonNull() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    persistAmendment(
+        amendmentId,
+        diff(change("client_surname", "\"Smith\"", "null", "REQUESTED")),
+        Instant.parse("2026-05-02T09:14:00Z"));
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    var change = event.metadata().get("changes").get(0);
+    // The key is present but null - a cleared value, distinguishable from an absent key.
+    assertThat(change.has("after")).isTrue();
+    assertThat(change.get("after").isNull()).isTrue();
+  }
+
+  @Test
+  @DisplayName("The AMENDMENT metadata never exposes the raw request payload or before-state")
+  void amendmentMetadataOmitsRawPayloadAndBeforeState() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    persistAmendment(
+        amendmentId,
+        diff(change("client_surname", "\"Smyth\"", "\"Smith\"", "REQUESTED")),
+        Instant.parse("2026-05-02T09:14:00Z"));
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.metadata().has("request_payload")).isFalse();
+    assertThat(event.metadata().has("before_state")).isFalse();
+    assertThat(event.metadata().has("beforeState")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Returns each amendment as its own event in reverse-chronological order")
+  void returnsEachAmendmentAsOwnEventInChronologicalOrder() {
+    UUID earlierAmendmentId = Uuid7.timeBasedUuid();
+    UUID laterAmendmentId = Uuid7.timeBasedUuid();
+    persistAmendment(
+        earlierAmendmentId,
+        diff(change("client_surname", "\"Smyth\"", "\"Smith\"", "REQUESTED")),
+        Instant.parse("2026-05-02T09:14:00Z"));
+    persistAmendment(
+        laterAmendmentId,
+        diff(change("fee_code", "\"OLD\"", "\"NEW\"", "REQUESTED")),
+        Instant.parse("2026-05-03T10:00:00Z"));
+
+    List<ClaimHistoryEventRow> amendments =
+        claimHistoryRepository.findHistory(CLAIM_1_ID, 50).stream()
+            .filter(event -> "AMENDMENT".equals(event.eventType()))
+            .toList();
+
+    // Newest amendment first, so the latest amendment is unambiguously derivable for the banner.
+    assertThat(amendments)
+        .extracting(ClaimHistoryEventRow::sourceId)
+        .containsExactly(laterAmendmentId, earlierAmendmentId);
+  }
+
+  @Test
+  @DisplayName("Orders same-timestamp amendments deterministically by source id descending")
+  void ordersSameTimestampAmendmentsBySourceIdDescending() {
+    UUID idA = Uuid7.timeBasedUuid();
+    UUID idB = Uuid7.timeBasedUuid();
+    Instant shared = Instant.parse("2026-05-02T09:14:00Z");
+    persistAmendment(idA, diff(change("client_surname", "\"A\"", "\"B\"", "REQUESTED")), shared);
+    persistAmendment(idB, diff(change("fee_code", "\"A\"", "\"B\"", "REQUESTED")), shared);
+
+    List<UUID> amendmentOrder =
+        claimHistoryRepository.findHistory(CLAIM_1_ID, 50).stream()
+            .filter(event -> "AMENDMENT".equals(event.eventType()))
+            .map(ClaimHistoryEventRow::sourceId)
+            .toList();
+
+    UUID higher = idA.compareTo(idB) > 0 ? idA : idB;
+    UUID lower = idA.compareTo(idB) > 0 ? idB : idA;
+    assertThat(amendmentOrder).containsExactly(higher, lower);
+  }
+
+  @Test
+  @DisplayName("Interleaves an amendment chronologically with submission and assessment events")
+  void interleavesAmendmentWithSubmissionAndAssessment() {
+    Instant submissionTimestamp =
+        claimHistoryRepository.findHistory(CLAIM_1_ID, 50).getFirst().eventTimestamp();
+
+    UUID earlierAssessmentId = Uuid7.timeBasedUuid();
+    UUID laterAmendmentId = Uuid7.timeBasedUuid();
+    persistAssessment(
+        earlierAssessmentId,
+        AssessmentType.ESCAPE_CASE_ASSESSMENT,
+        AssessmentOutcome.PAID_IN_FULL,
+        "Before submission");
+    forceCreatedOn(earlierAssessmentId, submissionTimestamp.minusSeconds(60));
+    persistAmendment(
+        laterAmendmentId,
+        diff(change("client_surname", "\"Smyth\"", "\"Smith\"", "REQUESTED")),
+        submissionTimestamp.plusSeconds(60));
+
+    List<ClaimHistoryEventRow> events = claimHistoryRepository.findHistory(CLAIM_1_ID, 50);
+
+    // Newest first: AMENDMENT (after) -> SUBMISSION -> ASSESSMENT (before).
+    assertThat(events).hasSize(3);
+    assertThat(events)
+        .extracting(ClaimHistoryEventRow::eventType)
+        .containsExactly("AMENDMENT", "SUBMISSION", "ASSESSMENT");
+    assertThat(events)
+        .extracting(ClaimHistoryEventRow::sourceId)
+        .containsExactly(laterAmendmentId, CLAIM_1_ID, earlierAssessmentId);
+  }
+
+  @Test
+  @DisplayName("Returns no AMENDMENT event when the claim has no claim_amendment row")
+  void returnsNoAmendmentEventWhenClaimHasNoAmendment() {
+    // A failed/rejected attempt persists no claim_amendment row, so it never appears (AC4).
+    List<ClaimHistoryEventRow> events = claimHistoryRepository.findHistory(CLAIM_1_ID, 50);
+
+    assertThat(events).extracting(ClaimHistoryEventRow::eventType).doesNotContain("AMENDMENT");
+  }
+
+  private ClaimHistoryEventRow findAmendmentEvent(UUID amendmentId) {
+    return claimHistoryRepository.findHistory(CLAIM_1_ID, 50).stream()
+        .filter(event -> amendmentId.equals(event.sourceId()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private void persistAmendment(UUID id, String diffJson, Instant createdOn) {
+    claimAmendmentRepository.save(
+        ClaimAmendment.builder()
+            .id(id)
+            .claim(claimRepository.getReferenceById(CLAIM_1_ID))
+            .requestedByCode(REQUESTED_BY_PROVIDER)
+            .amendmentReasonCode(REASON_PROVIDER_ERROR)
+            .beforeState("{}")
+            .requestPayload("{}")
+            .diff(diffJson)
+            .createdByUserId(USER_ID)
+            .createdOn(OffsetDateTime.ofInstant(createdOn, ZoneOffset.UTC))
+            .build());
+    claimAmendmentRepository.flush();
+  }
+
+  private static String diff(String... changeObjects) {
+    return "{\"schema_version\":1,\"changes\":[" + String.join(",", changeObjects) + "]}";
+  }
+
+  private static String change(String field, String beforeJson, String afterJson, String source) {
+    return "{\"field_identifier\":\""
+        + field
+        + "\",\"before\":"
+        + beforeJson
+        + ",\"after\":"
+        + afterJson
+        + ",\"change_source\":\""
+        + source
+        + "\"}";
   }
 
   private ClaimHistoryEventRow findAssessmentEvent(UUID assessmentId) {

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/AmendmentNoChangeIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/AmendmentNoChangeIntegrationTest.java
@@ -1,0 +1,80 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.AmendmentTestFixtures.REASON_PROVIDER_ERROR;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.AmendmentTestFixtures.REQUESTED_BY_PROVIDER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.AmendmentTestFixtures.VALID_USER_UUID;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentPayload;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentResult;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationCode;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentExternalValidationStep;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.ClaimAmendmentValidationStep;
+
+@DisplayName("No-op amendment halts early with a 204 outcome and persists nothing (integration)")
+class AmendmentNoChangeIntegrationTest extends AbstractAmendmentPipelineIntegrationTest {
+
+  @BeforeEach
+  void seedAndReset() throws IOException {
+    seedClaimsData();
+    claimAmendmentRepository.deleteAll();
+  }
+
+  @Test
+  void noOpAmendmentHaltsBeforeExternalStepsAndPersistsNothing() {
+    // Seed CLAIM_1 into the amendable VALID state (committed; test is not @Transactional).
+    Claim amendable = claimRepository.findById(CLAIM_1_ID).orElseThrow();
+    amendable.setStatus(ClaimStatus.VALID);
+    claimRepository.saveAndFlush(amendable);
+
+    long amendmentsBefore = claimAmendmentRepository.count();
+
+    // Metadata-only payload: valid requested-by/reason/user id, but no claim field changes.
+    ClaimAmendmentPayload payload =
+        ClaimAmendmentPayload.builder()
+            .amendmentRequestedBy(JsonNullable.of(REQUESTED_BY_PROVIDER))
+            .amendmentReasonCode(JsonNullable.of(REASON_PROVIDER_ERROR))
+            .amendmentUserId(JsonNullable.of(VALID_USER_UUID))
+            .build();
+
+    // Spy the external (PDA) step so we can prove the no-change guard short-circuits before it
+    // runs.
+    Pipeline pipeline = amendmentPipeline();
+    ClaimAmendmentValidationStep spiedExternal =
+        spy(pipeline.realStep(AmendmentExternalValidationStep.class));
+    ClaimAmendmentService service =
+        pipeline.replaceStep(AmendmentExternalValidationStep.class, spiedExternal).build();
+
+    ClaimAmendmentResult result = submitInNewTransaction(service, CLAIM_1_ID, payload);
+
+    // The no-op is rejected by the pipeline with the fatal 204 no-change code...
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .singleElement()
+        .satisfies(
+            error -> {
+              assertThat(error.getCode())
+                  .isEqualTo(
+                      ClaimAmendmentValidationCode.NO_AMENDMENT_CHANGES_SUBMITTED.toString());
+              assertThat(error.isFatal()).isTrue();
+            });
+
+    // ...the external PDA step is never reached (proves the guard runs early)...
+    verify(spiedExternal, never()).validate(any());
+
+    // ...and nothing is persisted: no phantom claim_amendment row.
+    assertThat(claimAmendmentRepository.count()).isEqualTo(amendmentsBefore);
+  }
+}

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationServiceIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationServiceIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_1_ID;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -22,6 +23,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendment
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationError;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.AmendmentReasonReferenceEntity;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.RequestedByReferenceEntity;
 import uk.gov.justice.laa.dstew.payments.claimsdata.helper.MockServerIntegrationTest;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
@@ -60,8 +62,14 @@ class ClaimAmendmentValidationServiceIntegrationTest extends MockServerIntegrati
 
   private static final String VALID_UUID = "0190b6a0-9b7e-7c8a-9e2d-2f3a4b5c6d7e";
 
-  // The claim fee code used by the fixtures below (alphanumeric, <= 10 chars per the claim schema).
+  // The claim fee code used by the FieldAmendabilityGate fixture (alphanumeric, <= 10 chars).
   private static final String CLAIM_FEE_CODE = "FEE01";
+
+  // A genuine, amendable change applied by the shared fixture so every state carries a real
+  // provider change. Client forename is amendable for CLAIM_1's area of law (LEGAL_HELP) and is not
+  // a pricing field, so it passes the no-op guard and the amendability gate without disturbing the
+  // metadata/reference/status behaviour under test. It differs from the seeded value ("Alice").
+  private static final String AMENDED_CLIENT_FORENAME = "Amended-Forename";
 
   // Seeded (V41) codes used by the happy-path and lookup scenarios.
   private static final String SEEDED_PARTY = "PROVIDER";
@@ -71,16 +79,18 @@ class ClaimAmendmentValidationServiceIntegrationTest extends MockServerIntegrati
   public static final String NOT_A_UUID = "not-a-uuid";
 
   @Autowired private ClaimAmendmentValidationService validationService;
+  @Autowired private ClaimAmendmentStateService amendmentStateService;
   @Autowired private RequestedByReferenceRepository requestedByReferenceRepository;
   @Autowired private AmendmentReasonReferenceRepository amendmentReasonReferenceRepository;
 
   /**
-   * Stubs the validation-core external calls so the assembled chain can run end to end. The
-   * responses are deliberately "clean" so the external validation contributes no issues, leaving
-   * the amendment-metadata errors (the focus of these tests) as the only failures.
+   * Seeds the richly-populated, schema-valid CLAIM_1 and stubs the validation-core external calls
+   * so the assembled chain can run end to end. The seeded claim keeps the external validation step
+   * clean, leaving the amendment-metadata errors (the focus of these tests) as the only failures.
    */
   @BeforeEach
   void setUp() throws IOException {
+    seedClaimsData();
     stubExternalValidationEndpoints();
   }
 
@@ -313,32 +323,24 @@ class ClaimAmendmentValidationServiceIntegrationTest extends MockServerIntegrati
   private ClaimAmendmentState stateOf(
       ClaimStatus status, String requestedBy, String reason, String userId) {
 
-    // A schema-valid claim so the external validation step (which runs the full CLAIM_* validator
-    // set against MockServer) contributes no issues, leaving the amendment-metadata errors as the
-    // only failures. Required fields per the validation-core claim schema: status, line_number,
-    // net_disbursement_amount, disbursements_vat_amount, fee_code (alphanumeric, <= 10 chars).
-    ClaimStateSnapshot snapshot =
-        ClaimStateSnapshot.builder()
-            .claimId(Uuid7.timeBasedUuid())
-            .feeCode(CLAIM_FEE_CODE)
-            .status(status)
-            .lineNumber(1)
-            .netDisbursementAmount(new BigDecimal("0.00"))
-            .disbursementsVatAmount(new BigDecimal("0.00"))
-            .caseStartDate(LocalDate.ofInstant(Instant.now(), ZoneId.systemDefault()))
-            .calculatedFeeDetail(
-                CalculatedFeeDetailSnapshot.builder().totalAmount(BigDecimal.TEN).build())
+    // Drive the state off the richly-seeded, schema-valid CLAIM_1 (LEGAL_HELP) so the assembled
+    // chain's external validation contributes no issues. The payload carries a genuine amendable
+    // change (client forename) so the no-op guard and the amendability gate both pass, isolating
+    // the
+    // metadata/reference/status behaviour under test. The before/post states are built by the real
+    // retrieval so this exercises the production wiring end to end.
+    Claim claim = claimRepository.findById(CLAIM_1_ID).orElseThrow();
+    claim.setStatus(status);
+    claimRepository.saveAndFlush(claim);
+
+    ClaimAmendmentPayload payload =
+        ClaimAmendmentPayload.builder()
+            .amendmentRequestedBy(JsonNullable.of(requestedBy))
+            .amendmentReasonCode(JsonNullable.of(reason))
+            .amendmentUserId(JsonNullable.of(userId))
+            .clientForename(JsonNullable.of(AMENDED_CLIENT_FORENAME))
             .build();
 
-    return ClaimAmendmentState.builder()
-        .beforeState(snapshot)
-        .postAmendmentState(snapshot)
-        .requestPayload(
-            ClaimAmendmentPayload.builder()
-                .amendmentRequestedBy(JsonNullable.of(requestedBy))
-                .amendmentReasonCode(JsonNullable.of(reason))
-                .amendmentUserId(JsonNullable.of(userId))
-                .build())
-        .build();
+    return amendmentStateService.retrieveAmendmentState(claim, payload).state();
   }
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ChangeSource.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ChangeSource.java
@@ -12,11 +12,11 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *       (DSTEW-1762).
  * </ul>
  *
- * <p>The serialised JSON value is the stable label ({@code "Requested"} / {@code "FSP"}) used in
- * the {@code diff} JSONB column.
+ * <p>The serialised JSON value is the stable, upper-case label ({@code "REQUESTED"} / {@code
+ * "FSP"}) used in the {@code diff} JSONB column.
  */
 public enum ChangeSource {
-  REQUESTED("Requested"),
+  REQUESTED("REQUESTED"),
   FSP("FSP");
 
   private final String jsonValue;

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentValidationCode.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/dto/amendment/ClaimAmendmentValidationCode.java
@@ -26,6 +26,23 @@ public enum ClaimAmendmentValidationCode {
       "Amendments are not currently enabled.",
       "Amendments feature flag (laa.claims.api.amendments.enabled) is disabled"),
 
+  /**
+   * The submitted amendment changes nothing (no provider-requested field differs from the stored
+   * value), so there is nothing to amend.
+   *
+   * <p>This is a "no work to do" outcome rather than a client mistake, so it resolves to a <b>204
+   * No Content</b> - the same success status a genuine amendment returns - and no {@code
+   * claim_amendment} row is written. It is nonetheless modelled as a {@code FATAL} step outcome so
+   * it halts the pipeline through the same mechanism as every other stop condition (see {@code
+   * AmendmentNoChangeValidationStep}); the request-boundary handler recognises the 204 status and
+   * returns an empty body, as a 204 response must not carry one.
+   */
+  NO_AMENDMENT_CHANGES_SUBMITTED(
+      ValidationSeverity.FATAL,
+      HttpStatus.NO_CONTENT,
+      "No changes were submitted; there is nothing to amend.",
+      "Amendment payload produced no provider-requested field changes (no-op); nothing to persist"),
+
   /** The claim has a null version number so cannot be amended. */
   INVALID_NULL_VERSION(
       ValidationSeverity.FATAL, HttpStatus.BAD_REQUEST, "Claim Version is null", null),

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/exception/DataClaimsExceptionHandler.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/exception/DataClaimsExceptionHandler.java
@@ -150,6 +150,12 @@ public class DataClaimsExceptionHandler extends ResponseEntityExceptionHandler {
       status = primaryError.getHttpStatus();
     }
 
+    // A 204 outcome (e.g. a no-op amendment that changed nothing) is a success status and must not
+    // carry a response body per RFC 9110; return an empty 204 without the ProblemDetail/errors.
+    if (status == HttpStatus.NO_CONTENT) {
+      return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     ResponseEntity<ProblemDetail> response =
         buildProblemDetailResponse(status, ex.getMessage(), ex.getClass(), request);
 

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationService.java
@@ -10,6 +10,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendment
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentExternalValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentFeatureFlagValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentFspValidationStep;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentNoChangeValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentReferenceValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentUserIdValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AssessedClaimPricingValidationStep;
@@ -64,6 +65,9 @@ public class ClaimAmendmentValidationService {
           // any other work is done.
           AmendmentFeatureFlagValidationStep.class,
           BeforeStatePresenceValidationStep.class,
+          // No-op guard: if the payload changes nothing, halt here (204) before the status,
+          // metadata, PDA and FSP steps run, so no phantom claim_amendment row is written.
+          AmendmentNoChangeValidationStep.class,
           ClaimStatusValidationStep.class,
           AssessedClaimPricingValidationStep.class,
           FieldAmendabilityValidationStep.class,

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/AmendmentNoChangeValidationStep.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/AmendmentNoChangeValidationStep.java
@@ -1,0 +1,54 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationCode;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.persistence.AmendmentChangeDetector;
+
+/**
+ * Guard that halts a no-op amendment - one whose payload changes nothing - before any work is done
+ * or any {@code claim_amendment} row is written.
+ *
+ * <p>The change signal is {@link AmendmentChangeDetector#detectChanges(ClaimAmendmentState)}, which
+ * compares the before-state against the post-amendment state and returns the provider-requested
+ * changed fields. This step runs early - after the before-state is known but before the metadata,
+ * PDA and FSP steps - so a genuinely empty change-set short-circuits the pipeline before any
+ * external call is made. At this point no FSP recalculation has run, so {@code afterFee} is absent
+ * and the detector reports the provider-requested changes only, which is exactly the "did the
+ * provider actually request a change" question.
+ *
+ * <ul>
+ *   <li>at least one changed field -&gt; the step passes and amendment processing continues;
+ *   <li>no changed fields -&gt; the step fails with a fatal {@link
+ *       ClaimAmendmentValidationCode#NO_AMENDMENT_CHANGES_SUBMITTED}, halting the flow so no later
+ *       step runs and nothing is saved.
+ * </ul>
+ *
+ * <p>Although a no-op is not a client mistake, it is modelled as a fatal step outcome so it stops
+ * the pipeline through the same mechanism as every other stop condition. Its code resolves to a
+ * <b>204 No Content</b> - the same success status a genuine amendment returns - so the caller sees
+ * a consistent "accepted, nothing to do" response and no phantom history row is created.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmendmentNoChangeValidationStep implements ClaimAmendmentValidationStep {
+
+  private final AmendmentChangeDetector changeDetector;
+
+  @Override
+  public List<ClaimAmendmentValidationError> validate(ClaimAmendmentState state) {
+    if (!changeDetector.detectChanges(state).isEmpty()) {
+      return List.of();
+    }
+
+    log.debug("Amendment submitted no field changes (no-op); halting with a 204 outcome.");
+    return List.of(
+        ClaimAmendmentValidationError.of(
+            ClaimAmendmentValidationCode.NO_AMENDMENT_CHANGES_SUBMITTED));
+  }
+}

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/exception/DataClaimsExceptionHandlerTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/exception/DataClaimsExceptionHandlerTest.java
@@ -183,6 +183,25 @@ class DataClaimsExceptionHandlerTest {
   }
 
   @Test
+  @DisplayName("a no-op amendment (204 fatal outcome) returns an empty 204 with no body")
+  void handleClaimAmendmentValidationException_returnsBodiless204WhenNoChanges() {
+    // A no-op amendment halts with a fatal NO_AMENDMENT_CHANGES_SUBMITTED code carrying a 204
+    // status; a 204 response must not carry a body per RFC 9110.
+    ClaimAmendmentValidationError noChangeError =
+        ClaimAmendmentValidationError.of(
+            ClaimAmendmentValidationCode.NO_AMENDMENT_CHANGES_SUBMITTED);
+    ClaimAmendmentValidationException ex =
+        new ClaimAmendmentValidationException(List.of(noChangeError));
+
+    ResponseEntity<ProblemDetail> result =
+        dataClaimsExceptionHandler.handleClaimAmendmentValidationException(ex, mockRequest);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(result.getBody()).isNull();
+  }
+
+  @Test
   void handleDatabaseOptimisticLockingException_returnsConflictStatusWithPredefinedMessage() {
     // Arrange
     OptimisticLockException ex =

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimHistoryEventRowMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimHistoryEventRowMapperTest.java
@@ -64,6 +64,43 @@ class ClaimHistoryEventRowMapperTest {
   }
 
   @Test
+  void mapsAmendmentEventWithRequesterReasonAndChanges() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getObject("event_timestamp", OffsetDateTime.class))
+        .thenReturn(OffsetDateTime.parse("2026-05-02T09:14:00Z"));
+    when(rs.getObject("source_id", UUID.class)).thenReturn(UUID.randomUUID());
+    when(rs.getString("event_type")).thenReturn("AMENDMENT");
+    when(rs.getString("actor_id")).thenReturn("entra-uuid");
+    when(rs.getString("metadata"))
+        .thenReturn(
+            "{\"requested_by_code\":\"PROVIDER\","
+                + "\"amendment_reason_code\":\"PROVIDER_ERROR\","
+                + "\"changes\":["
+                + "{\"field_identifier\":\"client_surname\",\"before\":\"Smyth\","
+                + "\"after\":\"Smith\",\"change_source\":\"REQUESTED\"},"
+                + "{\"field_identifier\":\"calculated_fee_detail.total_amount\","
+                + "\"before\":\"100.00\",\"after\":null,\"change_source\":\"FSP\"}]}");
+
+    ClaimHistoryEventRow row = mapper.mapRow(rs, 0);
+
+    assertThat(row.eventType()).isEqualTo("AMENDMENT");
+    assertThat(row.actorId()).isEqualTo("entra-uuid");
+    assertThat(row.metadata().get("requested_by_code").asText()).isEqualTo("PROVIDER");
+    assertThat(row.metadata().get("amendment_reason_code").asText()).isEqualTo("PROVIDER_ERROR");
+
+    var changes = row.metadata().get("changes");
+    assertThat(changes).hasSize(2);
+    // First change: a provider-requested value change.
+    assertThat(changes.get(0).get("field_identifier").asText()).isEqualTo("client_surname");
+    assertThat(changes.get(0).get("before").asText()).isEqualTo("Smyth");
+    assertThat(changes.get(0).get("after").asText()).isEqualTo("Smith");
+    assertThat(changes.get(0).get("change_source").asText()).isEqualTo("REQUESTED");
+    // Second change: an FSP consequence with an explicit null after value (a cleared field).
+    assertThat(changes.get(1).get("change_source").asText()).isEqualTo("FSP");
+    assertThat(changes.get(1).get("after").isNull()).isTrue();
+  }
+
+  @Test
   void mapsVoidEvent_withoutOutcome() throws SQLException {
     ResultSet rs = mock(ResultSet.class);
     when(rs.getObject("event_timestamp", OffsetDateTime.class))

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/ClaimAmendmentValidationServiceTest.java
@@ -20,10 +20,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.dstew.payments.claims.validation.core.service.ValidationService;
 import uk.gov.justice.laa.dstew.payments.claimsdata.client.FeeSchemePlatformRestClient;
 import uk.gov.justice.laa.dstew.payments.claimsdata.config.ClaimsApiProperties;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ChangeSource;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationCode;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationError;
 import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimStateSnapshot;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.DiffEntry;
 import uk.gov.justice.laa.dstew.payments.claimsdata.mapper.ClaimStateSnapshotMapper;
 import uk.gov.justice.laa.dstew.payments.claimsdata.mapper.ValidationClaimMapper;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
@@ -35,6 +37,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.persistenc
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentExternalValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentFeatureFlagValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentFspValidationStep;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentNoChangeValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentReferenceValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AmendmentUserIdValidationStep;
 import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation.AssessedClaimPricingValidationStep;
@@ -127,15 +130,20 @@ class ClaimAmendmentValidationServiceTest {
     ClaimsApiProperties claimsApiProperties = new ClaimsApiProperties();
     claimsApiProperties.getAmendments().setEnabled("true");
 
-    // Provide a bean for every declared step so ordered() can resolve STEP_ORDER. The status step
-    // returns a fatal error for the empty state below, so the orchestrator short-circuits before
-    // the later steps run.
+    // Provide a bean for every declared step so ordered() can resolve STEP_ORDER. The no-change
+    // step's detector reports a change so it passes; the status step then returns a fatal error for
+    // the empty state below, so the orchestrator short-circuits before the later steps run.
+    AmendmentChangeDetector changeDetector = mock(AmendmentChangeDetector.class);
+    when(changeDetector.detectChanges(any()))
+        .thenReturn(List.of(new DiffEntry("claim.feeCode", ChangeSource.REQUESTED, "A", "B")));
+
     ClaimAmendmentValidationService service =
         new ClaimAmendmentValidationService(
             List.of(
                 extraStep,
                 new AmendmentFeatureFlagValidationStep(claimsApiProperties),
                 new BeforeStatePresenceValidationStep(),
+                new AmendmentNoChangeValidationStep(changeDetector),
                 new ClaimStatusValidationStep(),
                 new AssessedClaimPricingValidationStep(new AmendmentChangeDetector()),
                 new FieldAmendabilityValidationStep(diffAssembler),

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/AmendmentJsonWriterTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/AmendmentJsonWriterTest.java
@@ -61,7 +61,7 @@ class AmendmentJsonWriterTest {
     assertThat(json)
         .contains("\"schema_version\":1")
         .contains("\"field_identifier\":\"claim.feeCode\"")
-        .contains("\"change_source\":\"Requested\"")
+        .contains("\"change_source\":\"REQUESTED\"")
         .contains("\"before\":\"OLD\"")
         .contains("\"after\":\"NEW\"");
   }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/AmendmentNoChangeValidationStepTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/validation/AmendmentNoChangeValidationStepTest.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ChangeSource;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentState;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationCode;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.ClaimAmendmentValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsdata.dto.amendment.DiffEntry;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.amendment.persistence.AmendmentChangeDetector;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AmendmentNoChangeValidationStep")
+class AmendmentNoChangeValidationStepTest {
+
+  @Mock private AmendmentChangeDetector changeDetector;
+
+  @InjectMocks private AmendmentNoChangeValidationStep step;
+
+  private final ClaimAmendmentState state = ClaimAmendmentState.builder().build();
+
+  @Test
+  @DisplayName("no detected changes yields a single fatal 204 no-change error")
+  void noChangesYieldsFatalNoContentError() {
+    when(changeDetector.detectChanges(state)).thenReturn(List.of());
+
+    List<ClaimAmendmentValidationError> errors = step.validate(state);
+
+    assertThat(errors).hasSize(1);
+    ClaimAmendmentValidationError error = errors.get(0);
+    assertThat(error.getCode())
+        .isEqualTo(ClaimAmendmentValidationCode.NO_AMENDMENT_CHANGES_SUBMITTED.toString());
+    assertThat(error.isFatal()).isTrue();
+    assertThat(error.getHttpStatus()).isEqualTo(HttpStatus.NO_CONTENT);
+  }
+
+  @Test
+  @DisplayName("at least one detected change passes with no errors")
+  void detectedChangesPasses() {
+    when(changeDetector.detectChanges(state))
+        .thenReturn(
+            List.of(new DiffEntry("client.clientSurname", ChangeSource.REQUESTED, "Old", "New")));
+
+    assertThat(step.validate(state)).isEmpty();
+  }
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1813)

## Summary
Amendments that change nothing currently persist an empty-diff "phantom" `claim_amendment` row. This PR adds a no-op guard to the amendment validation pipeline so a no-change amendment is short-circuited early and returns **204 No Content** without writing any history row or making downstream external calls.

## Changes
- **New validation code** `NO_AMENDMENT_CHANGES_SUBMITTED` in `ClaimAmendmentValidationCode` — modelled as `FATAL` with `HttpStatus.NO_CONTENT`, so it halts the pipeline consistently with the existing fatal-error mechanism.
- **New step** `AmendmentNoChangeValidationStep` — uses `AmendmentChangeDetector` to detect whether the payload produces any provider-requested field changes; raises the fatal 204 error when there are none.
- **Pipeline ordering** — inserted the step into `ClaimAmendmentValidationService.STEP_ORDER` early (after `BeforeStatePresenceValidationStep`, before `ClaimStatusValidationStep`), so no-ops are rejected before the status/metadata/PDA/FSP steps run and nothing is persisted.
- **Exception handling** — `DataClaimsExceptionHandler.handleClaimAmendmentValidationException` now returns a bodiless 204 for the no-content outcome (per RFC 9110), rather than attaching a ProblemDetail body.

## Tests
- **Unit**: `AmendmentNoChangeValidationStepTest` (no-change → fatal 204; changes present → passes); handler test asserting a bodiless 204; updated `ClaimAmendmentValidationServiceTest` step-ordering test to include the new step.
- **Integration**: `AmendmentNoChangeIntegrationTest` (real pipeline: no-op halts before external steps and persists nothing); `ClaimAmendmentIntegrationTest` HTTP case asserting 204, empty body, no `claim_amendment` row, claim not marked amended.
- Reworked `ClaimAmendmentValidationServiceIntegrationTest` fixtures to drive off the seeded, schema-valid `CLAIM_1` (via the real amendment state service) so the metadata-validation cases exercise a genuine field change rather than an identical before/after snapshot.

## Behaviour / impact
- No-op amendment → **204 No Content**, no history row, no external calls.
- Amendments that change at least one field are unaffected.
- No changes to the write contract or the legacy status/fee update path.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
