### PR TITLE
fix(DSTEW-2140): Map isAmended is claim responses

### DIFF
--- a/claims-data/service/build.gradle
+++ b/claims-data/service/build.gradle
@@ -77,8 +77,8 @@ dependencyManagement {
 
 dependencies {
     implementation project(':claims-data:api')
-    implementation 'uk.gov.justice.laa.dstew.payments.claims.validation:claims-validation-core:1.4.0'
-    implementation 'uk.gov.justice.laa.dstew.payments.claims.validation:reference-fee-scheme-platform-api:1.4.0'
+    implementation 'uk.gov.justice.laa.dstew.payments.claims.validation:claims-validation-core:1.4.4'
+    implementation 'uk.gov.justice.laa.dstew.payments.claims.validation:reference-fee-scheme-platform-api:1.4.4'
 
     implementation 'uk.gov.justice.service.laa:laa-spring-boot-starter-auth'
     implementation 'uk.gov.justice.service.laa:laa-spring-boot-starter-sql-scanner'

--- a/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimControllerIntegrationTest.java
+++ b/claims-data/service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/ClaimControllerIntegrationTest.java
@@ -469,6 +469,13 @@ public class ClaimControllerIntegrationTest extends AbstractIntegrationTest {
   @DisplayName("GET /claims - returns claims for office code and unique file reference")
   void shouldReturnAllClaimsForAGivenOfficeCodeAndUniqueFileReference() throws Exception {
     // given: required claims exist in the database
+    var amendedClaim =
+        claimRepository
+            .findById(CLAIM_2_ID)
+            .orElseThrow(() -> new RuntimeException("Claim not found for fixture setup"));
+    amendedClaim.setHasAssessment(true);
+    amendedClaim.setAmended(true);
+    claimRepository.saveAndFlush(amendedClaim);
 
     // when: calling the GET endpoint to retrieve all claims for an office_code and a unique file
     // number
@@ -487,7 +494,10 @@ public class ClaimControllerIntegrationTest extends AbstractIntegrationTest {
     var claimResultSet = OBJECT_MAPPER.readValue(responseBody, ClaimResultSet.class);
     assertThat(claimResultSet.getTotalElements()).isEqualTo(1);
     assertThat(claimResultSet.getContent()).hasSize(1);
-    assertThat(claimResultSet.getContent().getFirst().getId()).isEqualTo(CLAIM_2_ID.toString());
+    var claimResponse = claimResultSet.getContent().getFirst();
+    assertThat(claimResponse.getId()).isEqualTo(CLAIM_2_ID.toString());
+    assertThat(claimResponse.getHasAssessment()).isTrue();
+    assertThat(claimResponse.getIsAmended()).isTrue();
   }
 
   @Test
@@ -567,6 +577,13 @@ public class ClaimControllerIntegrationTest extends AbstractIntegrationTest {
   @DisplayName("GET /api/v2/claims - returns claims for office code and unique file reference (v2)")
   void shouldReturnAllClaimsForAGivenOfficeCodeAndUniqueFileReferenceV2() throws Exception {
     // given: required claims exist in the database
+    var amendedClaim =
+        claimRepository
+            .findById(CLAIM_2_ID)
+            .orElseThrow(() -> new RuntimeException("Claim not found for fixture setup"));
+    amendedClaim.setHasAssessment(false);
+    amendedClaim.setAmended(true);
+    claimRepository.saveAndFlush(amendedClaim);
 
     // when: calling the GET endpoint to retrieve all claims for an office_code and a unique file
     // number
@@ -585,7 +602,10 @@ public class ClaimControllerIntegrationTest extends AbstractIntegrationTest {
     var claimResultSet = OBJECT_MAPPER.readValue(responseBody, ClaimResultSetV2.class);
     assertThat(claimResultSet.getTotalElements()).isEqualTo(1);
     assertThat(claimResultSet.getContent()).hasSize(1);
-    assertThat(claimResultSet.getContent().getFirst().getId()).isEqualTo(CLAIM_2_ID.toString());
+    var claimResponse = claimResultSet.getContent().getFirst();
+    assertThat(claimResponse.getId()).isEqualTo(CLAIM_2_ID.toString());
+    assertThat(claimResponse.getHasAssessment()).isFalse();
+    assertThat(claimResponse.getIsAmended()).isTrue();
   }
 
   @Test

--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapper.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapper.java
@@ -51,12 +51,14 @@ public interface ClaimMapper {
    */
   @Mapping(target = "isDutySolicitor", source = "dutySolicitor")
   @Mapping(target = "isYouthCourt", source = "youthCourt")
+  @Mapping(target = "isAmended", source = "amended")
   @Mapping(target = "submissionId", source = "submission.id")
   @Mapping(target = "submissionPeriod", source = "submission.submissionPeriod")
   ClaimResponse toClaimResponse(Claim entity);
 
   @Mapping(target = "isDutySolicitor", source = "dutySolicitor")
   @Mapping(target = "isYouthCourt", source = "youthCourt")
+  @Mapping(target = "isAmended", source = "amended")
   @Mapping(target = "submissionId", source = "submission.id")
   @Mapping(target = "submissionPeriod", source = "submission.submissionPeriod")
   @Mapping(target = "dateSubmitted", source = "submission.createdOn")

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/mapper/ClaimMapperTest.java
@@ -146,6 +146,8 @@ class ClaimMapperTest {
             .mediationTimeMinutes(90)
             .outreachLocation("OUTLOC")
             .referralSource("REFSRC")
+            .hasAssessment(true)
+            .isAmended(false)
             .submission(Submission.builder().id(submissionId).submissionPeriod("APR-2025").build())
             .build();
 
@@ -184,6 +186,8 @@ class ClaimMapperTest {
     assertEquals(entity.getMediationTimeMinutes(), fields.getMediationTimeMinutes());
     assertEquals(entity.getOutreachLocation(), fields.getOutreachLocation());
     assertEquals(entity.getReferralSource(), fields.getReferralSource());
+    assertEquals(entity.isHasAssessment(), fields.getHasAssessment());
+    assertEquals(entity.isAmended(), fields.getIsAmended());
     assertEquals(entity.getSubmission().getId().toString(), fields.getSubmissionId());
     assertEquals(entity.getSubmission().getSubmissionPeriod(), fields.getSubmissionPeriod());
   }
@@ -221,6 +225,8 @@ class ClaimMapperTest {
             .mediationTimeMinutes(90)
             .outreachLocation("OUTLOC")
             .referralSource("REFSRC")
+            .hasAssessment(false)
+            .isAmended(true)
             .claimSummaryFee(new ArrayList<>())
             .submission(
                 Submission.builder()
@@ -270,6 +276,8 @@ class ClaimMapperTest {
     assertEquals(entity.getMediationTimeMinutes(), fields.getMediationTimeMinutes());
     assertEquals(entity.getOutreachLocation(), fields.getOutreachLocation());
     assertEquals(entity.getReferralSource(), fields.getReferralSource());
+    assertEquals(entity.isHasAssessment(), fields.getHasAssessment());
+    assertEquals(entity.isAmended(), fields.getIsAmended());
     assertEquals(entity.getSubmission().getId().toString(), fields.getSubmissionId());
     assertEquals(entity.getSubmission().getSubmissionPeriod(), fields.getSubmissionPeriod());
     assertEquals(entity.getSubmission().getCreatedOn(), fields.getDateSubmitted().toInstant());
@@ -329,6 +337,8 @@ class ClaimMapperTest {
     assertEquals(expectedDerived, response.getDerivedClaimStatus());
     // ...and the raw processing status is left untouched.
     assertEquals(status, response.getStatus());
+    assertEquals(hasAssessment, response.getHasAssessment());
+    assertEquals(isAmended, response.getIsAmended());
   }
 
   @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2140)

isAmended need to be manually mapped in MapStruct because its getter does not follow a format that MapStruct can automatically map (i.e. it has isAmended as it's getting but MapStruct would need getIsAmended)

Also bumped validation package version as now that the value is populated it needs to be ignored in claim schema validation

> **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/)** (e.g. `feat(DSTEW-XXX): add outcome validation`).\
> It is linted in CI and drives the release version bump.\
> Allowed types: `feat`, `fix`, `chore`, `refactor`, `test`, `spike`, `docs`, `ci`, `infra`.\
> Version bump: `feat` → minor; any type followed by `!` or a `BREAKING CHANGE` footer → major; every other type (`fix`, `chore`, `refactor`, `test`, `spike`, `docs`, `ci`, `infra`) → patch.

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
