### PR TITLE
chore(DSTEW-2051): Fix assessment version bump bug

### DIFF
--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AssessmentControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/AssessmentControllerIntegrationTest.java
@@ -22,9 +22,19 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUt
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.CLAIM_2_SUMMARY_FEE_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.getAssessmentPost;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.OptimisticLockException;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,9 +43,14 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Assessment;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentGet;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentPost;
@@ -59,6 +74,11 @@ public class AssessmentControllerIntegrationTest extends AbstractIntegrationTest
   private static final UUID SUMMARY_FEE_ID_FOR_VALID_CLAIM = CLAIM_2_SUMMARY_FEE_ID;
   private static final UUID SUMMARY_FEE_ID_FOR_CLAIM_WITH_ASSESSMENTS = CLAIM_1_SUMMARY_FEE_ID;
 
+  private static final String CLAIM_NOT_FOUND = "Claim not found exception";
+
+  @Autowired private PlatformTransactionManager transactionManager;
+  @Autowired private EntityManager entityManager;
+
   @BeforeEach
   void setUp() {
     seedAssessmentsData();
@@ -70,6 +90,14 @@ public class AssessmentControllerIntegrationTest extends AbstractIntegrationTest
     final AssessmentPost assessmentPost = getAssessmentPost();
     assessmentPost.setClaimId(CLAIM_ID_WITH_VALID_STATUS);
     assessmentPost.setClaimSummaryFeeId(SUMMARY_FEE_ID_FOR_VALID_CLAIM);
+
+    // capture the claim version and audit state the caller would have loaded before assessing.
+    final Claim claimBeforeAssessment =
+        claimRepository
+            .findById(CLAIM_ID_WITH_VALID_STATUS)
+            .orElseThrow(() -> new RuntimeException(CLAIM_NOT_FOUND));
+    final Long versionBeforeAssessment = claimBeforeAssessment.getVersion();
+    final Instant updatedOnBeforeAssessment = claimBeforeAssessment.getUpdatedOn();
 
     // when: calling the POST endpoint with the AssessmentPost
     MvcResult result =
@@ -96,7 +124,7 @@ public class AssessmentControllerIntegrationTest extends AbstractIntegrationTest
     final var updatedClaim =
         claimRepository
             .findById(CLAIM_ID_WITH_VALID_STATUS)
-            .orElseThrow(() -> new RuntimeException("Claim not found exception"));
+            .orElseThrow(() -> new RuntimeException(CLAIM_NOT_FOUND));
 
     assertThat(savedAssessment.getClaim().getId()).isEqualTo(CLAIM_ID_WITH_VALID_STATUS);
     assertThat(savedAssessment.getClaimSummaryFee().getId())
@@ -107,6 +135,148 @@ public class AssessmentControllerIntegrationTest extends AbstractIntegrationTest
     assertThat(savedAssessment.getAssessmentType())
         .isEqualTo(AssessmentType.ESCAPE_CASE_ASSESSMENT);
     assertTrue(updatedClaim.isHasAssessment());
+    // a successful assessment is a version-advancing action: it must move claim.version on by one
+    // so any amendment loaded beforehand is detected as stale (CLAIM_VERSION_CONFLICT).
+    assertThat(updatedClaim.getVersion()).isEqualTo(versionBeforeAssessment + 1);
+    // the assessment must also record who advanced the claim and refresh when it was advanced.
+    assertThat(updatedClaim.getUpdatedByUserId()).isEqualTo(API_USER_ID);
+    assertThat(updatedClaim.getUpdatedOn()).isNotNull();
+    if (updatedOnBeforeAssessment != null) {
+      assertThat(updatedClaim.getUpdatedOn()).isAfterOrEqualTo(updatedOnBeforeAssessment);
+    }
+  }
+
+  @Test
+  @DisplayName(
+      "every successful assessment advances claim.version and refreshes the audit fields - both the "
+          + "first (which also flips hasAssessment) and a subsequent repeat by the same user")
+  void eachSuccessfulAssessmentAdvancesClaimVersion() throws Exception {
+    final Long versionBeforeAnyAssessment = claimVersion(CLAIM_ID_WITH_VALID_STATUS);
+
+    // first assessment: flips hasAssessment AND advances the version AND records the audit fields.
+    postAssessmentForValidClaim();
+    final Claim claimAfterFirstAssessment = reloadValidClaim();
+    assertThat(claimAfterFirstAssessment.getVersion()).isEqualTo(versionBeforeAnyAssessment + 1);
+    assertTrue(claimAfterFirstAssessment.isHasAssessment());
+    assertThat(claimAfterFirstAssessment.getUpdatedByUserId()).isEqualTo(API_USER_ID);
+    assertThat(claimAfterFirstAssessment.getUpdatedOn()).isNotNull();
+
+    // subsequent assessment by the SAME user: hasAssessment is already true and updatedByUserId is
+    // unchanged, but the refreshed updatedOn keeps the claim dirty so the version STILL advances.
+    postAssessmentForValidClaim();
+    final Claim claimAfterSecondAssessment = reloadValidClaim();
+    assertThat(claimAfterSecondAssessment.getVersion())
+        .isEqualTo(claimAfterFirstAssessment.getVersion() + 1);
+    assertThat(claimAfterSecondAssessment.getUpdatedByUserId()).isEqualTo(API_USER_ID);
+    assertThat(claimAfterSecondAssessment.getUpdatedOn())
+        .isAfterOrEqualTo(claimAfterFirstAssessment.getUpdatedOn());
+  }
+
+  private Claim reloadValidClaim() {
+    return claimRepository
+        .findById(CLAIM_ID_WITH_VALID_STATUS)
+        .orElseThrow(() -> new RuntimeException(CLAIM_NOT_FOUND));
+  }
+
+  private Long claimVersion(UUID claimId) {
+    return claimRepository
+        .findById(claimId)
+        .orElseThrow(() -> new RuntimeException(CLAIM_NOT_FOUND))
+        .getVersion();
+  }
+
+  private void postAssessmentForValidClaim() throws Exception {
+    final AssessmentPost assessmentPost = getAssessmentPost();
+    assessmentPost.setClaimId(CLAIM_ID_WITH_VALID_STATUS);
+    assessmentPost.setClaimSummaryFeeId(SUMMARY_FEE_ID_FOR_VALID_CLAIM);
+    mockMvc
+        .perform(
+            post(POST_AN_ASSESSMENT_ENDPOINT, CLAIM_ID_WITH_VALID_STATUS)
+                .content(OBJECT_MAPPER.writeValueAsString(assessmentPost))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  @DisplayName(
+      "two genuinely concurrent assessment version-advances on the same claim collide: exactly one "
+          + "caller hits the optimistic-lock conflict that the handler maps to 409 "
+          + "CLAIM_VERSION_CONFLICT, and only one increment is persisted (no silent lost update)")
+  void concurrentAssessmentsRaiseOptimisticLockConflictRatherThanLosingAnUpdate() throws Exception {
+    final UUID claimId = CLAIM_ID_WITH_VALID_STATUS;
+    final long startVersion = claimVersion(claimId);
+
+    final TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
+    // Both transactions must read the same version before either flushes, so the two increments
+    // genuinely race on the same base version (mirroring two caseworkers assessing at once).
+    final CyclicBarrier bothLoaded = new CyclicBarrier(2);
+
+    // Each task reproduces exactly what AssessmentService does to the claim inside its transaction:
+    // load the managed claim, advance it (record the assessing user and refresh updatedOn - a dirty
+    // change that triggers a versioned UPDATE), then flush it.
+    final Callable<Optional<Exception>> advanceClaimVersion =
+        () -> {
+          try {
+            txTemplate.executeWithoutResult(
+                transactionStatus -> {
+                  Claim claim = entityManager.find(Claim.class, claimId);
+                  awaitQuietly(bothLoaded);
+                  claim.setHasAssessment(true);
+                  claim.setUpdatedByUserId(API_USER_ID);
+                  claim.setUpdatedOn(Instant.now());
+                  entityManager.flush();
+                });
+            return Optional.empty();
+          } catch (Exception thrown) {
+            return Optional.of(thrown);
+          }
+        };
+
+    final List<Exception> failures;
+    try (var pool = Executors.newFixedThreadPool(2)) {
+      Future<Optional<Exception>> first = pool.submit(advanceClaimVersion);
+      Future<Optional<Exception>> second = pool.submit(advanceClaimVersion);
+      failures =
+          Stream.of(first.get(15, TimeUnit.SECONDS), second.get(15, TimeUnit.SECONDS))
+              .filter(Optional::isPresent)
+              .map(Optional::get)
+              .toList();
+    }
+
+    // Exactly one writer wins; the loser fails - the OCC contract turns a would-be lost update into
+    // a detectable conflict.
+    assertThat(failures).hasSize(1);
+    assertTrue(
+        isOptimisticLockFailure(failures.getFirst()),
+        "the losing concurrent assessment must raise the optimistic-lock failure the handler maps "
+            + "to 409 CLAIM_VERSION_CONFLICT, but was: "
+            + failures.getFirst());
+
+    // Only the winning advance persisted: the version moved on by exactly one, not two.
+    assertThat(claimVersion(claimId)).isEqualTo(startVersion + 1);
+  }
+
+  private static void awaitQuietly(CyclicBarrier barrier) {
+    try {
+      barrier.await(10, TimeUnit.SECONDS);
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(
+          "Interrupted while awaiting the concurrency barrier", interrupted);
+    } catch (Exception exception) {
+      throw new IllegalStateException("Failed to await the concurrency barrier", exception);
+    }
+  }
+
+  private static boolean isOptimisticLockFailure(Throwable throwable) {
+    for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+      if (cause instanceof OptimisticLockException
+          || cause instanceof ObjectOptimisticLockingFailureException) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Test

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/claim/amendments/AmendmentVersusAssessmentOccIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/claim/amendments/AmendmentVersusAssessmentOccIntegrationTest.java
@@ -10,7 +10,6 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUt
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.SUBMISSION_1_ID;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.getAssessmentPost;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -57,14 +56,6 @@ class AmendmentVersusAssessmentOccIntegrationTest extends AbstractAmendmentPatch
       API_URI_PREFIX + "/claims/{claimId}/assessments";
 
   @Test
-  @Disabled(
-      "CONFIRMED GAP (DSTEW-1658 coordination): the assessment path updates the claim via the bulk"
-          + " JPQL ClaimRepository.updateAssessmentStatus, which does not increment @Version (and"
-          + " only runs for the first assessment). An assessment therefore does NOT advance"
-          + " claim.version, so a concurrent assessment does not invalidate a stale amendment. This"
-          + " test asserts the required behaviour and will pass once the assessment OCC/version work"
-          + " advances claim.version on every assessment. Empirically verified: version was 1 before"
-          + " and after the assessment.")
   @DisplayName(
       "an assessment submitted after the claim is loaded invalidates a stale amendment with 409 "
           + "Conflict")

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimAmendmentStorageIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimAmendmentStorageIntegrationTest.java
@@ -127,7 +127,10 @@ class ClaimAmendmentStorageIntegrationTest extends AbstractIntegrationTest {
 
     Claim evaluatedClaim = claimRepository.findById(ClaimsDataTestUtil.CLAIM_1_ID).orElseThrow();
 
-    assertThat(evaluatedClaim.getVersion()).isEqualTo(initialVersion + 2);
+    // A single versioned UPDATE of the claim increments the version by exactly one. (Before
+    // created_on was made immutable via @Column(updatable = false), the @CreationTimestamp column
+    // was spuriously rewritten on update, producing a second UPDATE and a misleading +2.)
+    assertThat(evaluatedClaim.getVersion()).isEqualTo(initialVersion + 1);
     assertThat(evaluatedClaim.getCalculatedFeeDetails()).hasSize(baselineSize + 1);
     assertThat(evaluatedClaim.getLatestCalculatedFee()).isNotNull();
     assertThat(evaluatedClaim.getLatestCalculatedFee().getTotalAmount())

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/ClaimAmendmentPersistenceServiceIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/ClaimAmendmentPersistenceServiceIntegrationTest.java
@@ -45,6 +45,7 @@ class ClaimAmendmentPersistenceServiceIntegrationTest extends AbstractIntegratio
   @DisplayName("persists one claim_amendment row and applies the amended claim and fee values")
   void persistsSuccessfulAmendment() {
     Claim claim = claimRepository.findById(CLAIM_1_ID).orElseThrow();
+    long versionBefore = claim.getVersion();
 
     ClaimStateSnapshot before =
         ClaimStateSnapshot.builder()
@@ -99,6 +100,12 @@ class ClaimAmendmentPersistenceServiceIntegrationTest extends AbstractIntegratio
     Claim reloadedClaim = claimRepository.findById(CLAIM_1_ID).orElseThrow();
     assertThat(reloadedClaim.getFeeCode()).isEqualTo(AMENDED_FEE_CODE);
     assertThat(reloadedClaim.isAmended()).isTrue();
+    // DSTEW-2051 Finding B: a successful amendment stamps the amending user and advances the
+    // version/updated_on audit fields on the claim itself. The amendment performs exactly one
+    // versioned UPDATE, so the version increments by exactly one.
+    assertThat(reloadedClaim.getUpdatedByUserId()).isEqualTo(ClaimsDataTestUtil.USER_ID);
+    assertThat(reloadedClaim.getVersion()).isEqualTo(versionBefore + 1);
+    assertThat(reloadedClaim.getUpdatedOn()).isNotNull();
 
     ClaimSummaryFee reloadedFee = claimSummaryFeeRepository.findByClaimId(CLAIM_1_ID).orElseThrow();
     assertThat(reloadedFee.getNetProfitCostsAmount())

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Claim.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/entity/Claim.java
@@ -134,7 +134,7 @@ public class Claim {
   private String createdByUserId;
 
   @CreationTimestamp
-  @Column(nullable = false)
+  @Column(nullable = false, updatable = false)
   private Instant createdOn;
 
   private String updatedByUserId;

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimRepository.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/repository/ClaimRepository.java
@@ -22,8 +22,4 @@ public interface ClaimRepository
   @Modifying
   @Query("UPDATE Claim c SET c.status = :status WHERE c.submission.id = :submissionId")
   int updateStatusBySubmissionId(UUID submissionId, ClaimStatus status);
-
-  @Modifying
-  @Query("UPDATE Claim c SET c.hasAssessment = :hasAssessment WHERE c.id = :id")
-  int updateAssessmentStatus(UUID id, boolean hasAssessment);
 }

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentService.java
@@ -4,12 +4,12 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.service.ClaimValidati
 
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,7 +31,6 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
 /** Service containing business logic for handling assessments. */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class AssessmentService {
 
   private final ClaimRepository claimRepository;
@@ -56,7 +55,7 @@ public class AssessmentService {
         claimValidationService.getClaimSummaryFeeByIdOrThrow(request.getClaimSummaryFeeId());
 
     claimValidationService.validateAssessmentType(request.getAssessmentType());
-    updateClaimAssessmentStatus(claim);
+    advanceClaimForAssessment(claim, request.getCreatedByUserId());
 
     Assessment assessment = assessmentMapper.toAssessment(request);
 
@@ -72,25 +71,31 @@ public class AssessmentService {
   }
 
   /**
-   * Updates the claim assessment status when an assessment is first created for a claim.
+   * Advances the claim as a version-advancing action whenever an assessment is created.
    *
-   * <p>This method checks whether the claim has been assessed before. If the claim has not been
-   * assessed ({@link Claim#isHasAssessment()} returns false), it updates the claim's assessment
-   * status to true and logs the result.
+   * <p>Operates on the already-loaded managed {@link Claim} entity so persistence is handled by JPA
+   * dirty checking and optimistic locking within the caller's transaction. On every assessment it:
    *
-   * <p>This is typically called during assessment creation to mark the claim as assessed once the
-   * first assessment is added.
+   * <ul>
+   *   <li>marks the claim as assessed ({@link Claim#setHasAssessment(boolean)} - a no-op after the
+   *       first assessment);
+   *   <li>records the assessing user in {@code updatedByUserId}; and
+   *   <li>refreshes {@code updatedOn} to the current instant.
+   * </ul>
    *
-   * @param claim the claim to update; must not be null
+   * <p>Because {@code updatedOn} always changes, the claim is dirty on every assessment, so a
+   * single versioned {@code UPDATE} advances {@code claim.version} by exactly one - even a repeat
+   * assessment by the same user. This upholds the OCC contract (any amendment loaded beforehand
+   * becomes stale) while keeping the audit fields accurate, and the versioned {@code UPDATE ...
+   * WHERE version = ?} still surfaces concurrent assessments as an optimistic-lock conflict.
+   *
+   * @param claim the managed claim to advance; must not be null
+   * @param userId the id of the user creating the assessment
    */
-  private void updateClaimAssessmentStatus(Claim claim) {
-    if (!claim.isHasAssessment()) {
-      int noOfClaimsUpdated = claimRepository.updateAssessmentStatus(claim.getId(), true);
-      log.info(
-          "Number of claims updated with assessed status: {} Claim id: {}",
-          noOfClaimsUpdated,
-          claim.getId());
-    }
+  private void advanceClaimForAssessment(Claim claim, String userId) {
+    claim.setHasAssessment(true);
+    claim.setUpdatedByUserId(userId);
+    claim.setUpdatedOn(Instant.now());
   }
 
   /**

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/AmendmentEntitiesWriter.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/AmendmentEntitiesWriter.java
@@ -32,15 +32,23 @@ public class AmendmentEntitiesWriter {
   private final ClaimSummaryFeeRepository claimSummaryFeeRepository;
 
   /**
-   * Applies the post-amendment values onto the managed claim and its related entities and marks the
-   * claim amended.
+   * Applies the post-amendment values onto the managed claim and its related entities, marks the
+   * claim amended and stamps the amending user onto {@code updated_by_user_id}.
+   *
+   * <p>The {@code updated_on} timestamp ({@code @UpdateTimestamp}) and the optimistic-lock {@code
+   * version} ({@code @Version}) are refreshed automatically by Hibernate when the guarded claim
+   * update flushes, so only the acting user is set explicitly here (DSTEW-2051 Finding B).
    *
    * @param claim the managed claim being amended (mutated in place; not saved here)
    * @param postAmendmentState the proposed post-amendment values
+   * @param amendedByUserId the id of the user submitting the amendment, stamped onto {@code
+   *     updated_by_user_id}
    */
-  public void applyAmendedValues(Claim claim, ClaimStateSnapshot postAmendmentState) {
+  public void applyAmendedValues(
+      Claim claim, ClaimStateSnapshot postAmendmentState, String amendedByUserId) {
     claimUpdater.applyAmendedFields(claim, postAmendmentState);
     claim.setAmended(true);
+    claim.setUpdatedByUserId(amendedByUserId);
 
     clientRepository
         .findByClaimId(claim.getId())

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/ClaimAmendmentPersistenceService.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/ClaimAmendmentPersistenceService.java
@@ -56,6 +56,7 @@ public class ClaimAmendmentPersistenceService {
   public ClaimAmendment persistSuccessfulAmendment(Claim claim, ClaimAmendmentState state) {
     ClaimAmendmentPayload payload = state.getRequestPayload();
     AmendmentDiff diff = diffAssembler.assemble(state);
+    String amendmentUserId = unwrap(payload.getAmendmentUserId());
 
     ClaimAmendment amendment =
         ClaimAmendment.builder()
@@ -63,7 +64,7 @@ public class ClaimAmendmentPersistenceService {
             .claim(claim)
             .requestedByCode(unwrap(payload.getAmendmentRequestedBy()))
             .amendmentReasonCode(unwrap(payload.getAmendmentReasonCode()))
-            .createdByUserId(unwrap(payload.getAmendmentUserId()))
+            .createdByUserId(amendmentUserId)
             .createdOn(OffsetDateTime.now(ZoneOffset.UTC))
             .beforeState(jsonWriter.writeBeforeState(state.getBeforeState()))
             .requestPayload(jsonWriter.writeRequestPayload(payload))
@@ -74,10 +75,11 @@ public class ClaimAmendmentPersistenceService {
     log.debug("Inserted claim_amendment {} for claim {}", savedAmendment.getId(), claim.getId());
 
     // Contribute the amended column writes to the managed claim and its related entities (client,
-    // claim_case, claim_summary_fee). The version-guarded claim update and the version increment
-    // are
-    // owned by DSTEW-1753; we never issue our own save here.
-    entitiesWriter.applyAmendedValues(claim, state.getPostAmendmentState());
+    // claim_case, claim_summary_fee) and stamp the amending user onto the claim's
+    // updated_by_user_id (DSTEW-2051 Finding B). The version-guarded claim update, the version
+    // increment and the updated_on timestamp are owned by DSTEW-1753; we never issue our own save
+    // here.
+    entitiesWriter.applyAmendedValues(claim, state.getPostAmendmentState(), amendmentUserId);
 
     // Attach the amendment-driven calculated_fee_detail row (one per pricing amendment) from the
     // FSP handoff; a non-pricing amendment attaches nothing.

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/AssessmentServiceTest.java
@@ -4,10 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -94,7 +92,12 @@ class AssessmentServiceTest {
       verify(claimValidationService).validateAssessmentType(post.getAssessmentType());
       verify(claimValidationService).validateAssessmentReason(post.getAssessmentReason());
 
-      verify(claimRepository).updateAssessmentStatus(claimId, true);
+      // First assessment marks the managed claim as assessed and records the assessing user; the
+      // false->true change plus the refreshed updatedOn make the claim dirty, so JPA dirty checking
+      // advances @Version by one within the transaction.
+      assertThat(claim.isHasAssessment()).isTrue();
+      assertThat(claim.getUpdatedByUserId()).isEqualTo(API_USER_ID);
+      assertThat(claim.getUpdatedOn()).isNotNull();
 
       verify(assessmentRepository).save(assessment);
     }
@@ -153,7 +156,7 @@ class AssessmentServiceTest {
     }
 
     @Test
-    void shouldCreateAssessmentWithoutUpdatingClaimStatusWhenAlreadyAssessed() {
+    void shouldAdvanceClaimVersionWithoutRemarkingAssessedWhenAlreadyAssessed() {
 
       UUID claimId = UUID.randomUUID();
       UUID claimSummaryFeeId = UUID.randomUUID();
@@ -178,7 +181,12 @@ class AssessmentServiceTest {
 
       assessmentService.createAssessment(claimId, post);
 
-      verify(claimRepository, never()).updateAssessmentStatus(any(), anyBoolean());
+      // Subsequent assessments must still advance claim.version even though hasAssessment is
+      // already true - the OCC contract requires every assessment to invalidate a stale amendment.
+      // The refreshed audit fields keep the claim dirty, so a versioned UPDATE is issued.
+      assertThat(claim.isHasAssessment()).isTrue();
+      assertThat(claim.getUpdatedByUserId()).isEqualTo(API_USER_ID);
+      assertThat(claim.getUpdatedOn()).isNotNull();
       verify(assessmentRepository).save(assessment);
     }
 

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/AmendmentEntitiesWriterTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/AmendmentEntitiesWriterTest.java
@@ -39,6 +39,7 @@ class AmendmentEntitiesWriterTest {
   @InjectMocks private AmendmentEntitiesWriter entitiesWriter;
 
   private static final UUID CLAIM_ID = Uuid7.timeBasedUuid();
+  private static final String AMENDED_BY_USER_ID = "0190b6a0-9b7e-7c8a-9e2d-2f3a4b5c6d7e";
   private final ClaimStateSnapshot post = ClaimStateSnapshot.builder().claimId(CLAIM_ID).build();
 
   @Test
@@ -53,10 +54,11 @@ class AmendmentEntitiesWriterTest {
     when(claimCaseRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.of(claimCase));
     when(claimSummaryFeeRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.of(summaryFee));
 
-    entitiesWriter.applyAmendedValues(claim, post);
+    entitiesWriter.applyAmendedValues(claim, post, AMENDED_BY_USER_ID);
 
     verify(claimUpdater).applyAmendedFields(claim, post);
     assertThat(claim.isAmended()).isTrue();
+    assertThat(claim.getUpdatedByUserId()).isEqualTo(AMENDED_BY_USER_ID);
     verify(clientUpdater).applyAmendedFields(client, post);
     verify(claimCaseUpdater).applyAmendedFields(claimCase, post);
     verify(claimSummaryFeeUpdater).applyAmendedFields(summaryFee, post);
@@ -71,10 +73,11 @@ class AmendmentEntitiesWriterTest {
     when(claimCaseRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
     when(claimSummaryFeeRepository.findByClaimId(CLAIM_ID)).thenReturn(Optional.empty());
 
-    entitiesWriter.applyAmendedValues(claim, post);
+    entitiesWriter.applyAmendedValues(claim, post, AMENDED_BY_USER_ID);
 
     verify(claimUpdater).applyAmendedFields(claim, post);
     assertThat(claim.isAmended()).isTrue();
+    assertThat(claim.getUpdatedByUserId()).isEqualTo(AMENDED_BY_USER_ID);
     verifyNoInteractions(clientUpdater, claimCaseUpdater, claimSummaryFeeUpdater);
   }
 }

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/ClaimAmendmentPersistenceServiceTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/service/amendment/persistence/ClaimAmendmentPersistenceServiceTest.java
@@ -87,9 +87,10 @@ class ClaimAmendmentPersistenceServiceTest {
     assertThat(inserted.getRequestPayload()).isEqualTo("PAYLOAD_JSON");
     assertThat(inserted.getDiff()).isEqualTo("DIFF_JSON");
 
-    // Delegation to the target writer (which applies claim + related-entity values and marks the
-    // claim amended) is verified in AmendmentEntitiesWriterTest.
-    verify(entitiesWriter).applyAmendedValues(claim, state.getPostAmendmentState());
+    // Delegation to the target writer (which applies claim + related-entity values, marks the
+    // claim amended and stamps the amending user onto updated_by_user_id) is verified in
+    // AmendmentEntitiesWriterTest.
+    verify(entitiesWriter).applyAmendedValues(claim, state.getPostAmendmentState(), "user-123");
     verify(calculatedFeeWriter).attach(eq(saved), eq(state));
   }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2051)

Enforces the claim optimistic-concurrency (OCC) contract - every version-advancing action must increment claim.version and correctly record the acting user/time - and fixes an audit-integrity bug uncovered along the way.

1. Assessments now advance version (core fix) Previously AssessmentService updated the claim via a bulk JPQL update that bypassed Hibernate, so @ Version was never bumped and only the first assessment touched the claim. Now the managed claim is mutated in-place on every assessment (hasAssessment, updated_by_user_id, updated_on = now()), producing one versioned UPDATE. Result: an amendment loaded before an assessment is correctly detected as stale and rejected with 409 CLAIM_VERSION_CONFLICT. The bulk repository method was removed. Re-enabled the acceptance spec AmendmentVersusAssessmentOccIntegrationTest.
2. Amendments now record the acting user on the claim (Finding B) A successful amendment advanced version/updated_on but never recorded who made the change. It now stamps claim.updated_by_user_id with the amending user, folded into the existing dirty-checked update - no extra SQL.
3. Fixed created_on being overwritten on update (and a double version bump) While adding version assertions we found an amendment bumped version by 2. Root cause: Claim.createdOn (@ CreationTimestamp) was not immutable, so it participated in UPDATEs/dirty-checking and was regenerated to now() during flush - overwriting created_on and causing a second versioned UPDATE. Fixed by making it immutable:

```
@CreationTimestamp
@Column(nullable = false, updatable = false)
private Instant createdOn;
```
### Changes

- AssessmentService - advance the managed claim on every assessment; removed the bulk JPQL update and @ Slf4j.
- ClaimRepository - removed the version-bypassing updateAssessmentStatus.
- AmendmentEntitiesWriter / ClaimAmendmentPersistenceService - stamp updated_by_user_id on amend.
- Claim.java - created_on marked updatable = false.
- Tests: added assessment version/audit-field + concurrent-conflict (409) coverage; amendment updated_by_user_id/updated_on + exact +1 version coverage.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
