### PR TITLE
feat(DSTEW-1644): submission totals recalculation

### DIFF
--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AbstractIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AbstractIntegrationTest.java
@@ -34,6 +34,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
@@ -992,5 +993,60 @@ public abstract class AbstractIntegrationTest {
     // Attach it to the logger
     logger.addAppender(listAppender);
     return listAppender;
+  }
+
+  // --- Helper Methods specifically for Submissions Totals testing ---
+
+  protected Submission createIsolatedSubmission() {
+    Submission submission =
+        Submission.builder()
+            .id(Uuid7.timeBasedUuid())
+            .officeAccountNumber("totals-office")
+            .status(SubmissionStatus.CREATED)
+            .submissionPeriod("JAN-2025")
+            .areaOfLaw(AreaOfLaw.LEGAL_HELP)
+            .createdByUserId(USER_ID)
+            .providerUserId(USER_ID)
+            .createdOn(Instant.now())
+            .build();
+    return submissionRepository.saveAndFlush(submission);
+  }
+
+  protected Claim createClaimForSubmission(Submission submission) {
+    Claim claim =
+        Claim.builder()
+            .id(Uuid7.timeBasedUuid())
+            .submission(submission)
+            .status(ClaimStatus.VALID)
+            .feeCode("TEST")
+            .lineNumber(1)
+            .matterTypeCode("TEST_MATTER")
+            .createdByUserId(USER_ID)
+            .build();
+    claim = claimRepository.saveAndFlush(claim);
+
+    ClaimSummaryFee summaryFee =
+        ClaimSummaryFee.builder()
+            .id(Uuid7.timeBasedUuid())
+            .claim(claim)
+            .createdByUserId(USER_ID)
+            .build();
+    claimSummaryFeeRepository.saveAndFlush(summaryFee);
+
+    return claim;
+  }
+
+  protected void createFeeDetail(
+      Claim claim, BigDecimal amount, OffsetDateTime createdOn, UUID forceId) {
+    UUID idToUse = forceId != null ? forceId : Uuid7.timeBasedUuid();
+    calculatedFeeDetailRepository.saveAndFlush(
+        CalculatedFeeDetail.builder()
+            .id(idToUse)
+            .claim(claim)
+            .claimSummaryFee(claimSummaryFeeRepository.findByClaimId(claim.getId()).orElseThrow())
+            .totalAmount(amount)
+            .createdOn(createdOn)
+            .createdByUserId(USER_ID)
+            .build());
   }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/SubmissionControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/SubmissionControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.dstew.payments.claimsdata.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -22,7 +23,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
@@ -41,11 +45,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
 import software.amazon.awssdk.services.sns.model.SubscribeRequest;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.*;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Submission;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ValidationMessageLog;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
@@ -60,7 +66,6 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.ValidationMessagePatch
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ValidationMessageType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.BulkSubmissionRepository;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimRepository;
-import uk.gov.justice.laa.dstew.payments.claimsdata.repository.MatterStartRepository;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.SubmissionRepository;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ValidationMessageLogRepository;
 import uk.gov.justice.laa.dstew.payments.claimsdata.util.IntegrationTestUtils;
@@ -79,11 +84,11 @@ public class SubmissionControllerIntegrationTest extends AbstractIntegrationTest
 
   @Autowired private ClaimRepository claimRepository;
 
-  @Autowired private MatterStartRepository matterStartRepository;
-
   @Autowired private SqsClient sqsClient;
 
   @Autowired private SnsClient snsClient;
+
+  @Autowired private EntityManager entityManager;
 
   @Value("${aws.sqs.queue-name}")
   private String queueName;
@@ -1331,5 +1336,39 @@ public class SubmissionControllerIntegrationTest extends AbstractIntegrationTest
                 .param(PARAM_SORT, "unknownField,asc")
                 .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @Transactional
