### PR TITLE
fix(DSTEW-2124): split claims-api health probes into liveness/readiness

### DIFF
--- a/.helm/data-claims-api/templates/deployment.yaml
+++ b/.helm/data-claims-api/templates/deployment.yaml
@@ -32,16 +32,24 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8081
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/liveness
               port: 8081
             initialDelaySeconds: 60
+            periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/readiness
               port: 8081
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
+            periodSeconds: 10
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/claims-data/service/src/main/resources/application.yml
+++ b/claims-data/service/src/main/resources/application.yml
@@ -69,6 +69,8 @@ management:
   # show detailed health status
   endpoint:
     health:
+      probes:
+        enabled: true
       show-details: always
 
   info:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2124)

Pods are showing repeated probe failures and restart behaviour.
Current behaviour checks a generic health endpoint, which can conflate process liveliness with dependency readiness. This can trigger unnecessary restarts during dependency turbulence or slow startup.

This change aligns probe behaviour with Spring Boot Actuator probe groups so that:

- Liveness reflects whether the process is alive.
- Readiness reflects whether the app is ready to serve traffic.
- Startup has enough time to complete before liveness enforcement.


## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
