### PR TITLE
fix(DSTEW-2146): Cap the JVM metaspace explicitly rather than letting the Paketo memory calculator derive it from a build-time class count.

### DIFF
--- a/.helm/data-claims-api/templates/deployment.yaml
+++ b/.helm/data-claims-api/templates/deployment.yaml
@@ -166,6 +166,13 @@ spec:
                   name: laa-data-claims-api-secrets
                   key: fee-scheme-platform-api-connect-timeout-ms
                   optional: true
+            # Caps the JVM metaspace explicitly rather than letting the Paketo memory
+            # calculator derive it from a build-time class count (which comes to a lower number of ~169m).
+            # 224m matches this app's real runtime class loading (loaded classes stabilise around 33K)
+            # Under the fixed container memory limit the metaspace reservation comes out of heap;
+            # revisit if heap pressure appears.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxMetaspaceSize=224m"
             - name: SPRING_PROFILES_ACTIVE
               value: {{ .Values.spring.profile | quote }}
             - name: AWS_REGION


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2146)

After investigating (via temp integration tests and grafana queries) I confirmed the current situation as this:   

1. The metaspace is restricted to around 169M based on estimates of classes loaded by the application at start up.
2. This estimate is too low, given the dynamically generated classes (by Javers, Json parsers etc) and after a few hours of usage, the number of classes increases to ~32K and stabilises there.

Solution applied: It is better to set the Metaspace limit manually, at a higher limit of 224M (still leaving 230M for the heap, sufficiently larger than the current observed peak usage of 160M). We will observe the grafana dashboards to see how this affects the behaviour and reduces the pod restarts that are being seen at the moment.


## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
