### PR TITLE
feat(DSTEW-1815): Expose amendment-level FSP history indicators on the Claim History Timeline

### DIFF
--- a/claims-data/api/open-api-specification.yml
+++ b/claims-data/api/open-api-specification.yml
@@ -2507,7 +2507,114 @@ components:
         metadata:
           type: object
           additionalProperties: true
-          description: Event-specific attributes, shaped per event type.
+          description: >
+            Event-specific attributes, shaped per event type. The concrete shape is determined by
+            event_type; see the documented per-type schemas:
+            claim_history_submission_metadata (SUBMISSION),
+            claim_history_amendment_metadata (AMENDMENT),
+            claim_history_assessment_metadata (ASSESSMENT) and
+            claim_history_void_metadata (VOID). The container stays open (additionalProperties)
+            so new event types and attributes can be added without reshaping the contract.
+    claim_history_change_entry:
+      type: object
+      description: >
+        A single field-level change recorded on an amendment, lifted verbatim from the persisted
+        amendment diff. change_source distinguishes provider-requested changes from FSP
+        (Fee Scheme Platform) repricing consequences.
+      properties:
+        field_identifier:
+          type: string
+          description: Stable, machine-readable identifier of the changed field (not a display label).
+        change_source:
+          type: string
+          enum:
+            - Requested
+            - FSP
+          description: >
+            Origin of the change. "Requested" is a provider-requested change; "FSP" is a downstream
+            consequence of Fee Scheme Platform repricing.
+        before:
+          nullable: true
+          description: Value before the amendment, in its natural JSON type. Null means cleared.
+        after:
+          nullable: true
+          description: Value after the amendment, in its natural JSON type. Null means cleared.
+    claim_history_submission_metadata:
+      type: object
+      description: Metadata carried by a SUBMISSION event.
+      properties:
+        submission_period:
+          type: string
+          description: The submission period the claim belongs to.
+        office_account_number:
+          type: string
+          description: The provider office account number for the submission.
+        area_of_law:
+          type: string
+          description: The area of law of the submission.
+    claim_history_amendment_metadata:
+      type: object
+      description: >
+        Metadata carried by an AMENDMENT event. The FSP indicators are derived exclusively from
+        amendment-linked persisted data (the linked calculated_fee_detail and the amendment diff),
+        never inferred from current claim state.
+      properties:
+        requested_by_code:
+          type: string
+          description: Governed reference code for the requesting party (e.g. PROVIDER).
+        amendment_reason_code:
+          type: string
+          description: Governed reference code for the amendment reason.
+        pricing_recalculated:
+          type: boolean
+          description: >
+            True when FSP repricing ran for this amendment, i.e. a calculated_fee_detail row is
+            linked to the amendment.
+        price_changed:
+          type: boolean
+          description: >
+            True when repricing changed the monetary value (currently driven by a change in
+            total_amount versus the previous calculated_fee_detail). False when repricing ran with
+            no monetary change, or when it did not run.
+        escape_case_logged:
+          type: boolean
+          description: >
+            True only when this amendment CAUSED the claim to become an escape case
+            (an FSP-sourced fee.escapeCaseFlag transition from false to true recorded in the
+            amendment diff). An already-escaped claim, or an amendment that did not trigger an
+            escape transition, yields false.
+        changes:
+          type: array
+          description: Field-level changes recorded on this amendment (may be empty).
+          items:
+            $ref: '#/components/schemas/claim_history_change_entry'
+    claim_history_assessment_metadata:
+      type: object
+      description: Metadata carried by an ASSESSMENT event.
+      properties:
+        assessment_type:
+          type: string
+          nullable: true
+          description: The type of assessment (null for legacy rows with no populated type).
+        assessment_outcome:
+          type: string
+          nullable: true
+          description: The assessment outcome (null when not yet determined).
+        assessment_reason:
+          type: string
+          description: The reason recorded against the assessment.
+    claim_history_void_metadata:
+      type: object
+      description: >
+        Metadata carried by a VOID event. A void carries no outcome; assessment_reason holds the
+        void reason.
+      properties:
+        assessment_type:
+          type: string
+          description: Always VOID for this event type.
+        assessment_reason:
+          type: string
+          description: The reason the claim was voided.
     claim_history_result_set:
       type: object
       description: A claim's history events in reverse-chronological order.

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepositoryIntegrationTest.java
@@ -22,6 +22,8 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.CalculatedFeeDetail;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimAmendment;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.projection.ClaimHistoryEventRow;
@@ -261,6 +263,296 @@ class JdbcClaimHistoryRepositoryIntegrationTest extends AbstractIntegrationTest 
     assertThat(events)
         .extracting(ClaimHistoryEventRow::eventType)
         .doesNotContain("ASSESSMENT", "VOID");
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // AMENDMENT events (DSTEW-1815 — FSP history indicators derived from amendment-linked data)
+  // ----------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName(
+      "Maps a claim_amendment into an AMENDMENT event exposing requester, reason and changes")
+  void mapsAmendmentEvent_withRequesterReasonAndChanges() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    // A non-pricing amendment: a provider-requested change with no linked calculated_fee_detail.
+    persistAmendment(
+        amendmentId,
+        "{\"schema_version\":1,\"changes\":[{\"field_identifier\":\"claim.feeCode\","
+            + "\"change_source\":\"Requested\",\"before\":\"OLD\",\"after\":\"NEW\"}]}");
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.eventType()).isEqualTo("AMENDMENT");
+    assertThat(event.actorId()).isEqualTo(USER_ID);
+    assertThat(event.metadata().get("requested_by_code").asText()).isEqualTo("PROVIDER");
+    assertThat(event.metadata().get("amendment_reason_code").asText()).isEqualTo("PROVIDER_ERROR");
+    // No linked fee row: repricing did not run, so no fabricated pricing/escape metadata.
+    assertThat(event.metadata().get("pricing_recalculated").asBoolean()).isFalse();
+    assertThat(event.metadata().get("price_changed").asBoolean()).isFalse();
+    assertThat(event.metadata().get("escape_case_logged").asBoolean()).isFalse();
+    assertThat(event.metadata().get("changes").isArray()).isTrue();
+    assertThat(event.metadata().get("changes")).hasSize(1);
+    assertThat(event.metadata().get("changes").get(0).get("field_identifier").asText())
+        .isEqualTo("claim.feeCode");
+  }
+
+  @Test
+  @DisplayName(
+      "Pricing amendment with a monetary change: pricing_recalculated & price_changed true")
+  void pricingAmendment_priceChanged() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    persistAmendment(amendmentId, emptyDiff());
+    linkCalculatedFeeDetail(amendmentId, true, false);
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.metadata().get("pricing_recalculated").asBoolean()).isTrue();
+    assertThat(event.metadata().get("price_changed").asBoolean()).isTrue();
+    assertThat(event.metadata().get("escape_case_logged").asBoolean()).isFalse();
+  }
+
+  @Test
+  @DisplayName("Pricing amendment with no monetary change: pricing_recalculated true, price false")
+  void pricingAmendment_priceUnchanged() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    persistAmendment(amendmentId, emptyDiff());
+    linkCalculatedFeeDetail(amendmentId, false, false);
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.metadata().get("pricing_recalculated").asBoolean()).isTrue();
+    assertThat(event.metadata().get("price_changed").asBoolean()).isFalse();
+  }
+
+  @Test
+  @DisplayName(
+      "Amendment that caused the escape transition (false -> true): escape_case_logged true")
+  void amendmentCausedEscapeTransition_logsEscape() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    // FSP-sourced fee.escapeCaseFlag transition from false to true is the transition source.
+    persistAmendment(amendmentId, escapeDiff(false, true));
+    linkCalculatedFeeDetail(amendmentId, true, true);
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.metadata().get("escape_case_logged").asBoolean()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Amendment on an already-escaped claim (no transition): escape_case_logged false")
+  void alreadyEscapedClaim_doesNotLogEscape() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    // No FSP escapeCaseFlag transition entry in the diff (an already-escaped claim never records
+    // one), even though the linked fee still carries escape_case_flag = true. The indicator must be
+    // derived from the transition, not the state.
+    persistAmendment(
+        amendmentId,
+        "{\"schema_version\":1,\"changes\":[{\"field_identifier\":\"fee.totalAmount\","
+            + "\"change_source\":\"FSP\",\"before\":\"100.00\",\"after\":\"120.00\"}]}");
+    linkCalculatedFeeDetail(amendmentId, true, true);
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.metadata().get("pricing_recalculated").asBoolean()).isTrue();
+    assertThat(event.metadata().get("escape_case_logged").asBoolean()).isFalse();
+  }
+
+  @Test
+  @DisplayName("Escape de-escalation (true -> false) is not logged as an escape transition")
+  void escapeDeEscalation_doesNotLogEscape() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    persistAmendment(amendmentId, escapeDiff(true, false));
+    linkCalculatedFeeDetail(amendmentId, true, false);
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.metadata().get("escape_case_logged").asBoolean()).isFalse();
+  }
+
+  @Test
+  @DisplayName(
+      "Multiple amendments flipping escape back and forth: each event reflects its own transition")
+  void multipleAmendments_escapeFlipFlop_resolvedPerAmendment() {
+    // Three amendments on the same claim, each with its own FSP escapeCaseFlag transition and its
+    // own linked fee row. The read model must resolve each event independently from that
+    // amendment's diff — never aggregating across amendments or reading current claim state.
+    UUID escalateId = Uuid7.timeBasedUuid();
+    UUID deEscalateId = Uuid7.timeBasedUuid();
+    UUID reEscalateId = Uuid7.timeBasedUuid();
+
+    // 1st amendment: escalates (false -> true) with a monetary change.
+    persistAmendment(escalateId, escapeDiff(false, true));
+    linkCalculatedFeeDetail(escalateId, true, true);
+    // 2nd amendment: de-escalates (true -> false) with a monetary change.
+    persistAmendment(deEscalateId, escapeDiff(true, false));
+    linkCalculatedFeeDetail(deEscalateId, true, false);
+    // 3rd amendment: re-escalates (false -> true) with NO monetary change.
+    persistAmendment(reEscalateId, escapeDiff(false, true));
+    linkCalculatedFeeDetail(reEscalateId, false, true);
+
+    ClaimHistoryEventRow escalate = findAmendmentEvent(escalateId);
+    ClaimHistoryEventRow deEscalate = findAmendmentEvent(deEscalateId);
+    ClaimHistoryEventRow reEscalate = findAmendmentEvent(reEscalateId);
+
+    // Escape is logged only on the amendments that caused a false -> true transition.
+    assertThat(escalate.metadata().get("escape_case_logged").asBoolean()).isTrue();
+    assertThat(deEscalate.metadata().get("escape_case_logged").asBoolean()).isFalse();
+    assertThat(reEscalate.metadata().get("escape_case_logged").asBoolean()).isTrue();
+
+    // price_changed is likewise independent per amendment (from each linked fee row).
+    assertThat(escalate.metadata().get("price_changed").asBoolean()).isTrue();
+    assertThat(deEscalate.metadata().get("price_changed").asBoolean()).isTrue();
+    assertThat(reEscalate.metadata().get("price_changed").asBoolean()).isFalse();
+
+    // All three ran repricing (each has a linked calculated_fee_detail).
+    assertThat(escalate.metadata().get("pricing_recalculated").asBoolean()).isTrue();
+    assertThat(deEscalate.metadata().get("pricing_recalculated").asBoolean()).isTrue();
+    assertThat(reEscalate.metadata().get("pricing_recalculated").asBoolean()).isTrue();
+  }
+
+  @Test
+  @DisplayName(
+      "Multiple amendments: price_changed is resolved per amendment (changed, unchanged, changed)")
+  void multipleAmendments_priceChangedMix_resolvedPerAmendment() {
+    // Three repricing amendments, none causing an escape transition, with differing monetary
+    // outcomes. Each event's price_changed must reflect only its own linked fee row.
+    UUID firstChanged = Uuid7.timeBasedUuid();
+    UUID secondUnchanged = Uuid7.timeBasedUuid();
+    UUID thirdChanged = Uuid7.timeBasedUuid();
+
+    persistAmendment(firstChanged, emptyDiff());
+    linkCalculatedFeeDetail(firstChanged, true, false);
+    persistAmendment(secondUnchanged, emptyDiff());
+    linkCalculatedFeeDetail(secondUnchanged, false, false);
+    persistAmendment(thirdChanged, emptyDiff());
+    linkCalculatedFeeDetail(thirdChanged, true, false);
+
+    ClaimHistoryEventRow first = findAmendmentEvent(firstChanged);
+    ClaimHistoryEventRow second = findAmendmentEvent(secondUnchanged);
+    ClaimHistoryEventRow third = findAmendmentEvent(thirdChanged);
+
+    assertThat(first.metadata().get("price_changed").asBoolean()).isTrue();
+    assertThat(second.metadata().get("price_changed").asBoolean()).isFalse();
+    assertThat(third.metadata().get("price_changed").asBoolean()).isTrue();
+
+    // No escape transition on any of them, and all ran repricing.
+    for (ClaimHistoryEventRow event : List.of(first, second, third)) {
+      assertThat(event.metadata().get("pricing_recalculated").asBoolean()).isTrue();
+      assertThat(event.metadata().get("escape_case_logged").asBoolean()).isFalse();
+    }
+  }
+
+  @Test
+  @DisplayName(
+      "Provider-requested change with repricing but no monetary change: P=true, C=false, E=false")
+  void requestedChangeWithRepricing_noPriceChange_noEscape() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    // A provider-requested (non-FSP) field change; repricing ran but produced the same total and no
+    // escape. Validates all three indicators plus the REQUESTED change_source passthrough.
+    persistAmendment(
+        amendmentId,
+        "{\"schema_version\":1,\"changes\":[{\"field_identifier\":\"claim.caseReferenceNumber\","
+            + "\"change_source\":\"Requested\",\"before\":\"REF-1\",\"after\":\"REF-2\"}]}");
+    linkCalculatedFeeDetail(amendmentId, false, false);
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.metadata().get("pricing_recalculated").asBoolean()).isTrue();
+    assertThat(event.metadata().get("price_changed").asBoolean()).isFalse();
+    assertThat(event.metadata().get("escape_case_logged").asBoolean()).isFalse();
+    assertThat(event.metadata().get("changes")).hasSize(1);
+    assertThat(event.metadata().get("changes").get(0).get("change_source").asText())
+        .isEqualTo("Requested");
+  }
+
+  @Test
+  @DisplayName(
+      "Rich amendment with REQUESTED and FSP changes: all indicators true, changes preserved")
+  void richAmendment_requestedAndFspChanges_allIndicatorsTrue() {
+    UUID amendmentId = Uuid7.timeBasedUuid();
+    // A provider-requested field change plus FSP consequences: a total change and an escape
+    // transition. Repricing ran, price changed, and the escape transition is logged.
+    persistAmendment(
+        amendmentId,
+        "{\"schema_version\":1,\"changes\":["
+            + "{\"field_identifier\":\"claim.netProfitCostsAmount\",\"change_source\":\"Requested\","
+            + "\"before\":\"100.00\",\"after\":\"150.00\"},"
+            + "{\"field_identifier\":\"fee.totalAmount\",\"change_source\":\"FSP\","
+            + "\"before\":\"100.00\",\"after\":\"180.00\"},"
+            + "{\"field_identifier\":\"fee.escapeCaseFlag\",\"change_source\":\"FSP\","
+            + "\"before\":false,\"after\":true}]}");
+    linkCalculatedFeeDetail(amendmentId, true, true);
+
+    ClaimHistoryEventRow event = findAmendmentEvent(amendmentId);
+
+    assertThat(event.metadata().get("pricing_recalculated").asBoolean()).isTrue();
+    assertThat(event.metadata().get("price_changed").asBoolean()).isTrue();
+    assertThat(event.metadata().get("escape_case_logged").asBoolean()).isTrue();
+    assertThat(event.metadata().get("changes")).hasSize(3);
+  }
+
+  private static String emptyDiff() {
+    return "{\"schema_version\":1,\"changes\":[]}";
+  }
+
+  @Test
+  @DisplayName("A claim with no amendment rows produces no AMENDMENT event (failed amendments)")
+  void noAmendmentRows_produceNoAmendmentEvent() {
+    // A failed amendment never persists a claim_amendment row, so no AMENDMENT event can appear.
+    List<ClaimHistoryEventRow> events = claimHistoryRepository.findHistory(CLAIM_1_ID, 50);
+
+    assertThat(events).extracting(ClaimHistoryEventRow::eventType).doesNotContain("AMENDMENT");
+  }
+
+  private static String escapeDiff(boolean before, boolean after) {
+    return "{\"schema_version\":1,\"changes\":[{\"field_identifier\":\"fee.escapeCaseFlag\","
+        + "\"change_source\":\"FSP\",\"before\":"
+        + before
+        + ",\"after\":"
+        + after
+        + "}]}";
+  }
+
+  private ClaimAmendment persistAmendment(UUID id, String diffJson) {
+    ClaimAmendment amendment =
+        ClaimAmendment.builder()
+            .id(id)
+            .claim(claimRepository.getReferenceById(CLAIM_1_ID))
+            .requestedByCode("PROVIDER")
+            .amendmentReasonCode("PROVIDER_ERROR")
+            .beforeState("{}")
+            .requestPayload("{}")
+            .diff(diffJson)
+            .createdByUserId(USER_ID)
+            .createdOn(OffsetDateTime.now())
+            .build();
+    claimAmendmentRepository.save(amendment);
+    claimAmendmentRepository.flush();
+    return amendment;
+  }
+
+  private void linkCalculatedFeeDetail(UUID amendmentId, boolean priceChanged, boolean escapeFlag) {
+    CalculatedFeeDetail fee =
+        CalculatedFeeDetail.builder()
+            .id(Uuid7.timeBasedUuid())
+            .claim(claimRepository.getReferenceById(CLAIM_1_ID))
+            .claimSummaryFee(claimSummaryFeeRepository.getReferenceById(CLAIM_1_SUMMARY_FEE_ID))
+            .claimAmendment(claimAmendmentRepository.getReferenceById(amendmentId))
+            .isPriceChanged(priceChanged)
+            .escapeCaseFlag(escapeFlag)
+            .totalAmount(new BigDecimal("120.00"))
+            .createdByUserId(USER_ID)
+            .createdOn(OffsetDateTime.now())
+            .build();
+    calculatedFeeDetailRepository.save(fee);
+    calculatedFeeDetailRepository.flush();
+  }
+
+  private ClaimHistoryEventRow findAmendmentEvent(UUID amendmentId) {
+    return claimHistoryRepository.findHistory(CLAIM_1_ID, 50).stream()
+        .filter(event -> amendmentId.equals(event.sourceId()))
+        .findFirst()
+        .orElseThrow();
   }
 
   private ClaimHistoryEventRow findAssessmentEvent(UUID assessmentId) {

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/JdbcClaimHistoryRepository.java
@@ -43,9 +43,23 @@ public class JdbcClaimHistoryRepository implements ClaimHistoryRepository {
    * assessment_type = 'VOID'} are surfaced as a {@code VOID} event carrying only {@code
    * assessment_type} and {@code assessment_reason}; all other assessments become {@code ASSESSMENT}
    * events carrying {@code assessment_type}, {@code assessment_outcome} and {@code
-   * assessment_reason}. Amendment events expose the requester and reason, pricing/escape flags
-   * derived from the linked {@code calculated_fee_detail}, and the field-level {@code changes}
-   * array lifted from the amendment {@code diff} document.
+   * assessment_reason}. Amendment events expose the requester and reason, {@code
+   * pricing_recalculated} / {@code price_changed} derived from the linked {@code
+   * calculated_fee_detail}, and {@code escape_case_logged} derived from the amendment {@code diff}
+   * (an {@code FSP}-sourced {@code fee.escapeCaseFlag} entry whose {@code after} is {@code true} —
+   * i.e. this amendment <em>caused</em> the escape transition, not merely that the resulting fee is
+   * an escape case). The field-level {@code changes} array is lifted from the same {@code diff}
+   * document.
+   *
+   * <p><b>Escape transition (DSTEW-1815).</b> {@code escape_case_logged} is intentionally derived
+   * from the persisted amendment {@code diff} rather than {@code
+   * calculated_fee_detail.escape_case_flag}. The change detector only records a {@code
+   * fee.escapeCaseFlag} diff entry when the value actually changed, so a {@code false -> true} flip
+   * yields {@code after = true} (transition), whereas an already-escaped claim ({@code true ->
+   * true}) produces no entry and correctly yields {@code false}. Caveat: if an amendment has no
+   * prior fee snapshot (no {@code FSP} diff entries at all) the transition cannot be proven from
+   * the diff and this resolves to {@code false}; a valid claim always carries a summary fee record,
+   * so the persisted data remains the source of truth for later audit.
    */
   private static final String HISTORY_SQL =
       """
@@ -79,7 +93,13 @@ public class JdbcClaimHistoryRepository implements ClaimHistoryRepository {
                   'amendment_reason_code', am.amendment_reason_code,
                   'pricing_recalculated', (cfd.id IS NOT NULL),
                   'price_changed',        COALESCE(cfd.is_price_changed, false),
-                  'escape_case_logged',   COALESCE(cfd.escape_case_flag, false),
+                  'escape_case_logged',   EXISTS (
+                      SELECT 1
+                      FROM jsonb_array_elements(COALESCE(am.diff -> 'changes', '[]'::jsonb)) AS ch
+                      WHERE ch ->> 'field_identifier' = 'fee.escapeCaseFlag'
+                        AND ch ->> 'change_source'    = 'FSP'
+                        AND ch ->> 'after'            = 'true'
+                  ),
                   'changes',              COALESCE(am.diff -> 'changes', '[]'::jsonb)
               )                                  AS metadata
           FROM claims.claim_amendment am

--- a/docs/claim-history-timeline-poc.md
+++ b/docs/claim-history-timeline-poc.md
@@ -98,7 +98,13 @@ FROM (
             'amendment_reason_code', am.amendment_reason_code,
             'pricing_recalculated',  (cfd.id IS NOT NULL),
             'price_changed',         COALESCE(cfd.is_price_changed, false),
-            'escape_case_logged',    COALESCE(cfd.escape_case_flag, false),
+            'escape_case_logged',    EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(COALESCE(am.diff -> 'changes', '[]'::jsonb)) AS ch
+                WHERE ch ->> 'field_identifier' = 'fee.escapeCaseFlag'
+                  AND ch ->> 'change_source'    = 'FSP'
+                  AND ch ->> 'after'            = 'true'
+            ),
             'changes',               COALESCE(am.diff -> 'changes', '[]'::jsonb)
         )                                        AS metadata
     FROM claims.claim_amendment am
@@ -140,8 +146,12 @@ Key properties:
 - A **void** assessment (`assessment_type = 'VOID'`) is surfaced as a distinct `VOID` event whose
   metadata contains only `assessment_type` and `assessment_reason`; all other assessments become
   `ASSESSMENT` events carrying `assessment_type`, `assessment_outcome` and `assessment_reason`.
-- Amendment events expose the requester and reason, pricing/escape flags derived from the linked
-  `calculated_fee_detail`, and the field-level `changes` array lifted from the amendment `diff`
+- Amendment events expose the requester and reason, `pricing_recalculated` / `price_changed`
+  derived from the linked `calculated_fee_detail`, and `escape_case_logged` derived from the
+  amendment `diff` — an FSP-sourced `fee.escapeCaseFlag` entry whose `after` is `true`, i.e. this
+  amendment **caused** the escape transition (`false -> true`) rather than the resulting fee simply
+  being an escape case. An already-escaped claim (`true -> true`) records no such diff entry and so
+  correctly yields `false`. The field-level `changes` array is lifted from the same `diff`
   document (`diff -> 'changes'`) as nested jsonb (not stringified).
 - Only `LIMIT` is used — **no `OFFSET`**.
 
@@ -190,9 +200,9 @@ AMENDMENT    2026-07-09T10:10:00Z  u-4410    018f...c2           { "requested_by
                                                                    "pricing_recalculated": true,
                                                                    "price_changed": false,
                                                                    "escape_case_logged": false,
-                                                                   "changes": [ { "field_identifier": "net_profit_costs_amount",
-                                                                                  "before": "100.00", "after": "120.00",
-                                                                                  "change_source": "REQUESTED" } ] }
+                                                                    "changes": [ { "field_identifier": "net_profit_costs_amount",
+                                                                                   "before": "100.00", "after": "120.00",
+                                                                                   "change_source": "REQUESTED" } ] }
 ASSESSMENT   2026-07-09T10:05:00Z  SYSTEM    018f...a7           { "assessment_type": "ESCAPE_CASE_ASSESSMENT",
                                                                    "assessment_outcome": "PAID_IN_FULL",
                                                                    "assessment_reason": "Escape Fee Case Assessment" }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1815)

DSTEW-1815 requires the Claim History Timeline API to expose, per amendment, whether FSP
repricing ran, whether it changed monetary values, and whether the amendment caused the
claim to become an escape case - all derived from amendment-linked persisted data, never
inferred from current claim state.

The read-side already exposed `pricing_recalculated` and `price_changed` correctly. The
main correction here is `escape_case_logged`, which previously reflected the fee's escape
*state* rather than whether *this amendment caused the escape transition*.

## Changes

- **Escape-correction (`JdbcClaimHistoryRepository`)** - `escape_case_logged` is now derived
  from the persisted amendment `diff`: an FSP-sourced `fee.escapeCaseFlag` entry whose
  `after` is `true` (a genuine `false → true` transition). An already-escaped claim
  (`true → true`) records no diff entry and correctly yields `false`. `pricing_recalculated`
  and `price_changed` are unchanged.
- **Contract formalisation (`open-api-specification.yml`)** - added documented, additive
  (non-breaking) per-event-type metadata schemas (`claim_history_submission_metadata`,
  `claim_history_amendment_metadata`, `claim_history_assessment_metadata`,
  `claim_history_void_metadata`, `claim_history_change_entry`). `metadata` stays open for
  forward-compatibility.
- **Tests (`JdbcClaimHistoryRepositoryIntegrationTest`)** — added full AMENDMENT-branch
  coverage: every valid combination of `pricing_recalculated` / `price_changed` /
  `escape_case_logged`, escape transition vs. state vs. de-escalation, per-amendment
  independence across multiple amendments (escape flip-flop, price changed/unchanged mix),
  provider-requested (non-FSP) changes, a rich all-indicators-true case, and the
  no-amendment/failed-amendment path.

## Notes

- No write-side changes: the escape transition and `is_price_changed` are already persisted
  correctly at amendment time (`FeeSchemeHandoffFactory`, `AmendmentChangeDetector`).

## Testing

- `JdbcClaimHistoryRepositoryIntegrationTest`: 21/21 pass (real Postgres via Testcontainers).
- ClaimHistory unit tests: 16/16 pass. Full module build green (incl. OpenAPI regeneration).

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
