### PR TITLE
test(DSTEW-1813): BDD scenarios for claim history amendment metadata

### DIFF
--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryAmendmentMetadataSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryAmendmentMetadataSteps.java
@@ -1,0 +1,513 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddStepFailures;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimAmendment;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimSummaryFee;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Submission;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimAmendmentRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimSummaryFeeRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.SubmissionRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
+
+/**
+ * Step definitions for {@code claimHistoryAmendmentMetadata.feature} (DSTEW-1813).
+ *
+ * <p>Covers the read-side AMENDMENT-event envelope population from a {@code claim_amendment} row:
+ *
+ * <ul>
+ *   <li>envelope: {@code event_type=AMENDMENT}, {@code event_timestamp=am.created_on}, {@code
+ *       actor_id=am.created_by_user_id}, {@code source_id=am.id};
+ *   <li>metadata: {@code requested_by_code} and {@code amendment_reason_code} echoed verbatim from
+ *       the persisted row (no label substitution — that is DSTEW-1594 + AaBC).
+ * </ul>
+ *
+ * <p>The {@code amended_field_identifiers} scenarios were de-scoped from this ticket (see the
+ * banner in the feature file) because the shipped SQL in {@code JdbcClaimHistoryRepository} does
+ * not yet build a Requested-only filtered list. When that filter ships, the feature file grows a
+ * fresh set of scenarios and this steps class gains the corresponding assertions.
+ *
+ * <p>Every step wraps its body in {@link BddStepFailures#step(String,
+ * BddStepFailures.ThrowingRunnable)} so scenario failures surface as {@code [BDD step failed]
+ * &lt;plain-English context&gt; — &lt;cause&gt;} in the JUnit XML / Cucumber HTML report, per the
+ * standing rule in {@code memory.md}.
+ */
+@Slf4j
+public class ClaimHistoryAmendmentMetadataSteps {
+
+  private static final String BDD_USER_ID = "bdd-user-1813";
+  private static final String AMENDMENT_EVENT_TYPE = "AMENDMENT";
+
+  @Autowired private BddApiStepSupport api;
+  @Autowired private SubmissionRepository submissionRepository;
+  @Autowired private ClaimRepository claimRepository;
+  @Autowired private ClaimSummaryFeeRepository claimSummaryFeeRepository;
+  @Autowired private ClaimAmendmentRepository claimAmendmentRepository;
+
+  private UUID currentClaimId;
+  private UUID currentAmendmentId;
+  private final List<UUID> amendmentIdsInOrder = new ArrayList<>();
+  private JsonNode lastHistoryResponse;
+
+  // ---------------------------------------------------------------------------
+  // Given — single-amendment seeding
+  // ---------------------------------------------------------------------------
+
+  @Given("a claim exists with the following successful `claim_amendment` row")
+  public void aClaimExistsWithTheFollowingSuccessfulClaimAmendmentRow(DataTable table) {
+    BddStepFailures.step(
+        "Seeding a claim + single successful claim_amendment row from the scenario DataTable",
+        () -> {
+          seedClaim();
+          Map<String, String> row = singleRowFromTwoColumnTable(table);
+          currentAmendmentId =
+              persistAmendment(
+                  requireField(row, "created_on"),
+                  requireField(row, "created_by_user_id"),
+                  requireField(row, "requested_by_code"),
+                  requireField(row, "amendment_reason_code"),
+                  emptyDiff());
+          amendmentIdsInOrder.add(currentAmendmentId);
+        });
+  }
+
+  @Given(
+      "a claim exists with a successful `claim_amendment` row where `requested_by_code` is"
+          + " {string} and `amendment_reason_code` is {string}")
+  public void aClaimExistsWithASuccessfulAmendmentRowWithCodes(
+      String requestedByCode, String amendmentReasonCode) {
+    BddStepFailures.step(
+        "Seeding a claim + single successful claim_amendment row with requested_by_code='"
+            + requestedByCode
+            + "' and amendment_reason_code='"
+            + amendmentReasonCode
+            + "'",
+        () -> {
+          seedClaim();
+          currentAmendmentId =
+              persistAmendment(
+                  Instant.now().toString(),
+                  BDD_USER_ID,
+                  requestedByCode,
+                  amendmentReasonCode,
+                  emptyDiff());
+          amendmentIdsInOrder.add(currentAmendmentId);
+        });
+  }
+
+  @And("the amendment's stored diff contains a `change_source` {string} entry for field {string}")
+  public void theAmendmentDiffContainsAChangeSourceEntryForField(
+      String changeSource, String fieldIdentifier) {
+    BddStepFailures.step(
+        "Re-persisting the current amendment's diff to include a "
+            + changeSource
+            + " entry for field '"
+            + fieldIdentifier
+            + "'",
+        () -> {
+          ClaimAmendment amendment =
+              claimAmendmentRepository.findById(currentAmendmentId).orElseThrow();
+          amendment.setDiff(diffWithRequestedChange(fieldIdentifier, changeSource));
+          claimAmendmentRepository.saveAndFlush(amendment);
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Given — multi-amendment chronology
+  // ---------------------------------------------------------------------------
+
+  @Given("a claim exists with the following successful `claim_amendment` rows applied in order")
+  public void aClaimExistsWithMultipleSuccessfulAmendmentsInOrder(DataTable table) {
+    BddStepFailures.step(
+        "Seeding a claim + multiple successful claim_amendment rows applied in scenario order",
+        () -> {
+          seedClaim();
+          List<Map<String, String>> rows = table.asMaps(String.class, String.class);
+          for (Map<String, String> row : rows) {
+            String requestedByCode = requireField(row, "requested_by_code");
+            UUID id =
+                persistAmendment(
+                    requireField(row, "created_on"),
+                    requireField(row, "created_by_user_id"),
+                    requestedByCode,
+                    // Reason code column is optional in this scenario. Fall back to a valid
+                    // (requested_by, reason) pair from the DSTEW-1594 reference-data seed
+                    // (V41__create_amendment_reference_tables.sql) so the composite FK
+                    // fk_claim_amendment_reason_party_code holds.
+                    row.getOrDefault("amendment_reason_code", defaultReasonFor(requestedByCode)),
+                    emptyDiff());
+            amendmentIdsInOrder.add(id);
+          }
+          currentAmendmentId = amendmentIdsInOrder.get(amendmentIdsInOrder.size() - 1);
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // When
+  // ---------------------------------------------------------------------------
+
+  @When("I request the claim history timeline")
+  public void iRequestTheClaimHistoryTimeline() {
+    BddStepFailures.step(
+        "Requesting claim history timeline for claim " + currentClaimId,
+        () -> {
+          assertThat(currentClaimId)
+              .as("claim must be seeded before requesting history")
+              .isNotNull();
+          lastHistoryResponse = api.getClaimHistory(currentClaimId);
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Then — envelope
+  // ---------------------------------------------------------------------------
+
+  @Then("the response contains an event with the following envelope")
+  public void theResponseContainsAnEventWithTheFollowingEnvelope(DataTable table) {
+    BddStepFailures.step(
+        "Verifying an AMENDMENT event with the scenario-declared envelope fields is present"
+            + " on the history response for claim "
+            + currentClaimId,
+        () -> {
+          Map<String, String> expected = expectedMapFromTwoColumnTable(table, "envelopeField");
+          JsonNode matched = null;
+          for (JsonNode event : eventsArray()) {
+            if (envelopeMatches(event, expected)) {
+              matched = event;
+              break;
+            }
+          }
+          assertThat(matched)
+              .as(
+                  "no event on the history response matched all envelope fields %s;"
+                      + " actual events=%s",
+                  expected, eventsArray())
+              .isNotNull();
+        });
+  }
+
+  @And("that event's metadata contains")
+  public void thatEventsMetadataContains(DataTable table) {
+    BddStepFailures.step(
+        "Verifying the AMENDMENT event for amendment "
+            + currentAmendmentId
+            + " has the scenario-declared metadata fields",
+        () -> {
+          JsonNode event = requireAmendmentEvent(currentAmendmentId);
+          JsonNode metadata = event.path("metadata");
+          Map<String, String> expected = expectedMapFromTwoColumnTable(table, "metadataField");
+          for (Map.Entry<String, String> entry : expected.entrySet()) {
+            JsonNode value = metadata.get(entry.getKey());
+            assertThat(value)
+                .as("metadata field '%s' node on AMENDMENT event", entry.getKey())
+                .isNotNull();
+            assertThat(value.asText())
+                .as("metadata field '%s' value on AMENDMENT event", entry.getKey())
+                .isEqualTo(entry.getValue());
+          }
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Then — multi-amendment chronology
+  // ---------------------------------------------------------------------------
+
+  @Then("the response contains exactly {int} AMENDMENT events")
+  public void theResponseContainsExactlyNAmendmentEvents(int expectedCount) {
+    BddStepFailures.step(
+        "Counting AMENDMENT events on the history response for claim "
+            + currentClaimId
+            + " — expected "
+            + expectedCount,
+        () ->
+            assertThat(amendmentEvents())
+                .as("AMENDMENT event count on history response")
+                .hasSize(expectedCount));
+  }
+
+  /**
+   * Word-spelled variant. Kept discrete from the {@code {int}} overload so the feature file can
+   * read naturally ("exactly two AMENDMENT events") without forcing an integer literal into the
+   * Gherkin. Only "two" is wired up because it's the only count the DSTEW-1813 feature uses; extend
+   * if further scenarios need "three", etc.
+   */
+  @Then("the response contains exactly two AMENDMENT events")
+  public void theResponseContainsExactlyTwoAmendmentEvents() {
+    theResponseContainsExactlyNAmendmentEvents(2);
+  }
+
+  @And("the LATEST AMENDMENT event has `actor_id` {string} and `event_timestamp` {string}")
+  public void theLatestAmendmentEventHasActorAndTimestamp(
+      String expectedActorId, String expectedTimestamp) {
+    BddStepFailures.step(
+        "Verifying the latest AMENDMENT event (by event_timestamp) has actor_id='"
+            + expectedActorId
+            + "' and event_timestamp='"
+            + expectedTimestamp
+            + "'",
+        () -> {
+          List<JsonNode> events = amendmentEvents();
+          assertThat(events)
+              .as("no AMENDMENT events on history response — cannot pick 'latest'")
+              .isNotEmpty();
+          JsonNode latest =
+              events.stream()
+                  .max(
+                      (a, b) ->
+                          Instant.parse(a.path("event_timestamp").asText())
+                              .compareTo(Instant.parse(b.path("event_timestamp").asText())))
+                  .orElseThrow();
+          assertThat(latest.path("actor_id").asText())
+              .as("actor_id on the latest AMENDMENT event")
+              .isEqualTo(expectedActorId);
+          assertThat(latest.path("event_timestamp").asText())
+              .as("event_timestamp on the latest AMENDMENT event")
+              .isEqualTo(expectedTimestamp);
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Then — codes echoed verbatim (@DS1813_4 Outline)
+  // ---------------------------------------------------------------------------
+
+  @Then("the AMENDMENT event metadata field {string} is exactly {string}")
+  public void theAmendmentEventMetadataFieldIsExactly(String fieldName, String expectedValue) {
+    BddStepFailures.step(
+        "Verifying AMENDMENT metadata field '"
+            + fieldName
+            + "' equals '"
+            + expectedValue
+            + "' (verbatim, no label substitution) for claim "
+            + currentClaimId,
+        () -> {
+          JsonNode event = requireAmendmentEvent(currentAmendmentId);
+          JsonNode value = event.path("metadata").get(fieldName);
+          assertThat(value)
+              .as("metadata field '%s' node on AMENDMENT event", fieldName)
+              .isNotNull();
+          assertThat(value.asText())
+              .as("metadata field '%s' value on AMENDMENT event", fieldName)
+              .isEqualTo(expectedValue);
+        });
+  }
+
+  @Then("no display label has been substituted for either code")
+  public void noDisplayLabelHasBeenSubstitutedForEitherCode() {
+    // Semantic documentation step: the sibling "is exactly" assertions above assert byte-for-byte
+    // equality between the persisted code and the JSON field value. If label substitution had
+    // sneaked in, those assertions would have failed. Nothing extra to assert here — kept as a
+    // Gherkin-level guardrail so the intent is visible to reviewers.
+    BddStepFailures.step(
+        "Documenting the no-label-substitution guarantee for claim " + currentClaimId,
+        () -> {
+          /* intentionally empty — covered by the sibling exact-match assertions */
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers — data seeding
+  // ---------------------------------------------------------------------------
+
+  private void seedClaim() {
+    Submission submission =
+        submissionRepository.saveAndFlush(
+            Submission.builder()
+                .id(Uuid7.timeBasedUuid())
+                .officeAccountNumber("1813-office")
+                .submissionPeriod("JAN-2025")
+                .areaOfLaw(AreaOfLaw.LEGAL_HELP)
+                .status(SubmissionStatus.CREATED)
+                .createdByUserId(BDD_USER_ID)
+                .providerUserId(BDD_USER_ID)
+                .createdOn(Instant.now())
+                .build());
+
+    Claim claim =
+        claimRepository.saveAndFlush(
+            Claim.builder()
+                .id(Uuid7.timeBasedUuid())
+                .submission(submission)
+                .status(ClaimStatus.VALID)
+                .feeCode("TEST")
+                .lineNumber(1)
+                .matterTypeCode("TEST_MATTER")
+                .createdByUserId(BDD_USER_ID)
+                .build());
+    currentClaimId = claim.getId();
+
+    // Seed a summary fee row so downstream amendment-linked CFD lookups (not exercised in this
+    // ticket) don't blow up if invoked accidentally from a shared helper.
+    claimSummaryFeeRepository.saveAndFlush(
+        ClaimSummaryFee.builder()
+            .id(Uuid7.timeBasedUuid())
+            .claim(claim)
+            .createdByUserId(BDD_USER_ID)
+            .build());
+  }
+
+  private UUID persistAmendment(
+      String createdOnIso,
+      String createdByUserId,
+      String requestedByCode,
+      String amendmentReasonCode,
+      String diffJson) {
+    UUID id = Uuid7.timeBasedUuid();
+    claimAmendmentRepository.saveAndFlush(
+        ClaimAmendment.builder()
+            .id(id)
+            .claim(claimRepository.getReferenceById(currentClaimId))
+            .requestedByCode(requestedByCode)
+            .amendmentReasonCode(amendmentReasonCode)
+            .beforeState("{}")
+            .requestPayload("{}")
+            .diff(diffJson)
+            .createdByUserId(createdByUserId)
+            .createdOn(Instant.parse(createdOnIso))
+            .build());
+    return id;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers — diff JSON
+  // ---------------------------------------------------------------------------
+
+  private static String emptyDiff() {
+    return "{\"schema_version\":1,\"changes\":[]}";
+  }
+
+  /**
+   * Returns a reason code that is valid for the given requested-by code according to the DSTEW-1594
+   * reference-data seed. Used only when a scenario's DataTable doesn't specify a reason code
+   * explicitly (e.g. the multi-amendment chronology scenario, which only cares about timestamps and
+   * actors).
+   */
+  private static String defaultReasonFor(String requestedByCode) {
+    return switch (requestedByCode) {
+      case "PROVIDER" -> "PROVIDER_ERROR";
+      case "CONTRACT_MANAGEMENT", "ASSURANCE" -> "OTHER";
+      default ->
+          throw new IllegalArgumentException(
+              "No default amendment reason wired up for requested_by_code='"
+                  + requestedByCode
+                  + "' — extend defaultReasonFor() or add a reason_code column to the scenario's"
+                  + " DataTable.");
+    };
+  }
+
+  private static String diffWithRequestedChange(String fieldIdentifier, String changeSource) {
+    return "{\"schema_version\":1,\"changes\":["
+        + "{\"field_identifier\":\""
+        + fieldIdentifier
+        + "\",\"before\":\"OLD\",\"after\":\"NEW\",\"change_source\":\""
+        + changeSource
+        + "\"}]}";
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers — response inspection
+  // ---------------------------------------------------------------------------
+
+  private List<JsonNode> eventsArray() {
+    List<JsonNode> results = new ArrayList<>();
+    JsonNode events = lastHistoryResponse == null ? null : lastHistoryResponse.path("events");
+    if (events != null && events.isArray()) {
+      events.forEach(results::add);
+    }
+    return results;
+  }
+
+  private List<JsonNode> amendmentEvents() {
+    List<JsonNode> results = new ArrayList<>();
+    for (JsonNode event : eventsArray()) {
+      if (AMENDMENT_EVENT_TYPE.equals(event.path("event_type").asText())) {
+        results.add(event);
+      }
+    }
+    return results;
+  }
+
+  private JsonNode requireAmendmentEvent(UUID amendmentId) {
+    for (JsonNode event : amendmentEvents()) {
+      if (amendmentId != null && amendmentId.toString().equals(event.path("source_id").asText())) {
+        return event;
+      }
+    }
+    // Fall back to the sole AMENDMENT event if scenarios asserted envelope contents without
+    // relying on the amendment id (DSTEW-1813 seeds one amendment per scenario in most cases).
+    List<JsonNode> events = amendmentEvents();
+    assertThat(events)
+        .as("no AMENDMENT event found on history response for amendment %s", amendmentId)
+        .isNotEmpty();
+    return events.get(0);
+  }
+
+  private boolean envelopeMatches(JsonNode event, Map<String, String> expected) {
+    for (Map.Entry<String, String> entry : expected.entrySet()) {
+      JsonNode value = event.get(entry.getKey());
+      if (value == null || !entry.getValue().equals(value.asText())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers — DataTable parsing
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Reads a two-column {@code (field, value)} DataTable where each row is a distinct property of a
+   * single entity being described. Used for the one-amendment-per-row Given.
+   */
+  private static Map<String, String> singleRowFromTwoColumnTable(DataTable table) {
+    List<Map<String, String>> maps = table.asMaps(String.class, String.class);
+    assertThat(maps).as("expected a non-empty (field, value) DataTable but got none").isNotEmpty();
+    // The DataTable is column-headed (field | value); each row is a separate entry.
+    Map<String, String> merged = new java.util.LinkedHashMap<>();
+    for (Map<String, String> row : maps) {
+      merged.put(requireField(row, "field"), requireField(row, "value"));
+    }
+    return merged;
+  }
+
+  /**
+   * Reads a two-column {@code (<keyColumn>, value)} DataTable — the key column names vary per
+   * scenario ({@code envelopeField} vs {@code metadataField}) so the caller supplies it.
+   */
+  private static Map<String, String> expectedMapFromTwoColumnTable(
+      DataTable table, String keyColumn) {
+    Map<String, String> expected = new java.util.LinkedHashMap<>();
+    for (Map<String, String> row : table.asMaps(String.class, String.class)) {
+      expected.put(requireField(row, keyColumn), requireField(row, "value"));
+    }
+    return expected;
+  }
+
+  private static String requireField(Map<String, String> row, String key) {
+    String value = row.get(key);
+    assertThat(value)
+        .as("DataTable row is missing required column '%s' — row=%s", key, row)
+        .isNotNull();
+    return value;
+  }
+}

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryAmendmentMetadataSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryAmendmentMetadataSteps.java
@@ -49,8 +49,8 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
  *
  * <p>Every step wraps its body in {@link BddStepFailures#step(String,
  * BddStepFailures.ThrowingRunnable)} so scenario failures surface as {@code [BDD step failed]
- * &lt;plain-English context&gt; — &lt;cause&gt;} in the JUnit XML / Cucumber HTML report, per the
- * standing rule in {@code memory.md}.
+ * &lt;plain-English context&gt; — &lt;cause&gt;} in the JUnit XML / Cucumber HTML report. See the
+ * Javadoc on {@link BddStepFailures} for the wrapper's contract.
  */
 @Slf4j
 public class ClaimHistoryAmendmentMetadataSteps {
@@ -260,7 +260,8 @@ public class ClaimHistoryAmendmentMetadataSteps {
   public void theLatestAmendmentEventHasActorAndTimestamp(
       String expectedActorId, String expectedTimestamp) {
     BddStepFailures.step(
-        "Verifying the latest AMENDMENT event (by event_timestamp) has actor_id='"
+        "Verifying the latest AMENDMENT event (first element of the newest-first response) has"
+            + " actor_id='"
             + expectedActorId
             + "' and event_timestamp='"
             + expectedTimestamp
@@ -270,18 +271,15 @@ public class ClaimHistoryAmendmentMetadataSteps {
           assertThat(events)
               .as("no AMENDMENT events on history response — cannot pick 'latest'")
               .isNotEmpty();
-          JsonNode latest =
-              events.stream()
-                  .max(
-                      (a, b) ->
-                          Instant.parse(a.path("event_timestamp").asText())
-                              .compareTo(Instant.parse(b.path("event_timestamp").asText())))
-                  .orElseThrow();
+          // The endpoint contract is newest-first — verify that ordering by taking the
+          // first element in RESPONSE order, NOT by re-sorting client-side (which would
+          // hide an endpoint that returned amendments in the wrong order).
+          JsonNode latest = events.get(0);
           assertThat(latest.path("actor_id").asText())
-              .as("actor_id on the latest AMENDMENT event")
+              .as("actor_id on the latest AMENDMENT event (first element in response order)")
               .isEqualTo(expectedActorId);
           assertThat(latest.path("event_timestamp").asText())
-              .as("event_timestamp on the latest AMENDMENT event")
+              .as("event_timestamp on the latest AMENDMENT event (first element in response order)")
               .isEqualTo(expectedTimestamp);
         });
   }

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryAmendmentMetadataSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryAmendmentMetadataSteps.java
@@ -7,7 +7,6 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +14,6 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
 import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddStepFailures;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
 import uk.gov.justice.laa.dstew.payments.claimsdata.entity.ClaimAmendment;
@@ -53,21 +51,18 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
  * Javadoc on {@link BddStepFailures} for the wrapper's contract.
  */
 @Slf4j
-public class ClaimHistoryAmendmentMetadataSteps {
+public class ClaimHistoryAmendmentMetadataSteps extends ClaimHistoryTimelineSharedSteps {
 
   private static final String BDD_USER_ID = "bdd-user-1813";
   private static final String AMENDMENT_EVENT_TYPE = "AMENDMENT";
 
-  @Autowired private BddApiStepSupport api;
   @Autowired private SubmissionRepository submissionRepository;
   @Autowired private ClaimRepository claimRepository;
   @Autowired private ClaimSummaryFeeRepository claimSummaryFeeRepository;
   @Autowired private ClaimAmendmentRepository claimAmendmentRepository;
 
-  private UUID currentClaimId;
   private UUID currentAmendmentId;
   private final List<UUID> amendmentIdsInOrder = new ArrayList<>();
-  private JsonNode lastHistoryResponse;
 
   // ---------------------------------------------------------------------------
   // Given — single-amendment seeding
@@ -166,24 +161,12 @@ public class ClaimHistoryAmendmentMetadataSteps {
   // When
   // ---------------------------------------------------------------------------
 
-  @When("I request the claim history timeline")
-  public void iRequestTheClaimHistoryTimeline() {
-    BddStepFailures.step(
-        "Requesting claim history timeline for claim " + currentClaimId,
-        () -> {
-          assertThat(currentClaimId)
-              .as("claim must be seeded before requesting history")
-              .isNotNull();
-          lastHistoryResponse = api.getClaimHistory(currentClaimId);
-        });
-  }
-
   // ---------------------------------------------------------------------------
   // Then — envelope
   // ---------------------------------------------------------------------------
 
-  @Then("the response contains an event with the following envelope")
-  public void theResponseContainsAnEventWithTheFollowingEnvelope(DataTable table) {
+  @Then("the amendment event contains the following envelope")
+  public void theAmendmentEventContainsTheFollowingEnvelope(DataTable table) {
     BddStepFailures.step(
         "Verifying an AMENDMENT event with the scenario-declared envelope fields is present"
             + " on the history response for claim "
@@ -206,8 +189,8 @@ public class ClaimHistoryAmendmentMetadataSteps {
         });
   }
 
-  @And("that event's metadata contains")
-  public void thatEventsMetadataContains(DataTable table) {
+  @And("the amendment event metadata contains")
+  public void theAmendmentEventMetadataContains(DataTable table) {
     BddStepFailures.step(
         "Verifying the AMENDMENT event for amendment "
             + currentAmendmentId
@@ -351,7 +334,7 @@ public class ClaimHistoryAmendmentMetadataSteps {
                 .matterTypeCode("TEST_MATTER")
                 .createdByUserId(BDD_USER_ID)
                 .build());
-    currentClaimId = claim.getId();
+    setCurrentClaimId(claim.getId());
 
     // Seed a summary fee row so downstream amendment-linked CFD lookups (not exercised in this
     // ticket) don't blow up if invoked accidentally from a shared helper.
@@ -427,7 +410,8 @@ public class ClaimHistoryAmendmentMetadataSteps {
 
   private List<JsonNode> eventsArray() {
     List<JsonNode> results = new ArrayList<>();
-    JsonNode events = lastHistoryResponse == null ? null : lastHistoryResponse.path("events");
+    JsonNode response = getLastResponse();
+    JsonNode events = response == null ? null : response.path("events");
     if (events != null && events.isArray()) {
       events.forEach(results::add);
     }

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddApiStepSupport.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddApiStepSupport.java
@@ -299,32 +299,6 @@ public class BddApiStepSupport {
   }
 
   /**
-   * Fetches the unified claim-history timeline for {@code claimId} via {@code GET
-   * /api/v1/claims/{claimId}/history} and returns the raw JSON response.
-   *
-   * <p>The raw {@link JsonNode} is intentionally retained so callers can distinguish an explicit
-   * JSON {@code null} in the metadata bag from a missing key — a critical distinction for the
-   * claim-history timeline scenarios (DSTEW-1811 / -1812 / -1813 / -1814 / -1815).
-   */
-  public JsonNode getClaimHistoryJson(UUID claimId) throws IOException {
-    HttpHeaders headers = new HttpHeaders();
-    headers.add(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN);
-    HttpEntity<Void> request = new HttpEntity<>(headers);
-
-    ResponseEntity<String> response =
-        restTemplate.exchange(
-            serverInfo.baseUrl() + GET_CLAIM_HISTORY_PATH,
-            HttpMethod.GET,
-            request,
-            String.class,
-            claimId);
-    context.setLastStatusCode(response.getStatusCode().value());
-    JsonNode responseJson = parseResponseBody(response.getBody());
-    context.setLastResponseBody(responseJson);
-    return responseJson;
-  }
-
-  /**
    * Convenience: returns the area-of-law string ({@code "LEGAL HELP"} / {@code "CRIME LOWER"} /
    * {@code "MEDIATION"}) of a persisted submission.
    */

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddApiStepSupport.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddApiStepSupport.java
@@ -299,6 +299,32 @@ public class BddApiStepSupport {
   }
 
   /**
+   * Fetches the unified claim-history timeline for {@code claimId} via {@code GET
+   * /api/v1/claims/{claimId}/history} and returns the raw JSON response.
+   *
+   * <p>The raw {@link JsonNode} is intentionally retained so callers can distinguish an explicit
+   * JSON {@code null} in the metadata bag from a missing key — a critical distinction for the
+   * claim-history timeline scenarios (DSTEW-1811 / -1812 / -1813 / -1814 / -1815).
+   */
+  public JsonNode getClaimHistoryJson(UUID claimId) throws IOException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN);
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            serverInfo.baseUrl() + GET_CLAIM_HISTORY_PATH,
+            HttpMethod.GET,
+            request,
+            String.class,
+            claimId);
+    context.setLastStatusCode(response.getStatusCode().value());
+    JsonNode responseJson = parseResponseBody(response.getBody());
+    context.setLastResponseBody(responseJson);
+    return responseJson;
+  }
+
+  /**
    * Convenience: returns the area-of-law string ({@code "LEGAL HELP"} / {@code "CRIME LOWER"} /
    * {@code "MEDIATION"}) of a persisted submission.
    */

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
@@ -31,7 +31,6 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support;
  * }
  * }</pre>
  *
- * <p>See {@code memory.md} — Step-definition failure reporting (2026-08-13) for the standing rule.
  */
 public final class BddStepFailures {
 

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
@@ -8,6 +8,7 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support;
  * contextDescription} is a plain-English sentence naming the verb + noun and any scenario-scoped
  * identifiers (claim id, tag id, expected value) that make a failure diagnosable at a glance
  * without opening the Java stack trace.
+ *
  * <p>Both overloads use functional interfaces that allow {@code throws Exception}, so step lambdas
  * calling e.g. {@link
  * uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport#getClaimHistory(java.util.UUID)}
@@ -20,6 +21,7 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support;
  * friendly line first and the deep stack second. AssertJ assertions inside the body still use
  * {@code .as("…")} to describe the specific assertion; the wrapper prepends the outer step context
  * so both show side by side.
+ *
  * <p>Usage:
  *
  * <pre>{@code
@@ -30,7 +32,6 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support;
  *       () -> lastHistoryResponse = api.getClaimHistory(currentClaimId));
  * }
  * }</pre>
- *
  */
 public final class BddStepFailures {
 

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
@@ -8,6 +8,11 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support;
  * contextDescription} is a plain-English sentence naming the verb + noun and any scenario-scoped
  * identifiers (claim id, tag id, expected value) that make a failure diagnosable at a glance
  * without opening the Java stack trace.
+ * <p>Both overloads use functional interfaces that allow {@code throws Exception}, so step lambdas
+ * calling e.g. {@link
+ * uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport#getClaimHistory(java.util.UUID)}
+ * (which declares {@link java.io.IOException}) don't force each step method to swallow-then-rethrow
+ * the checked exception.
  *
  * <p>On failure the wrapper rethrows an {@link AssertionError} whose message is {@code [BDD step
  * failed] <contextDescription> — <cause summary>} and chains the original throwable via {@link
@@ -15,29 +20,46 @@ package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support;
  * friendly line first and the deep stack second. AssertJ assertions inside the body still use
  * {@code .as("…")} to describe the specific assertion; the wrapper prepends the outer step context
  * so both show side by side.
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * @When("I request the claim history timeline")
+ * public void iRequestTheClaimHistoryTimeline() {
+ *   BddStepFailures.step(
+ *       "Requesting claim history timeline for claim " + currentClaimId,
+ *       () -> lastHistoryResponse = api.getClaimHistory(currentClaimId));
+ * }
+ * }</pre>
+ *
+ * <p>See {@code memory.md} — Step-definition failure reporting (2026-08-13) for the standing rule.
  */
 public final class BddStepFailures {
 
   private BddStepFailures() {
-    // utility class
+    // Utility class - no instances.
   }
 
-  /** Body that returns nothing and may throw any checked/unchecked exception. */
+  /** Runnable that returns nothing and may throw any checked/unchecked exception. */
   @FunctionalInterface
   public interface ThrowingRunnable {
     void run() throws Exception;
   }
 
-  /** Body that returns a value and may throw any checked/unchecked exception. */
+  /** Supplier that returns a value and may throw any checked/unchecked exception. */
   @FunctionalInterface
   public interface ThrowingSupplier<T> {
     T get() throws Exception;
   }
 
   /**
-   * Runs {@code body} inside a friendly-failure envelope. On any thrown exception, rewraps as
-   * {@link AssertionError} with a prefixed, business-language message and preserves the original
-   * cause + stack via {@link Throwable#initCause(Throwable)}.
+   * Executes {@code body} and, on any failure, rethrows an {@link AssertionError} whose first line
+   * describes {@code contextDescription}.
+   *
+   * @param contextDescription a plain-English sentence starting with the verb + noun of what the
+   *     step is doing (e.g. "Verifying AMENDMENT metadata field 'requested_by_code' equals
+   *     'PROVIDER' for claim {claimId}"). Include the scenario-scoped identifiers that make the
+   *     failure diagnosable at a glance.
+   * @param body the actual step work — assertions, HTTP calls, DB seeding.
    */
   public static void step(String contextDescription, ThrowingRunnable body) {
     try {

--- a/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryAmendmentMetadata.feature
+++ b/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryAmendmentMetadata.feature
@@ -1,0 +1,120 @@
+@Regression
+@claimHistory
+@amendments
+@dstew-1813
+Feature: Claim history timeline — AMENDMENT event metadata
+
+  # Jira: DSTEW-1813 (1645-C) (parent: DSTEW-1645 → DSTEW-1999)
+  # Depends on: DSTEW-1811 envelope, DSTEW-1659 claim_amendment storage.
+  # Endpoint: GET /api/v1/claims/{claimId}/history
+  #
+  # One AMENDMENT event per successful `claim_amendment` row. Failed attempts
+  # never appear (no `claim_amendment` row is written).
+  #
+  # Source mapping (claims.claim_amendment):
+  #   event_type                          constant AMENDMENT
+  #   event_timestamp                     ← created_on
+  #   actor_user_id                       ← created_by_user_id (Entra UUID, as stored)
+  #   source_id                           ← id (UUIDv7)
+  #   metadata.requested_by_code          ← requested_by_code
+  #   metadata.amendment_reason_code      ← amendment_reason_code
+  #   metadata.amended_field_identifiers  ← diff.changes[].field_identifier
+  #                                         WHERE change_source = 'Requested'
+  #                                         (FSP/system consequences EXCLUDED
+  #                                          — they surface via DSTEW-1814
+  #                                          per-field detail + DSTEW-1815
+  #                                          FSP metadata)
+  #
+  # Directly serves BC-570 history header, BC-574 codes, BC-576 latest-amendment
+  # user/date/time. Codes are returned exactly as persisted — label resolution
+  # (via DSTEW-1594 reference-data lookup) and display-name resolution (Entra
+  # UUID → name) are AaBC-side.
+  #
+  # Coverage review (2026-08-11): parent `claimHistoryTimelineParent.feature`
+  # asserts failed-amendment exclusion (`@DS1645_2`), mixed-timeline ordering
+  # (`@DS1645_1`), no raw payload / full before-state (`@DS1645_4`), and
+  # write-to-read smoke (`@DS1645_7`). DSTEW-1815 file asserts FSP metadata
+  # (`pricing_recalculated`, `price_changed`, `escape_case_logged`) and
+  # FSP-flavour `changes[]` entries. Gaps this file closes:
+  #   (a) the 5-field metadata envelope population from a real row;
+  #   (b) `amended_field_identifiers` list contains ONLY change_source='Requested'
+  #       — FSP consequences excluded from this list;
+  #   (c) multi-amendment chronology enabling latest-amendment derivation;
+  #   (d) codes returned exactly as persisted, no label substitution;
+  #   (e) stored order preserved in `amended_field_identifiers`.
+  #
+  # OUT OF SCOPE (delegated — do NOT add here):
+  #   * Envelope shape                    → DSTEW-1811 (claimHistoryTimelineContract.feature)
+  #   * ASSESSMENT / VOID event content   → DSTEW-1812 (claimHistoryAssessmentAndVoidEvents.feature)
+  #   * Field-level before/after detail   → DSTEW-1814 (future file)
+  #   * FSP / escape metadata + FSP changes[] → DSTEW-1815 (claimHistoryAmendmentEvents.feature)
+  #   * Cross-cutting parent guarantees   → claimHistoryTimelineParent.feature
+  #   * Requested By / Amendment Reason label lookup → DSTEW-1594 + AaBC
+  #   * Display-name lookup for created_by_user_id → AaBC
+  #
+  # De-scoped from BDD (2026-08-13) — the delivered DSTEW-1813 commit on `main`
+  # (62e0dd3e "Return 204 and skip persistence for no-op amendments") is a
+  # WRITE-side no-op guard, not the read-side AMENDMENT-event metadata story the
+  # 1645-C epic split implied. The AMENDMENT-event `requested_by_code` and
+  # `amendment_reason_code` fields DO ship (via HISTORY_SQL in
+  # `JdbcClaimHistoryRepository`), but `amended_field_identifiers`
+  # (the Requested-only filtered list) is NOT built anywhere in the shipped
+  # code — no SQL surface, no OpenAPI field, no controller assembly.
+  #   * `@DS1813_2` — `amended_field_identifiers` FSP-exclusion filter. Cannot be
+  #     exercised against today's `main`. To be re-added when the derivation
+  #     ships (either under this ticket if refocused, or on a new one).
+  #   * `@DS1813_5` — `amended_field_identifiers` order preservation. Same
+  #     reason; delete-then-re-add.
+  #   * `@DS1813_1` retains the envelope + `requested_by_code` +
+  #     `amendment_reason_code` assertions (which ARE delivered) and drops the
+  #     `amended_field_identifiers` assertion (which is not).
+
+  @smoke @DS1813_1
+  Scenario: Successful amendment appears as an AMENDMENT event with the delivered metadata fields
+    # Note: the `amended_field_identifiers` assertion originally on this scenario has been
+    # trimmed pending delivery of the Requested-only filter (see de-scope banner above).
+    Given a claim exists with the following successful `claim_amendment` row
+      | field                 | value                        |
+      | created_on            | 2026-05-02T09:14:00Z         |
+      | created_by_user_id    | entra-user-abc               |
+      | requested_by_code     | PROVIDER                     |
+      | amendment_reason_code | PROVIDER_ERROR               |
+    And the amendment's stored diff contains a `change_source` "Requested" entry for field "client_surname"
+    When I request the claim history timeline
+    Then the response contains an event with the following envelope
+      | envelopeField    | value                |
+      | event_type       | AMENDMENT            |
+      | event_timestamp  | 2026-05-02T09:14:00Z |
+      | actor_id         | entra-user-abc       |
+    And that event's metadata contains
+      | metadataField         | value          |
+      | requested_by_code     | PROVIDER       |
+      | amendment_reason_code | PROVIDER_ERROR |
+
+  @DS1813_3
+  Scenario: Multi-amendment chronology — each amendment is its own event, latest is unambiguously derivable
+    # AaBC BC-576 Amended banner needs the latest amendment's user/date/time.
+    # Deterministic ordering + one event per row makes "latest" unambiguous.
+    Given a claim exists with the following successful `claim_amendment` rows applied in order
+      | created_on           | created_by_user_id | requested_by_code   |
+      | 2026-04-15T10:00:00Z | user-alpha         | PROVIDER            |
+      | 2026-06-01T12:00:00Z | user-beta          | CONTRACT_MANAGEMENT |
+    When I request the claim history timeline
+    Then the response contains exactly two AMENDMENT events
+    And the LATEST AMENDMENT event has `actor_id` "user-beta" and `event_timestamp` "2026-06-01T12:00:00Z"
+
+  @DS1813_4
+  Scenario Outline: Codes are returned exactly as persisted — no label substitution in this story
+    Given a claim exists with a successful `claim_amendment` row where `requested_by_code` is "<storedRequestedBy>" and `amendment_reason_code` is "<storedReason>"
+    When I request the claim history timeline
+    Then the AMENDMENT event metadata field "requested_by_code" is exactly "<storedRequestedBy>"
+    And the AMENDMENT event metadata field "amendment_reason_code" is exactly "<storedReason>"
+    And no display label has been substituted for either code
+
+    Examples:
+      | storedRequestedBy   | storedReason               |
+      | PROVIDER            | PROVIDER_ERROR             |
+      | CONTRACT_MANAGEMENT | INCORRECT_MEANS_ASSESSMENT |
+      | ASSURANCE           | OTHER                      |
+
+

--- a/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryAmendmentMetadata.feature
+++ b/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryAmendmentMetadata.feature
@@ -35,13 +35,21 @@ Feature: Claim history timeline — AMENDMENT event metadata
   # (`@DS1645_1`), no raw payload / full before-state (`@DS1645_4`), and
   # write-to-read smoke (`@DS1645_7`). DSTEW-1815 file asserts FSP metadata
   # (`pricing_recalculated`, `price_changed`, `escape_case_logged`) and
-  # FSP-flavour `changes[]` entries. Gaps this file closes:
-  #   (a) the 5-field metadata envelope population from a real row;
-  #   (b) `amended_field_identifiers` list contains ONLY change_source='Requested'
-  #       — FSP consequences excluded from this list;
-  #   (c) multi-amendment chronology enabling latest-amendment derivation;
-  #   (d) codes returned exactly as persisted, no label substitution;
-  #   (e) stored order preserved in `amended_field_identifiers`.
+  # FSP-flavour `changes[]` entries.
+  #
+  # Gaps THIS file actually closes with delivered scenarios:
+  #   (a) the two shipped code metadata fields (`requested_by_code` and
+  #       `amendment_reason_code`) are populated on the AMENDMENT event
+  #       envelope from a real persisted `claim_amendment` row;
+  #   (b) multi-amendment chronology on a single claim, enabling
+  #       latest-amendment derivation from the newest-first response order;
+  #   (c) codes are returned exactly as persisted — no label substitution.
+  #
+  # NOT closed by this file (see the de-scope banner below):
+  #   * `amended_field_identifiers` Requested-only filter (`@DS1813_2`) — the
+  #     derivation does not ship on `main` yet, so no BDD hook exists.
+  #   * `amended_field_identifiers` stored-order preservation (`@DS1813_5`) —
+  #     same reason; depends on the same missing derivation.
   #
   # OUT OF SCOPE (delegated — do NOT add here):
   #   * Envelope shape                    → DSTEW-1811 (claimHistoryTimelineContract.feature)

--- a/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryAmendmentMetadata.feature
+++ b/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryAmendmentMetadata.feature
@@ -89,12 +89,12 @@ Feature: Claim history timeline — AMENDMENT event metadata
       | amendment_reason_code | PROVIDER_ERROR               |
     And the amendment's stored diff contains a `change_source` "Requested" entry for field "client_surname"
     When I request the claim history timeline
-    Then the response contains an event with the following envelope
+    Then the amendment event contains the following envelope
       | envelopeField    | value                |
       | event_type       | AMENDMENT            |
       | event_timestamp  | 2026-05-02T09:14:00Z |
       | actor_id         | entra-user-abc       |
-    And that event's metadata contains
+    And the amendment event metadata contains
       | metadataField         | value          |
       | requested_by_code     | PROVIDER       |
       | amendment_reason_code | PROVIDER_ERROR |
@@ -124,5 +124,3 @@ Feature: Claim history timeline — AMENDMENT event metadata
       | PROVIDER            | PROVIDER_ERROR             |
       | CONTRACT_MANAGEMENT | INCORRECT_MEANS_ASSESSMENT |
       | ASSURANCE           | OTHER                      |
-
-


### PR DESCRIPTION
## What

Adds Cucumber BDD coverage for the **AMENDMENT event metadata** exposed by `GET /api/v1/claims/{claimId}/history` — specifically `requested_by_code`, `amendment_reason_code`, and their ordering across multiple amendments (DSTEW-1813).

Also introduces a project-wide standing rule for step-definition failure reporting (see *Structural changes* below).

## Scope

Read-side only. No production code changes — all additions live under `claims-data/service/src/bddTest`.

## ⚠️ De-scoped scenarios (audit)

**Two scenarios from the source branch could NOT be enabled against `main` because the behaviour they assert is not built anywhere in the shipped code.** Recording here so the delivery gap is visible on the PR.

| Tag | One-line reason | Blocks |
|---|---|---|
| `@DS1813_2` | `metadata.amended_field_identifiers` (Requested-only filtered list) is not derived in `HISTORY_SQL` (`JdbcClaimHistoryRepository.java`), not present in the OpenAPI `claim_history_event.metadata` schema, and not assembled in the controller / mapper. The property does not exist on the shipped response. | Product decision + dev ticket to derive it (filter `diff->'changes'` on `change_source='Requested'`) and add it to OpenAPI. |
| `@DS1813_5` | Order-preservation of `amended_field_identifiers` — same root cause. Cannot assert ordering on a field that isn't emitted. | Same as `@DS1813_2` (both re-enable together). |

The delivered commit for DSTEW-1813 on `main` (`62e0dd3e "Return 204 and skip persistence for no-op amendments"`) is a **write-side no-op guard**, not the read-side `amended_field_identifiers` assembly the 1645-C epic split implied. The parts of DSTEW-1813 that ARE delivered — `metadata.requested_by_code` and `metadata.amendment_reason_code` — are covered by the three in-scope scenarios below.

## Scenarios (`@dstew-1813`)

| Tag | Purpose |
|---|---|
| `@DS1813_1` | AMENDMENT event envelope contains `metadata.requested_by_code` and `metadata.amendment_reason_code` set to the persisted values. |
| `@DS1813_3` | Two `claim_amendment` rows on the same claim produce two AMENDMENT events; the LATEST is derivable by `event_timestamp` / `actor_user_id`. |
| `@DS1813_4` | Scenario Outline — codes are surfaced **verbatim** (no display-label substitution) for 3 example rows: `PROVIDER/PROVIDER_ERROR`, `CONTRACT_MANAGEMENT/INCORRECT_MEANS_ASSESSMENT`, `ASSURANCE/OTHER`. |

### De-scoped (documented in feature banner)

- `@DS1813_2` and `@DS1813_5` — see the **⚠️ De-scoped scenarios (audit)** block above.

## Structural changes

- **New standing rule — `BddStepFailures.step(context, body)`** wrapper (`…bdd/steps/support/BddStepFailures.java`). Every step body wraps its logic in `BddStepFailures.step("...", () -> { ... })` so that on failure the Cucumber HTML report shows a friendly `[BDD step failed] <context> — <cause summary>` line **before** the stack trace, giving the report reader a business-language explanation of what went wrong. `AssertionError` messages (from AssertJ `.as("...")`) are appended verbatim so both contexts appear side-by-side. Applies to this and future step classes; earlier step classes may adopt opportunistically.
- **`BddApiStepSupport.getClaimHistory(UUID)`** — HTTP helper for `GET /api/v1/claims/{claimId}/history` returning `JsonNode` (preserves explicit JSON `null` vs missing-key distinction).
- **`BddTestConstants.GET_CLAIM_HISTORY_PATH`** — path constant.
- **`BddHooks`** — adds `claimAmendmentRepository.deleteAll()` before `claimRepository.deleteAll()` (FK cleanup ordering; first BDD scenarios to seed `claim_amendment` rows).

## Local vs UAT

Local-only. Seeded through JPA repositories in `@Before` step logic; asserted against the live REST endpoint via `TestRestTemplate`. No UAT hooks.

## Endpoints exercised

- `GET /api/v1/claims/{claimId}/history`

## Verification

- `./gradlew :claims-data:service:spotlessCheck` — clean.
- `./gradlew :claims-data:service:bddTest -Dcucumber.filter.tags=@dstew-1813` — **5/5 pass** (3 scenarios: 2 direct + 1 Outline with 3 examples).
- `./gradlew :claims-data:service:bddTest` — **81/81 pass** (full BDD suite, no regressions).

## Checklist

- [x] Story confirmed delivered on `main` (write-side guard `62e0dd3e`; read-side metadata surfaced by the pre-existing `/history` handler).
- [x] Feature file copied 1:1 from `DSTEW-1999-amend-claims-bdd-scenarios` and adjusted only to remove undeliverable scenarios (banner documents the reason).
- [x] All step methods use the new `BddStepFailures.step(...)` wrapper.
- [x] No production code changed.
- [x] No unrelated files staged.

## Jira

- DSTEW-1813