+  @DisplayName("Submission JSON contract shape remains unchanged for amended claims")
+  void submissionJsonContractIsUnchangedForAmendedClaims() throws Exception {
+    // Setup an Amended Submission (1 Claim, 2 Fee Rows)
+    Submission amendedSub = createIsolatedSubmission();
+    Claim amendedClaim = createClaimForSubmission(amendedSub);
+    createFeeDetail(
+        amendedClaim, BigDecimal.valueOf(100.00), OffsetDateTime.now().minusDays(1), null);
+    createFeeDetail(amendedClaim, BigDecimal.valueOf(250.00), OffsetDateTime.now(), null);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    mockMvc
+        .perform(
+            get("/api/v1/submissions/{id}", amendedSub.getId())
+                .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+
+        // 1. Prove the calculated total is the ONLY thing reflecting the amendment
+        .andExpect(jsonPath("$.calculated_total_amount").value(250.00))
+
+        // 2. Prove the shape/size of the nested collections is intact
+        .andExpect(jsonPath("$.claims", hasSize(1)))
+        .andExpect(jsonPath("$.claims[0].status").value("VALID"))
+
+        // 3. Prove NO amendment-specific fields were added to the payload shape
+        .andExpect(jsonPath("$.amendment_flags").doesNotExist())
+        .andExpect(jsonPath("$.is_amended").doesNotExist())
+        .andExpect(jsonPath("$.claims[0].claim_amendment_id").doesNotExist());
   }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -692,7 +692,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
               .submissionPeriod("JAN-2025")
               .areaOfLaw(AreaOfLaw.LEGAL_HELP)
               .createdByUserId(USER_ID)
-              .providerUserId(USER_ID) // <-- Add this!
+              .providerUserId(USER_ID)
               .createdOn(Instant.now())
               .build();
       return submissionRepository.saveAndFlush(submission);
@@ -705,8 +705,8 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
               .submission(submission)
               .status(ClaimStatus.VALID)
               .feeCode("TEST")
-              .lineNumber(1) // <-- Add this!
-              .matterTypeCode("TEST_MATTER") // <-- Add this!
+              .lineNumber(1)
+              .matterTypeCode("TEST_MATTER")
               .createdByUserId(USER_ID)
               .build();
       claim = claimRepository.saveAndFlush(claim);

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -728,7 +728,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
               .claimSummaryFee(claimSummaryFeeRepository.findByClaimId(claim.getId()).orElseThrow())
               .totalAmount(amount)
               .createdOn(createdOn)
-              .createdByUserId(USER_ID) // <-- Added to satisfy DB constraint
+              .createdByUserId(USER_ID)
               .build());
     }
   }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -562,7 +562,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
     @Test
     @Transactional
     @DisplayName(
-        "AC1: Given a submission whose claims each have a single calculated-fee row, it sums normally")
+        "Given a submission whose claims each have a single calculated-fee row, it sums normally")
     void singleRowPerClaimSumsNormally() {
       Submission submission = createIsolatedSubmission();
       Claim claim1 = createClaimForSubmission(submission);
@@ -587,7 +587,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
     @Test
     @Transactional
     @DisplayName(
-        "AC2 & AC4: Given a submission with claims that have multiple calculated-fee rows, it sums only the latest row using created_on")
+        "Given a submission with claims that have multiple calculated-fee rows, it sums only the latest row using created_on")
     void multipleRowsPerClaimSumsOnlyLatestByCreatedOn() {
       Submission submission = createIsolatedSubmission();
       Claim claimX = createClaimForSubmission(submission);
@@ -612,7 +612,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
     @Test
     @Transactional
     @DisplayName(
-        "AC3: Given two calculated-fee rows on the same claim have the same created_on, it uses greatest id as the tie-break")
+        "Given two calculated-fee rows on the same claim have the same created_on, it uses greatest id as the tie-break")
     void multipleRowsPerClaimSameCreatedOnTieBreaksById() {
       Submission submission = createIsolatedSubmission();
       Claim claim = createClaimForSubmission(submission);
@@ -638,7 +638,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
     @Test
     @Transactional
     @DisplayName(
-        "Bulk AC: Given multiple submissions, it groups by submission and sums only the latest row per claim")
+        "Bulk Submissions: Given multiple submissions, it groups by submission and sums only the latest row per claim")
     void bulkGetCalculatedTotalAmountsSumsLatestPerSubmission() {
       // Setup Submission 1 with an amended claim
       Submission sub1 = createIsolatedSubmission();

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -12,15 +12,20 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUt
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_STATUSES;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.USER_ID;
 
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -30,14 +35,20 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.BulkSubmission;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.CalculatedFeeDetail;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Submission;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.BulkSubmissionStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetBulkSubmission200ResponseDetails;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionStatus;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.specification.SubmissionSpecification;
+import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 
 /**
  * This contains integration tests to verify the filtering logic implemented in the {@link
@@ -469,7 +480,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
   @DisplayName(
       "submissionPeriodSortKey @Formula converts MON-YYYY period to YYYYMM chronological sort key")
   @Test
-  void submissionPeriodSortKey_producesCorrectYearMonthSortKey() {
+  void submissionPeriodSortKeyProducesCorrectYearMonthSortKey() {
     // Verifies that the @Formula correctly converts e.g. "APR-2025" → "202504",
     // which enables chronological ordering (alphabetical ordering would give wrong results).
     var submission =
@@ -493,7 +504,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
   @DisplayName(
       "submissionPeriodSortKey @Formula causes DataIntegrityViolationException if an invalid month name is in the database")
   @Test
-  void submissionPeriodSortKey_throwsForInvalidMonthName() {
+  void submissionPeriodSortKeyThrowsForInvalidMonthName() {
     // "ABC-2025" matches the expected MON-YYYY shape but "ABC" is not a valid PostgreSQL month
     // abbreviation. TO_DATE('ABC-2025', 'MON-YYYY') raises an error at SELECT time, which Spring
     // wraps as a DataIntegrityViolationException.
@@ -540,5 +551,189 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
             Pageable.ofSize(10).withPage(0));
 
     assertThat(actualResults.getContent()).hasSize(1);
+  }
+
+  @Nested
+  @DisplayName("PDS - Submission Totals Recalculation After Claim Amendments (DSTEW-1659)")
+  class SubmissionTotalsRecalculation {
+
+    @Autowired private EntityManager entityManager;
+
+    @Test
+    @Transactional
+    @DisplayName(
+        "AC1: Given a submission whose claims each have a single calculated-fee row, it sums normally")
+    void singleRowPerClaimSumsNormally() {
+      Submission submission = createIsolatedSubmission();
+      Claim claim1 = createClaimForSubmission(submission);
+      Claim claim2 = createClaimForSubmission(submission);
+      Claim claim3 = createClaimForSubmission(submission);
+
+      createFeeDetail(claim1, BigDecimal.valueOf(100.00), OffsetDateTime.now(), null);
+      createFeeDetail(claim2, BigDecimal.valueOf(200.00), OffsetDateTime.now(), null);
+      createFeeDetail(claim3, BigDecimal.valueOf(50.00), OffsetDateTime.now(), null);
+
+      // Force Hibernate to drop its cache and execute the raw SQL @Formula
+      entityManager.clear();
+      Submission retrieved = submissionRepository.findById(submission.getId()).orElseThrow();
+
+      // Note: Update 'getCalculatedTotalAmount()' if your Submission entity field is named
+      // differently!
+      BigDecimal calculatedTotalAmount =
+          submissionRepository.getCalculatedTotalAmount(retrieved.getId());
+      assertThat(calculatedTotalAmount).isEqualByComparingTo("350.00");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName(
+        "AC2 & AC4: Given a submission with claims that have multiple calculated-fee rows, it sums only the latest row using created_on")
+    void multipleRowsPerClaimSumsOnlyLatestByCreatedOn() {
+      Submission submission = createIsolatedSubmission();
+      Claim claimX = createClaimForSubmission(submission);
+      Claim claimY = createClaimForSubmission(submission);
+
+      // Claim X: Old row = 100.00, Latest row = 125.00
+      createFeeDetail(claimX, BigDecimal.valueOf(100.00), OffsetDateTime.now().minusDays(2), null);
+      createFeeDetail(claimX, BigDecimal.valueOf(125.00), OffsetDateTime.now(), null);
+
+      // Claim Y: Only one row = 200.00
+      createFeeDetail(claimY, BigDecimal.valueOf(200.00), OffsetDateTime.now().minusDays(1), null);
+
+      entityManager.clear();
+      Submission retrieved = submissionRepository.findById(submission.getId()).orElseThrow();
+
+      // Expected: 125.00 (from X's latest) + 200.00 (from Y) = 325.00
+      BigDecimal calculatedTotalAmount =
+          submissionRepository.getCalculatedTotalAmount(retrieved.getId());
+      assertThat(calculatedTotalAmount).isEqualByComparingTo("325.00");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName(
+        "AC3: Given two calculated-fee rows on the same claim have the same created_on, it uses greatest id as the tie-break")
+    void multipleRowsPerClaimSameCreatedOnTieBreaksById() {
+      Submission submission = createIsolatedSubmission();
+      Claim claim = createClaimForSubmission(submission);
+
+      OffsetDateTime exactSameTime = OffsetDateTime.now();
+
+      // Hardcode UUIDs to deterministically guarantee which ID is the "greatest"
+      UUID lowerId = UUID.fromString("01900000-0000-7000-8000-000000000001");
+      UUID greaterId = UUID.fromString("01900000-0000-7000-8000-000000000002");
+
+      createFeeDetail(claim, BigDecimal.valueOf(100.00), exactSameTime, lowerId);
+      createFeeDetail(claim, BigDecimal.valueOf(999.00), exactSameTime, greaterId);
+
+      entityManager.clear();
+      Submission retrieved = submissionRepository.findById(submission.getId()).orElseThrow();
+
+      // Expected: 999.00 because greaterId wins the tie-break
+      BigDecimal calculatedTotalAmount =
+          submissionRepository.getCalculatedTotalAmount(retrieved.getId());
+      assertThat(calculatedTotalAmount).isEqualByComparingTo("999.00");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName(
+        "Bulk AC: Given multiple submissions, it groups by submission and sums only the latest row per claim")
+    void bulkGetCalculatedTotalAmountsSumsLatestPerSubmission() {
+      // Setup Submission 1 with an amended claim
+      Submission sub1 = createIsolatedSubmission();
+      Claim sub1Claim = createClaimForSubmission(sub1);
+      createFeeDetail(
+          sub1Claim, BigDecimal.valueOf(100.00), OffsetDateTime.now().minusDays(1), null);
+      createFeeDetail(
+          sub1Claim, BigDecimal.valueOf(150.00), OffsetDateTime.now(), null); // Latest for Sub 1
+
+      // Setup Submission 2 with an amended claim
+      Submission sub2 = createIsolatedSubmission();
+      Claim sub2Claim = createClaimForSubmission(sub2);
+      createFeeDetail(
+          sub2Claim, BigDecimal.valueOf(300.00), OffsetDateTime.now().minusDays(1), null);
+      createFeeDetail(
+          sub2Claim, BigDecimal.valueOf(450.00), OffsetDateTime.now(), null); // Latest for Sub 2
+
+      // Force DB execution
+      entityManager.clear();
+
+      // Act
+      List<SubmissionRepository.CalculatedTotalAmountProjection> results =
+          submissionRepository.getCalculatedTotalAmounts(List.of(sub1.getId(), sub2.getId()));
+
+      // Assert
+      assertThat(results).hasSize(2);
+
+      SubmissionRepository.CalculatedTotalAmountProjection result1 =
+          results.stream()
+              .filter(r -> r.getSubmissionId().equals(sub1.getId()))
+              .findFirst()
+              .orElseThrow();
+      assertThat(result1.getTotal()).isEqualByComparingTo("150.00");
+
+      SubmissionRepository.CalculatedTotalAmountProjection result2 =
+          results.stream()
+              .filter(r -> r.getSubmissionId().equals(sub2.getId()))
+              .findFirst()
+              .orElseThrow();
+      assertThat(result2.getTotal()).isEqualByComparingTo("450.00");
+    }
+
+    // --- Helper Methods specifically for Totals testing ---
+
+    private Submission createIsolatedSubmission() {
+      Submission submission =
+          Submission.builder()
+              .id(Uuid7.timeBasedUuid())
+              .officeAccountNumber("totals-office")
+              .status(SubmissionStatus.CREATED)
+              .submissionPeriod("JAN-2025")
+              .areaOfLaw(AreaOfLaw.LEGAL_HELP)
+              .createdByUserId(USER_ID)
+              .providerUserId(USER_ID) // <-- Add this!
+              .createdOn(Instant.now())
+              .build();
+      return submissionRepository.saveAndFlush(submission);
+    }
+
+    private Claim createClaimForSubmission(Submission submission) {
+      Claim claim =
+          Claim.builder()
+              .id(Uuid7.timeBasedUuid())
+              .submission(submission)
+              .status(ClaimStatus.VALID)
+              .feeCode("TEST")
+              .lineNumber(1) // <-- Add this!
+              .matterTypeCode("TEST_MATTER") // <-- Add this!
+              .createdByUserId(USER_ID)
+              .build();
+      claim = claimRepository.saveAndFlush(claim);
+
+      ClaimSummaryFee summaryFee =
+          ClaimSummaryFee.builder()
+              .id(Uuid7.timeBasedUuid())
+              .claim(claim)
+              .createdByUserId(USER_ID)
+              .build();
+      claimSummaryFeeRepository.saveAndFlush(summaryFee);
+
+      return claim;
+    }
+
+    private void createFeeDetail(
+        Claim claim, BigDecimal amount, OffsetDateTime createdOn, UUID forceId) {
+      UUID idToUse = forceId != null ? forceId : Uuid7.timeBasedUuid();
+      calculatedFeeDetailRepository.saveAndFlush(
+          CalculatedFeeDetail.builder()
+              .id(idToUse)
+              .claim(claim)
+              .claimSummaryFee(claimSummaryFeeRepository.findByClaimId(claim.getId()).orElseThrow())
+              .totalAmount(amount)
+              .createdOn(createdOn)
+              .createdByUserId(USER_ID) // <-- Added to satisfy DB constraint
+              .build());
+    }
   }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -573,14 +573,10 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
       createFeeDetail(claim2, BigDecimal.valueOf(200.00), OffsetDateTime.now(), null);
       createFeeDetail(claim3, BigDecimal.valueOf(50.00), OffsetDateTime.now(), null);
 
-      // Force Hibernate to drop its cache and execute the raw SQL @Formula
       entityManager.clear();
-      Submission retrieved = submissionRepository.findById(submission.getId()).orElseThrow();
 
-      // Note: Update 'getCalculatedTotalAmount()' if your Submission entity field is named
-      // differently!
       BigDecimal calculatedTotalAmount =
-          submissionRepository.getCalculatedTotalAmount(retrieved.getId());
+          submissionRepository.getCalculatedTotalAmount(submission.getId());
       assertThat(calculatedTotalAmount).isEqualByComparingTo("350.00");
     }
 

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -554,7 +554,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
   }
 
   @Nested
-  @DisplayName("PDS - Submission Totals Recalculation After Claim Amendments (DSTEW-1659)")
+  @DisplayName("PDS - Submission Totals Recalculation After Claim Amendments (DSTEW-1644)")
   class SubmissionTotalsRecalculation {
 
     @Autowired private EntityManager entityManager;

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -555,8 +555,10 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
   @DisplayName("PDS - Submission Totals Recalculation After Claim Amendments (DSTEW-1644)")
   class SubmissionTotalsRecalculation {
 
-    @Autowired private EntityManager entityManager;
-    @Autowired private SubmissionService submissionService;
+    @Autowired
+    private EntityManager entityManager;
+    @Autowired
+    private SubmissionService submissionService;
 
     @Test
     @Transactional
@@ -714,7 +716,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
               "submitted", // Ignore millisecond creation differences
               "claims.claimId", // Ignore nested Claim IDs
               "calculatedTotalAmount" // The ONLY field allowed to differ
-              )
+          )
           .isEqualTo(classicResponse);
 
       // Explicitly prove the one-to-many join didn't duplicate the claim in the array
@@ -762,6 +764,79 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
       // Note: The SubmissionService handles this empty list by omitting the ID from the map,
       // which ultimately maps to a null total in the response DTO.
       assertThat(totals).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Single Query: Returns null when a submission has a fee detail but its total is null")
+    void getCalculatedTotalAmountReturnsNullWhenFeeDetailTotalIsNull() {
+      // 1. Setup Submission with a Claim
+      Submission submission = createIsolatedSubmission();
+      Claim claim = createClaimForSubmission(submission);
+
+      // 2. Create a fee detail row, but explicitly set the amount to null
+      createFeeDetail(claim, null, OffsetDateTime.now(), null);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // 3. Execute the SQL query
+      BigDecimal totalAmount = submissionRepository.getCalculatedTotalAmount(submission.getId());
+
+      // 4. Assert it evaluates to null (SUM of only NULLs evaluates to NULL)
+      assertThat(totalAmount).isNull();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Single Query: Sums correctly when multiple claims exist and one has a null fee detail total")
+    void getCalculatedTotalAmountSumsCorrectlyWhenOneFeeDetailIsNull() {
+      // 1. Setup Submission
+      Submission submission = createIsolatedSubmission();
+
+      // 2. Claim 1 with a valid total (e.g., 100.00)
+      Claim claim1 = createClaimForSubmission(submission);
+      createFeeDetail(claim1, BigDecimal.valueOf(100.00), OffsetDateTime.now(), null);
+
+      // 3. Claim 2 with a NULL total
+      Claim claim2 = createClaimForSubmission(submission);
+      createFeeDetail(claim2, null, OffsetDateTime.now(), null);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // 4. Execute the SQL query
+      BigDecimal totalAmount = submissionRepository.getCalculatedTotalAmount(submission.getId());
+
+      // 5. Assert it ignores the NULL and sums the rest correctly
+      assertThat(totalAmount).isEqualByComparingTo("100.00");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Bulk Query: Sums correctly for a submission when one of its claims has a null fee detail total")
+    void getCalculatedTotalAmountsSumsCorrectlyWhenOneFeeDetailIsNull() {
+      // 1. Setup Submission
+      Submission submission = createIsolatedSubmission();
+
+      // 2. Claim 1 with a valid total
+      Claim claim1 = createClaimForSubmission(submission);
+      createFeeDetail(claim1, BigDecimal.valueOf(100.00), OffsetDateTime.now(), null);
+
+      // 3. Claim 2 with a NULL total
+      Claim claim2 = createClaimForSubmission(submission);
+      createFeeDetail(claim2, null, OffsetDateTime.now(), null);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // 4. Execute the bulk SQL query
+      var totals = submissionRepository.getCalculatedTotalAmounts(List.of(submission.getId()));
+
+      // 5. Assert the list contains the submission and sums the valid rows, ignoring the null
+      assertThat(totals).hasSize(1);
+      assertThat(totals.get(0).getSubmissionId()).isEqualTo(submission.getId());
+      assertThat(totals.get(0).getTotal()).isEqualByComparingTo("100.00");
     }
   }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -723,5 +723,45 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
       // Explicitly prove the one-to-many join didn't duplicate the claim in the array
       assertThat(amendedResponse.getClaims()).hasSize(1);
     }
+
+    @Test
+    @Transactional
+    @DisplayName(
+        "Single Query: Returns null when a submission has claims but no calculated fee detail rows")
+    void getCalculatedTotalAmountReturnsNullWhenNoFeeDetails() {
+      // 1. Setup Submission with a Claim, but DO NOT create any CalculatedFeeDetail rows
+      Submission submission = createIsolatedSubmission();
+      createClaimForSubmission(submission);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // 2. Execute the single SQL query
+      BigDecimal totalAmount = submissionRepository.getCalculatedTotalAmount(submission.getId());
+
+      // 3. Assert it naturally evaluates to null
+      assertThat(totalAmount).isNull();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName(
+        "Bulk Query: Omits submission (yielding an empty list) when it has claims but no calculated fee detail rows")
+    void getCalculatedTotalAmountsOmitsSubmissionWhenNoFeeDetails() {
+      // 1. Setup Submission with a Claim, but DO NOT create any CalculatedFeeDetail rows
+      Submission submission = createIsolatedSubmission();
+      createClaimForSubmission(submission);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // 2. Execute the bulk SQL query
+      var totals = submissionRepository.getCalculatedTotalAmounts(List.of(submission.getId()));
+
+      // 3. Assert the list is empty (because the INNER JOIN drops claims without fee details)
+      // Note: The SubmissionService handles this empty list by omitting the ID from the map,
+      // which ultimately maps to a null total in the response DTO.
+      assertThat(totals).isEmpty();
+    }
   }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -38,17 +38,15 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.dstew.payments.claimsdata.controller.AbstractIntegrationTest;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.BulkSubmission;
-import uk.gov.justice.laa.dstew.payments.claimsdata.entity.CalculatedFeeDetail;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
-import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Submission;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.BulkSubmissionStatus;
-import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetBulkSubmission200ResponseDetails;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionResponse;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionStatus;
 import uk.gov.justice.laa.dstew.payments.claimsdata.repository.specification.SubmissionSpecification;
-import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
+import uk.gov.justice.laa.dstew.payments.claimsdata.service.SubmissionService;
 
 /**
  * This contains integration tests to verify the filtering logic implemented in the {@link
@@ -558,6 +556,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
   class SubmissionTotalsRecalculation {
 
     @Autowired private EntityManager entityManager;
+    @Autowired private SubmissionService submissionService;
 
     @Test
     @Transactional
@@ -677,59 +676,52 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
       assertThat(result2.getTotal()).isEqualByComparingTo("450.00");
     }
 
-    // --- Helper Methods specifically for Totals testing ---
+    @Test
+    @Transactional
+    @DisplayName(
+        "Response shape is unchanged and only calculated-total differs for multi-row claims")
+    void responseShapeIsUnchangedOnlyTotalDiffers() {
+      // 1. Setup Classic Submission (1 Claim, 1 Fee Row)
+      Submission classicSub = createIsolatedSubmission();
+      Claim classicClaim = createClaimForSubmission(classicSub);
+      createFeeDetail(classicClaim, BigDecimal.valueOf(100.00), OffsetDateTime.now(), null);
 
-    private Submission createIsolatedSubmission() {
-      Submission submission =
-          Submission.builder()
-              .id(Uuid7.timeBasedUuid())
-              .officeAccountNumber("totals-office")
-              .status(SubmissionStatus.CREATED)
-              .submissionPeriod("JAN-2025")
-              .areaOfLaw(AreaOfLaw.LEGAL_HELP)
-              .createdByUserId(USER_ID)
-              .providerUserId(USER_ID)
-              .createdOn(Instant.now())
-              .build();
-      return submissionRepository.saveAndFlush(submission);
-    }
+      // 2. Setup Amended Submission (1 Claim, 2 Fee Rows)
+      Submission amendedSub = createIsolatedSubmission();
+      Claim amendedClaim = createClaimForSubmission(amendedSub);
+      createFeeDetail(
+          amendedClaim, BigDecimal.valueOf(100.00), OffsetDateTime.now().minusDays(1), null);
+      createFeeDetail(
+          amendedClaim, BigDecimal.valueOf(250.00), OffsetDateTime.now(), null); // Latest
 
-    private Claim createClaimForSubmission(Submission submission) {
-      Claim claim =
-          Claim.builder()
-              .id(Uuid7.timeBasedUuid())
-              .submission(submission)
-              .status(ClaimStatus.VALID)
-              .feeCode("TEST")
-              .lineNumber(1)
-              .matterTypeCode("TEST_MATTER")
-              .createdByUserId(USER_ID)
-              .build();
-      claim = claimRepository.saveAndFlush(claim);
+      entityManager.flush();
+      entityManager.clear();
 
-      ClaimSummaryFee summaryFee =
-          ClaimSummaryFee.builder()
-              .id(Uuid7.timeBasedUuid())
-              .claim(claim)
-              .createdByUserId(USER_ID)
-              .build();
-      claimSummaryFeeRepository.saveAndFlush(summaryFee);
+      // 3. Fetch full responses via the Service
+      SubmissionResponse classicResponse = submissionService.getSubmission(classicSub.getId());
+      SubmissionResponse amendedResponse = submissionService.getSubmission(amendedSub.getId());
 
-      return claim;
-    }
+      // 4. Assert the TOTALS differ exactly as expected
+      assertThat(classicResponse.getCalculatedTotalAmount()).isEqualByComparingTo("100.00");
+      assertThat(amendedResponse.getCalculatedTotalAmount()).isEqualByComparingTo("250.00");
 
-    private void createFeeDetail(
-        Claim claim, BigDecimal amount, OffsetDateTime createdOn, UUID forceId) {
-      UUID idToUse = forceId != null ? forceId : Uuid7.timeBasedUuid();
-      calculatedFeeDetailRepository.saveAndFlush(
-          CalculatedFeeDetail.builder()
-              .id(idToUse)
-              .claim(claim)
-              .claimSummaryFee(claimSummaryFeeRepository.findByClaimId(claim.getId()).orElseThrow())
-              .totalAmount(amount)
-              .createdOn(createdOn)
-              .createdByUserId(USER_ID)
-              .build());
+      // 5. Assert the SHAPE and DATA remain absolutely identical
+      // (proving the extra fee row didn't duplicate the claims list or alter the structure)
+      assertThat(amendedResponse)
+          .usingRecursiveComparison()
+          .ignoringFields(
+              "submissionId", // Ignore root ID
+              "submitted", // Ignore millisecond creation differences
+              "claims.claimId", // Ignore nested Claim IDs
+              "calculatedTotalAmount" // The ONLY field allowed to differ
+              )
+          .isEqualTo(classicResponse);
+
+      // Explicitly prove the one-to-many join didn't duplicate the claim in the array
+      assertThat(amendedResponse.getClaims()).hasSize(1);
+
+      // Explicitly prove the one-to-many join didn't duplicate the claim in the array
+      assertThat(amendedResponse.getClaims()).hasSize(1);
     }
   }
 }

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepositoryIntegrationTest.java
@@ -555,10 +555,8 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
   @DisplayName("PDS - Submission Totals Recalculation After Claim Amendments (DSTEW-1644)")
   class SubmissionTotalsRecalculation {
 
-    @Autowired
-    private EntityManager entityManager;
-    @Autowired
-    private SubmissionService submissionService;
+    @Autowired private EntityManager entityManager;
+    @Autowired private SubmissionService submissionService;
 
     @Test
     @Transactional
@@ -716,7 +714,7 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
               "submitted", // Ignore millisecond creation differences
               "claims.claimId", // Ignore nested Claim IDs
               "calculatedTotalAmount" // The ONLY field allowed to differ
-          )
+              )
           .isEqualTo(classicResponse);
 
       // Explicitly prove the one-to-many join didn't duplicate the claim in the array
@@ -768,7 +766,8 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
 
     @Test
     @Transactional
-    @DisplayName("Single Query: Returns null when a submission has a fee detail but its total is null")
+    @DisplayName(
+        "Single Query: Returns null when a submission has a fee detail but its total is null")
     void getCalculatedTotalAmountReturnsNullWhenFeeDetailTotalIsNull() {
       // 1. Setup Submission with a Claim
       Submission submission = createIsolatedSubmission();
@@ -789,7 +788,8 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
 
     @Test
     @Transactional
-    @DisplayName("Single Query: Sums correctly when multiple claims exist and one has a null fee detail total")
+    @DisplayName(
+        "Single Query: Sums correctly when multiple claims exist and one has a null fee detail total")
     void getCalculatedTotalAmountSumsCorrectlyWhenOneFeeDetailIsNull() {
       // 1. Setup Submission
       Submission submission = createIsolatedSubmission();
@@ -814,7 +814,8 @@ public class SubmissionRepositoryIntegrationTest extends AbstractIntegrationTest
 
     @Test
     @Transactional
-    @DisplayName("Bulk Query: Sums correctly for a submission when one of its claims has a null fee detail total")
+    @DisplayName(
+        "Bulk Query: Sums correctly for a submission when one of its claims has a null fee detail total")
     void getCalculatedTotalAmountsSumsCorrectlyWhenOneFeeDetailIsNull() {
       // 1. Setup Submission
       Submission submission = createIsolatedSubmission();

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
@@ -41,7 +41,7 @@ public interface SubmissionRepository
   @Query(
       value =
           """
-          SELECT COALESCE(SUM(latest_fees.total_amount), 0)
+          SELECT SUM(latest_fees.total_amount)
           FROM (
             SELECT cfd.total_amount,
                    ROW_NUMBER() OVER (PARTITION BY cfd.claim_id ORDER BY cfd.created_on DESC, cfd.id DESC) as rn

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
@@ -57,9 +57,9 @@ public interface SubmissionRepository
   /**
    * Returns calculated total amounts for the given submissions.
    *
-   * <p>For each submission ID provided, this query returns the sum of {@code
-   * calculatedTotalInclVat} from the latest cfd record for each claim belonging to that submission.
-   * Results are grouped by submission ID.
+   * <p>For each submission ID provided, this query returns the sum of {@code totalAmount} from the
+   * latest cfd record for each claim belonging to that submission. Results are grouped by
+   * submission ID.
    *
    * <p>Submissions with no cfd records are not included in the returned list.
    *

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
@@ -33,6 +33,15 @@ public interface SubmissionRepository
     /**
      * Returns the Calculated total amount for the submission.
      *
+     * <p>This aggregation guarantees the following behavior:
+     *
+     * <ul>
+     *   <li>DSTEW-1538 - Must use scaleNullable
+     *   <li>Returns {@code null} if there are no CFD rows associated with the submission.
+     *   <li>Returns {@code 0} (Zero) if CFD rows exist but their combined sum is exactly zero.
+     *   <li>Returns the exact summed total of the latest CFD rows for all other scenarios.
+     * </ul>
+     *
      * @return the summed Calculated total amount
      */
     BigDecimal getTotal();
@@ -70,7 +79,7 @@ public interface SubmissionRepository
       value =
           """
           SELECT latest_fees.submission_id AS submissionId,
-                 COALESCE(SUM(latest_fees.total_amount), 0) AS total
+                 SUM(latest_fees.total_amount) AS total
           FROM (
             SELECT c.submission_id,
                    cfd.total_amount,

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
@@ -19,7 +19,7 @@ public interface SubmissionRepository
    * Projection for Calculated total amounts grouped by submission.
    *
    * <p>Used by {@link #getCalculatedTotalAmounts(List)} to return the Calculated total amount for
-   * each submission without loading full entity data.
+   * each submission without loading full entity data. Only uses latest CFD per claim.
    */
   interface CalculatedTotalAmountProjection {
 
@@ -58,7 +58,7 @@ public interface SubmissionRepository
    * Returns calculated total amounts for the given submissions.
    *
    * <p>For each submission ID provided, this query returns the sum of {@code
-   * calculatedTotalInclVat} from the cfd record for each claim belonging to that submission.
+   * calculatedTotalInclVat} from the latest cfd record for each claim belonging to that submission.
    * Results are grouped by submission ID.
    *
    * <p>Submissions with no cfd records are not included in the returned list.

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
@@ -39,12 +39,19 @@ public interface SubmissionRepository
   }
 
   @Query(
-      """
-        SELECT SUM(cfd.totalAmount)
-        FROM Claim c
-        JOIN CalculatedFeeDetail cfd ON cfd.claim = c
-        WHERE c.submission.id = :submissionId
-      """)
+      value =
+          """
+          SELECT COALESCE(SUM(latest_fees.total_amount), 0)
+          FROM (
+            SELECT cfd.total_amount,
+                   ROW_NUMBER() OVER (PARTITION BY cfd.claim_id ORDER BY cfd.created_on DESC, cfd.id DESC) as rn
+            FROM claims.calculated_fee_detail cfd
+            INNER JOIN claims.claim c ON c.id = cfd.claim_id
+            WHERE c.submission_id = :submissionId
+          ) latest_fees
+          WHERE latest_fees.rn = 1
+          """,
+      nativeQuery = true)
   BigDecimal getCalculatedTotalAmount(@Param("submissionId") UUID submissionId);
 
   /**
@@ -60,13 +67,22 @@ public interface SubmissionRepository
    * @return a list of projections containing submission IDs and their calculated total amounts
    */
   @Query(
-      """
-       SELECT c.submission.id AS submissionId, SUM(cfd.totalAmount) AS total
-       FROM Claim c
-       JOIN CalculatedFeeDetail cfd ON cfd.claim = c
-       WHERE c.submission.id IN :submissionIds
-       GROUP BY c.submission.id
-      """)
+      value =
+          """
+          SELECT latest_fees.submission_id AS submissionId,
+                 COALESCE(SUM(latest_fees.total_amount), 0) AS total
+          FROM (
+            SELECT c.submission_id,
+                   cfd.total_amount,
+                   ROW_NUMBER() OVER (PARTITION BY cfd.claim_id ORDER BY cfd.created_on DESC, cfd.id DESC) as rn
+            FROM claims.calculated_fee_detail cfd
+            INNER JOIN claims.claim c ON c.id = cfd.claim_id
+            WHERE c.submission_id IN :submissionIds
+          ) latest_fees
+          WHERE latest_fees.rn = 1
+          GROUP BY latest_fees.submission_id
+          """,
+      nativeQuery = true)
   List<CalculatedTotalAmountProjection> getCalculatedTotalAmounts(
       @Param("submissionIds") List<UUID> submissionIds);
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/SubmissionRepository.java
@@ -77,7 +77,7 @@ public interface SubmissionRepository
                    ROW_NUMBER() OVER (PARTITION BY cfd.claim_id ORDER BY cfd.created_on DESC, cfd.id DESC) as rn
             FROM claims.calculated_fee_detail cfd
             INNER JOIN claims.claim c ON c.id = cfd.claim_id
-            WHERE c.submission_id IN :submissionIds
+            WHERE c.submission_id IN (:submissionIds)
           ) latest_fees
           WHERE latest_fees.rn = 1
           GROUP BY latest_fees.submission_id


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1644)

This PR updates the submission read calculations to ensure submission totals use only the latest calculated_fee_detail row for each claim. This is a critical read-side correctness fix that paves the way for the one-to-many calculated fee detail storage model, preventing the double-counting of original and amended fee rows.

Key Changes
Single Submission Recalculation: Refactored getCalculatedTotalAmount in SubmissionRepository from a standard JPQL SUM to a native SQL query. It now uses a ROW_NUMBER() OVER (PARTITION BY cfd.claim_id ORDER BY cfd.created_on DESC, cfd.id DESC) window function to strictly filter out historical amendment rows before calculating the total.

Bulk Submission Recalculation: Applied the exact same window function logic to the plural getCalculatedTotalAmounts method, ensuring dashboard and list views accurately roll up the partitioned totals grouped by submission_id via a native query.

Validation Pipeline Fixes: Updated the ClaimStateSnapshot test fixtures in ClaimAmendmentValidationServiceIntegrationTest to inject a baseline CalculatedFeeDetailSnapshot. This aligns the integration tests with the strict rejection logic recently added to the AmendmentFspValidationStep.

Strict Test Builders: Expanded the test data builders inside SubmissionRepositoryIntegrationTest to satisfy mandatory database constraints (provider_user_id, created_by_user_id, submission_period, area_of_law, line_number, matter_type_code).

Testing Performed
Added a new nested integration test suite (SubmissionTotalsRecalculation) within SubmissionRepositoryIntegrationTest that hits the live test database to prove the Sum Calculation and native queries execute correctly. Tests include:

Single calculated-fee row per claim sums normally (Regression).

Multiple calculated-fee rows per claim sum only the latest row based on created_on.

Tie-break scenario verifying id fallback when multiple rows share the exact same created_on timestamp.

Bulk Query Validation: Verifies that multiple submissions passed to the IN clause securely partition and sum the latest fees per submission without cross-pollinating totals.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [x] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
