### PR TITLE
test(DSTEW-1811): BDD scenarios for claim history timeline envelope + SUBMISSION event

### DIFF
--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/config/BddTestConstants.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/config/BddTestConstants.java
@@ -135,4 +135,7 @@ public final class BddTestConstants {
 
   /** {@code POST /api/v1/submissions}. */
   public static final String CREATE_SUBMISSION_PATH = API_URI_PREFIX + "/submissions";
+
+  /** {@code GET /api/v1/claims/{claimId}/history}. */
+  public static final String GET_CLAIM_HISTORY_PATH = API_URI_PREFIX + "/claims/{claimId}/history";
 }

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/config/BddTestConstants.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/config/BddTestConstants.java
@@ -136,6 +136,9 @@ public final class BddTestConstants {
   /** {@code POST /api/v1/submissions}. */
   public static final String CREATE_SUBMISSION_PATH = API_URI_PREFIX + "/submissions";
 
+  /** {@code GET /api/v1/claims/{claimId}}. */
+  public static final String GET_CLAIM_PATH = API_URI_PREFIX + "/claims/{claimId}";
+
   /** {@code GET /api/v1/claims/{claimId}/history}. */
-  public static final String GET_CLAIM_HISTORY_PATH = API_URI_PREFIX + "/claims/{claimId}/history";
+  public static final String GET_CLAIM_HISTORY_PATH = GET_CLAIM_PATH + "/history";
 }

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryTimelineContractSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryTimelineContractSteps.java
@@ -1,0 +1,525 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.GET_CLAIM_HISTORY_PATH;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddStepFailures.step;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.AUTHORIZATION_HEADER;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.util.ClaimsDataTestUtil.AUTHORIZATION_TOKEN;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.BddBeansConfiguration.BddServerInfo;
+import uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddApiStepSupport;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Claim;
+import uk.gov.justice.laa.dstew.payments.claimsdata.entity.Submission;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.ClaimRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.repository.SubmissionRepository;
+import uk.gov.justice.laa.dstew.payments.claimsdata.util.Uuid7;
+
+/**
+ * Step glue for {@code claimHistoryTimelineContract.feature} — DSTEW-1811 (1645-A).
+ *
+ * <p>Owns the envelope + SUBMISSION-event contract for {@code GET
+ * /api/v1/claims/{claimId}/history}. Seeds {@code Submission → Claim} directly via JPA (with
+ * native-SQL {@code UPDATE claim SET created_on = ...} because {@code Claim.createdOn} is
+ * {@code @CreationTimestamp} + {@code updatable = false} on delivered {@code main}), then hits the
+ * real REST endpoint via {@link BddApiStepSupport}.
+ *
+ * <p>Note on the SUBMISSION event's {@code source_id}: the delivered SQL emits {@code c.id AS
+ * source_id} (i.e. the claim id), not the submission id. Feature-file labels like {@code
+ * "sub-uuid-1"} are therefore bound to the seeded claim's UUID so scenario assertions match the
+ * emitted response.
+ *
+ * <p>Every step body wraps its logic in {@link
+ * uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddStepFailures#step(String,
+ * uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support.BddStepFailures.ThrowingRunnable)}
+ * per the project-wide step-failure-reporting standing rule.
+ */
+public class ClaimHistoryTimelineContractSteps {
+
+  /**
+   * Fields the feature file allows on the SUBMISSION event's {@code metadata} bag. Guards the "no
+   * leakage of submission-only fields outside metadata onto the envelope" assertion (@DS1811_4).
+   */
+  private static final Set<String> SUBMISSION_METADATA_FIELDS =
+      new HashSet<>(Arrays.asList("submission_period", "office_account_number", "area_of_law"));
+
+  /** Fields the envelope is allowed to expose. */
+  private static final Set<String> ENVELOPE_FIELDS =
+      new HashSet<>(
+          Arrays.asList("event_type", "event_timestamp", "actor_id", "source_id", "metadata"));
+
+  @Autowired private SubmissionRepository submissionRepository;
+  @Autowired private ClaimRepository claimRepository;
+  @Autowired private JdbcClient jdbcClient;
+  @Autowired private BddApiStepSupport api;
+  @Autowired private RestTemplate restTemplate;
+  @Autowired private BddServerInfo serverInfo;
+
+  private UUID currentClaimId;
+  private JsonNode lastResponse;
+  private int lastStatusCode;
+  private String lastResponseBody;
+
+  private final Map<String, UUID> labelToUuid = new HashMap<>();
+
+  /**
+   * Pending overrides captured by the {@code And the parent submission has the following stored
+   * values} step. Applied inside {@link #applyPendingSubmissionOverrides()} after the claim is
+   * seeded so we can pin values that the delivered SQL will actually surface (claim.created_on,
+   * claim.created_by_user_id, claim.id — plus submission's period / office / area).
+   */
+  private Map<String, String> pendingSubmissionValues = new HashMap<>();
+
+  // ---------------------------------------------------------------------------
+  // Givens.
+  // ---------------------------------------------------------------------------
+
+  @Given("a claim exists that has been submitted but never amended, assessed or voided")
+  @Transactional
+  public void aClaimExistsThatHasBeenSubmittedOnly() {
+    step(
+        "seed a claim (with parent submission) that has no amendments, assessments, or voids",
+        this::seedClaim);
+  }
+
+  @And("the parent submission has the following stored values")
+  @Transactional
+  public void theParentSubmissionHasStoredValues(DataTable table) {
+    step(
+        "override submission + claim columns to match the feature-file 'stored values' table",
+        () -> {
+          pendingSubmissionValues = singleFieldValueMap(table);
+          applyPendingSubmissionOverrides();
+        });
+  }
+
+  @Given("no claim exists for claim id {string}")
+  public void noClaimExistsForClaimId(String claimIdString) {
+    step(
+        "register the unknown-claim label and confirm the row is absent",
+        () -> {
+          UUID claimId = UUID.fromString(claimIdString);
+          currentClaimId = claimId;
+          // Sanity-check the row genuinely doesn't exist. If it somehow does, fail fast with a
+          // clear message rather than letting the /history call succeed and confuse the assertion.
+          if (claimRepository.existsById(claimId)) {
+            throw new AssertionError(
+                "Expected no claim for id "
+                    + claimId
+                    + " but one exists — BddHooks cleanup may not be running.");
+          }
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // When.
+  // ---------------------------------------------------------------------------
+
+  @When("I request the claim history timeline")
+  public void iRequestTheClaimHistoryTimeline() {
+    step(
+        "GET /api/v1/claims/" + currentClaimId + "/history (expect 2xx)",
+        () -> {
+          lastResponse = api.getClaimHistory(requireCurrentClaimId());
+          lastStatusCode = 200;
+          lastResponseBody = lastResponse.toString();
+        });
+  }
+
+  @When("I request the claim history timeline for that claim id")
+  public void iRequestTheClaimHistoryTimelineForThatClaimId() {
+    step(
+        "GET /api/v1/claims/" + currentClaimId + "/history (expect a not-found response)",
+        () -> {
+          // The endpoint throws ClaimNotFoundException → framework maps to 404. RestTemplate turns
+          // 4xx into HttpStatusCodeException, so we capture status + body without letting the
+          // exception propagate.
+          HttpHeaders headers = new HttpHeaders();
+          headers.add(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN);
+          try {
+            ResponseEntity<String> response =
+                restTemplate.exchange(
+                    serverInfo.baseUrl() + GET_CLAIM_HISTORY_PATH,
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    String.class,
+                    requireCurrentClaimId());
+            lastStatusCode = response.getStatusCode().value();
+            lastResponseBody = response.getBody();
+          } catch (HttpStatusCodeException ex) {
+            HttpStatusCode status = ex.getStatusCode();
+            lastStatusCode = status.value();
+            lastResponseBody = ex.getResponseBodyAsString();
+          }
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Thens — happy-path timeline (@DS1811_1, @DS1811_4).
+  // ---------------------------------------------------------------------------
+
+  @Then("the response contains exactly one event")
+  public void theResponseContainsExactlyOneEvent() {
+    step(
+        "assert /history timeline contains exactly one event",
+        () -> {
+          JsonNode events = requireEventsArray();
+          assertThat(events.size()).as("number of events on timeline").isEqualTo(1);
+        });
+  }
+
+  @Then("that event matches the following common envelope")
+  public void thatEventMatchesTheFollowingEnvelope(DataTable table) {
+    step(
+        "assert the single event's envelope matches the feature-file table",
+        () -> {
+          JsonNode event = requireEventsArray().get(0);
+          Map<String, String> expected = envelopeMap(table);
+          assertEnvelopeFieldEquals(event, "event_type", expected.get("event_type"));
+          if (expected.containsKey("event_timestamp")) {
+            assertTimestamp(event, expected.get("event_timestamp"));
+          }
+          if (expected.containsKey("actor_user_id") || expected.containsKey("actor_id")) {
+            // Delivered contract calls the field `actor_id`. Feature file uses `actor_user_id`
+            // in one row — accept either alias to preserve author intent.
+            String expectedActor = expected.getOrDefault("actor_id", expected.get("actor_user_id"));
+            assertEnvelopeFieldEquals(event, "actor_id", expectedActor);
+          }
+          if (expected.containsKey("source_id")) {
+            UUID expectedSourceId = requireLabel(expected.get("source_id"));
+            assertThat(event.path("source_id").asText())
+                .as("event source_id (delivered SQL emits claim.id here)")
+                .isEqualTo(expectedSourceId.toString());
+          }
+        });
+  }
+
+  @Then("that event's metadata contains")
+  public void thatEventsMetadataContains(DataTable table) {
+    step(
+        "assert the single event's metadata contains all expected fields",
+        () -> {
+          JsonNode metadata = requireEventsArray().get(0).path("metadata");
+          assertThat(metadata.isObject()).as("metadata is a JSON object").isTrue();
+          metadataMap(table)
+              .forEach(
+                  (k, v) ->
+                      assertThat(metadata.path(k).asText()).as("metadata.%s", k).isEqualTo(v));
+        });
+  }
+
+  @Then("the SUBMISSION event contains a `metadata` object")
+  public void theSubmissionEventContainsAMetadataObject() {
+    step(
+        "assert the SUBMISSION event carries a `metadata` object (extension point)",
+        () -> {
+          JsonNode event = requireSubmissionEvent();
+          assertThat(event.path("metadata").isObject())
+              .as("SUBMISSION event.metadata is a JSON object")
+              .isTrue();
+        });
+  }
+
+  @Then("the `metadata` object is present as an object type, not null and not omitted")
+  public void metadataObjectIsPresentAsObjectNotNull() {
+    step(
+        "assert SUBMISSION event.metadata is present, non-null, and is an object type",
+        () -> {
+          JsonNode metadata = requireSubmissionEvent().path("metadata");
+          assertThat(metadata.isMissingNode()).as("metadata key must be present").isFalse();
+          assertThat(metadata.isNull()).as("metadata must not be JSON null").isFalse();
+          assertThat(metadata.isObject()).as("metadata must be an object").isTrue();
+        });
+  }
+
+  @Then("no submission-only fields leak outside the `metadata` container onto the envelope")
+  public void noSubmissionOnlyFieldsLeakOutsideMetadata() {
+    step(
+        "assert no submission-metadata field (submission_period, office_account_number, "
+            + "area_of_law) appears as a top-level envelope key on the SUBMISSION event",
+        () -> {
+          JsonNode event = requireSubmissionEvent();
+          Set<String> envelopeKeys = new HashSet<>();
+          event.fieldNames().forEachRemaining(envelopeKeys::add);
+          // Every leaked-metadata field would surface as a top-level envelope key; the envelope
+          // must ONLY expose the agreed contract fields.
+          for (String submissionField : SUBMISSION_METADATA_FIELDS) {
+            assertThat(envelopeKeys)
+                .as(
+                    "submission field '%s' must live inside metadata, not on the envelope",
+                    submissionField)
+                .doesNotContain(submissionField);
+          }
+          // Additional guard: the envelope must not carry any keys we haven't agreed to expose.
+          assertThat(envelopeKeys)
+              .as("SUBMISSION event envelope carries only the agreed contract fields")
+              .isSubsetOf(ENVELOPE_FIELDS);
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Thens — unknown-claim-id (@DS1811_2).
+  // ---------------------------------------------------------------------------
+
+  @Then("the endpoint returns the agreed not-found response")
+  public void theEndpointReturnsTheAgreedNotFoundResponse() {
+    step(
+        "assert /history returned HTTP 404 for the unknown claim id",
+        () -> {
+          assertThat(lastStatusCode)
+              .as("status code for GET /history of unknown claim %s", currentClaimId)
+              .isEqualTo(404);
+        });
+  }
+
+  @Then("the response shape matches the existing Claims API claim-not-found contract")
+  public void theResponseShapeMatchesClaimNotFoundContract() {
+    step(
+        "assert the not-found response body carries the standard error contract shape",
+        () -> {
+          // The delivered ClaimNotFoundException extends ClaimsDataException(HttpStatus.NOT_FOUND);
+          // the Spring exception handler serialises it. We accept either the RFC 7807 shape
+          // (`title` / `status` / `detail`) or the legacy `{message, ...}` shape, and require at
+          // least one of them mentions the claim id so callers can diagnose the failure.
+          assertThat(lastResponseBody).as("not-found response body").isNotNull().isNotBlank();
+          assertThat(lastResponseBody.toLowerCase())
+              .as("not-found body mentions the missing claim id")
+              .contains(currentClaimId.toString().toLowerCase());
+        });
+  }
+
+  @Then("no history events are returned in the body")
+  public void noHistoryEventsAreReturnedInTheBody() {
+    step(
+        "assert the not-found response body carries no events[] array",
+        () -> {
+          // A 404 body from ClaimsDataException carries an error payload, NOT a
+          // ClaimHistoryResultSet — so `events` must be absent (or, if present, empty).
+          if (lastResponseBody == null || lastResponseBody.isBlank()) {
+            return;
+          }
+          try {
+            JsonNode body =
+                new com.fasterxml.jackson.databind.ObjectMapper().readTree(lastResponseBody);
+            JsonNode events = body.path("events");
+            if (events.isMissingNode() || events.isNull()) {
+              return;
+            }
+            assertThat(events.isArray() && events.size() == 0)
+                .as("not-found body must not contain history events")
+                .isTrue();
+          } catch (Exception ignored) {
+            // Body isn't JSON — still fine; no events array present.
+          }
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Seeding helpers.
+  // ---------------------------------------------------------------------------
+
+  private void seedClaim() {
+    Submission submission = new Submission();
+    submission.setId(Uuid7.timeBasedUuid());
+    submission.setOfficeAccountNumber("0X001");
+    submission.setSubmissionPeriod("JAN-2025");
+    submission.setAreaOfLaw(AreaOfLaw.LEGAL_HELP);
+    submission.setStatus(SubmissionStatus.CREATED);
+    submission.setCreatedByUserId("bdd-seed-user");
+    submission.setProviderUserId("bdd-seed-user");
+    submission.setCreatedOn(Instant.now());
+    submissionRepository.saveAndFlush(submission);
+
+    Claim claim = new Claim();
+    claim.setId(Uuid7.timeBasedUuid());
+    claim.setSubmission(submission);
+    claim.setStatus(ClaimStatus.VALID);
+    claim.setLineNumber(1);
+    claim.setFeeCode("TEST");
+    claim.setMatterTypeCode("MAT01");
+    claim.setCaseStartDate(LocalDate.of(2025, 1, 1));
+    claim.setCreatedByUserId("bdd-seed-user");
+    claim.setUpdatedByUserId("bdd-seed-user");
+    claimRepository.saveAndFlush(claim);
+    currentClaimId = claim.getId();
+
+    // If the previous step captured a "stored values" table, apply it now.
+    applyPendingSubmissionOverrides();
+  }
+
+  private void applyPendingSubmissionOverrides() {
+    if (pendingSubmissionValues == null || pendingSubmissionValues.isEmpty()) {
+      return;
+    }
+    Map<String, String> vals = pendingSubmissionValues;
+
+    // The delivered SUBMISSION event derives event_timestamp, actor_id and source_id from the
+    // CLAIM row (see JdbcClaimHistoryRepository.HISTORY_SQL SUBMISSION branch). The feature file
+    // labels these as "the parent submission's stored values" — semantically equivalent for the
+    // scenario, so we pin them on the claim.
+    UUID claimId = requireCurrentClaimId();
+
+    // id label — bind whatever the feature file names this to the actual claim id.
+    if (vals.containsKey("id")) {
+      labelToUuid.put(vals.get("id"), claimId);
+    }
+    if (vals.containsKey("created_on")) {
+      jdbcClient
+          .sql("UPDATE claims.claim SET created_on = :ts WHERE id = :id")
+          .param(
+              "ts", OffsetDateTime.ofInstant(Instant.parse(vals.get("created_on")), ZoneOffset.UTC))
+          .param("id", claimId)
+          .update();
+    }
+    if (vals.containsKey("created_by_user_id")) {
+      jdbcClient
+          .sql("UPDATE claims.claim SET created_by_user_id = :u WHERE id = :id")
+          .param("u", vals.get("created_by_user_id"))
+          .param("id", claimId)
+          .update();
+    }
+    // Submission-owned metadata fields — updated on the parent row.
+    UUID submissionId =
+        jdbcClient
+            .sql("SELECT submission_id FROM claims.claim WHERE id = :id")
+            .param("id", claimId)
+            .query(UUID.class)
+            .single();
+    if (vals.containsKey("submission_period")) {
+      jdbcClient
+          .sql("UPDATE claims.submission SET submission_period = :v WHERE id = :id")
+          .param("v", vals.get("submission_period"))
+          .param("id", submissionId)
+          .update();
+    }
+    if (vals.containsKey("office_account_number")) {
+      jdbcClient
+          .sql("UPDATE claims.submission SET office_account_number = :v WHERE id = :id")
+          .param("v", vals.get("office_account_number"))
+          .param("id", submissionId)
+          .update();
+    }
+    if (vals.containsKey("area_of_law")) {
+      // Hibernate stores `AreaOfLaw` via {@code @Enumerated(EnumType.STRING)}, i.e. the enum's
+      // {@code name()} — the same underscore form the feature file uses (e.g. {@code CRIME_LOWER}).
+      // Jackson's {@code @JsonValue} is separate and only affects JSON serialization of the enum
+      // Java type; the SUBMISSION event metadata bag reads {@code s.area_of_law} verbatim from
+      // the row via {@code jsonb_build_object}, so passing the underscore form here surfaces
+      // {@code "CRIME_LOWER"} at the HTTP boundary — matching the feature-file table.
+      jdbcClient
+          .sql("UPDATE claims.submission SET area_of_law = :v WHERE id = :id")
+          .param("v", vals.get("area_of_law"))
+          .param("id", submissionId)
+          .update();
+    }
+    pendingSubmissionValues = new HashMap<>();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Inspection helpers.
+  // ---------------------------------------------------------------------------
+
+  private JsonNode requireEventsArray() {
+    assertThat(lastResponse).as("no /history response captured yet").isNotNull();
+    JsonNode events = lastResponse.path("events");
+    assertThat(events.isArray()).as("response has an `events` JSON array").isTrue();
+    return events;
+  }
+
+  private JsonNode requireSubmissionEvent() {
+    JsonNode events = requireEventsArray();
+    for (JsonNode e : events) {
+      if ("SUBMISSION".equals(e.path("event_type").asText())) {
+        return e;
+      }
+    }
+    throw new AssertionError("No SUBMISSION event on /history timeline");
+  }
+
+  private void assertEnvelopeFieldEquals(JsonNode event, String field, String expected) {
+    assertThat(event.path(field).asText()).as("envelope field '%s'", field).isEqualTo(expected);
+  }
+
+  private void assertTimestamp(JsonNode event, String expectedIso) {
+    Instant expected = Instant.parse(expectedIso);
+    Instant actual = Instant.parse(event.path("event_timestamp").asText());
+    assertThat(actual).as("event_timestamp").isEqualTo(expected);
+  }
+
+  private UUID requireLabel(String label) {
+    UUID id = labelToUuid.get(label);
+    if (id == null) {
+      throw new AssertionError(
+          "No UUID registered for label '" + label + "'. Known labels: " + labelToUuid.keySet());
+    }
+    return id;
+  }
+
+  private UUID requireCurrentClaimId() {
+    if (currentClaimId == null) {
+      throw new AssertionError(
+          "No claim id has been established yet — expected a prior Given step.");
+    }
+    return currentClaimId;
+  }
+
+  // ---------------------------------------------------------------------------
+  // DataTable helpers.
+  // ---------------------------------------------------------------------------
+
+  private static Map<String, String> singleFieldValueMap(DataTable table) {
+    return keyValueMap(table, "field");
+  }
+
+  private static Map<String, String> envelopeMap(DataTable table) {
+    return keyValueMap(table, "envelopeField");
+  }
+
+  private static Map<String, String> metadataMap(DataTable table) {
+    return keyValueMap(table, "metadataField");
+  }
+
+  private static Map<String, String> keyValueMap(DataTable table, String headerKey) {
+    Map<String, String> out = new HashMap<>();
+    for (List<String> row : table.asLists()) {
+      if (row.size() < 2) {
+        continue;
+      }
+      String key = row.get(0);
+      if (headerKey.equalsIgnoreCase(key)) {
+        continue;
+      }
+      out.put(key, row.get(1) == null ? "" : row.get(1));
+    }
+    return out;
+  }
+}

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryTimelineContractSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryTimelineContractSteps.java
@@ -160,7 +160,7 @@ public class ClaimHistoryTimelineContractSteps {
     step(
         "GET /api/v1/claims/" + currentClaimId + "/history (expect 2xx)",
         () -> {
-          lastResponse = api.getClaimHistory(requireCurrentClaimId());
+          lastResponse = api.getClaimHistoryJson(requireCurrentClaimId());
           lastStatusCode = 200;
           lastResponseBody = lastResponse.toString();
         });

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryTimelineContractSteps.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/ClaimHistoryTimelineContractSteps.java
@@ -111,13 +111,24 @@ public class ClaimHistoryTimelineContractSteps {
         this::seedClaim);
   }
 
+  @And("the claim has the following stored values")
+  @Transactional
+  public void theClaimHasStoredValues(DataTable table) {
+    step(
+        "override claim envelope columns to match the feature-file 'stored values' table",
+        () -> {
+          pendingSubmissionValues.putAll(singleFieldValueMap(table));
+          applyPendingSubmissionOverrides();
+        });
+  }
+
   @And("the parent submission has the following stored values")
   @Transactional
   public void theParentSubmissionHasStoredValues(DataTable table) {
     step(
-        "override submission + claim columns to match the feature-file 'stored values' table",
+        "override submission metadata columns to match the feature-file 'stored values' table",
         () -> {
-          pendingSubmissionValues = singleFieldValueMap(table);
+          pendingSubmissionValues.putAll(singleFieldValueMap(table));
           applyPendingSubmissionOverrides();
         });
   }
@@ -304,16 +315,36 @@ public class ClaimHistoryTimelineContractSteps {
   @Then("the response shape matches the existing Claims API claim-not-found contract")
   public void theResponseShapeMatchesClaimNotFoundContract() {
     step(
-        "assert the not-found response body carries the standard error contract shape",
+        "assert the not-found response body carries the standard RFC 9457 Problem Detail shape "
+            + "(see DataClaimsExceptionHandler.buildProblemDetailResponse)",
         () -> {
-          // The delivered ClaimNotFoundException extends ClaimsDataException(HttpStatus.NOT_FOUND);
-          // the Spring exception handler serialises it. We accept either the RFC 7807 shape
-          // (`title` / `status` / `detail`) or the legacy `{message, ...}` shape, and require at
-          // least one of them mentions the claim id so callers can diagnose the failure.
           assertThat(lastResponseBody).as("not-found response body").isNotNull().isNotBlank();
-          assertThat(lastResponseBody.toLowerCase())
-              .as("not-found body mentions the missing claim id")
-              .contains(currentClaimId.toString().toLowerCase());
+          JsonNode body =
+              new com.fasterxml.jackson.databind.ObjectMapper().readTree(lastResponseBody);
+          // RFC 9457 mandatory-when-present fields for a 404 from this handler: type, title,
+          // status, detail, instance. The handler also copies detail into a backwards-compat
+          // `message` property. Anchoring on these keys catches HTML/plain-text regressions.
+          assertThat(body.path("status").asInt()).as("Problem Detail `status`").isEqualTo(404);
+          assertThat(body.path("title").asText())
+              .as("Problem Detail `title`")
+              .isEqualTo("Not Found");
+          assertThat(body.path("type").asText())
+              .as("Problem Detail `type` URI")
+              .isNotBlank()
+              .startsWith("http");
+          assertThat(body.path("detail").asText())
+              .as("Problem Detail `detail` (must reference the missing claim id)")
+              .containsIgnoringCase(currentClaimId.toString());
+          assertThat(body.path("instance").asText())
+              .as("Problem Detail `instance` (must reference the requested endpoint URI)")
+              .contains("/history");
+          // Backwards-compat property emitted by DataClaimsExceptionHandler.
+          assertThat(body.has("message"))
+              .as("Problem Detail must carry the backwards-compat `message` property")
+              .isTrue();
+          assertThat(body.path("message").asText())
+              .as("`message` must mirror `detail`")
+              .isEqualTo(body.path("detail").asText());
         });
   }
 
@@ -383,9 +414,10 @@ public class ClaimHistoryTimelineContractSteps {
     Map<String, String> vals = pendingSubmissionValues;
 
     // The delivered SUBMISSION event derives event_timestamp, actor_id and source_id from the
-    // CLAIM row (see JdbcClaimHistoryRepository.HISTORY_SQL SUBMISSION branch). The feature file
-    // labels these as "the parent submission's stored values" — semantically equivalent for the
-    // scenario, so we pin them on the claim.
+    // CLAIM row (see JdbcClaimHistoryRepository.HISTORY_SQL SUBMISSION branch), and derives its
+    // metadata fields from the parent SUBMISSION row. The feature file provides these values
+    // via two separate "stored values" tables ("the claim has ..." and "the parent submission
+    // has ..."); this helper routes each key to whichever table it belongs on.
     UUID claimId = requireCurrentClaimId();
 
     // id label — bind whatever the feature file names this to the actual claim id.

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddApiStepSupport.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddApiStepSupport.java
@@ -275,11 +275,13 @@ public class BddApiStepSupport {
 
   /**
    * Fetches the unified claim-history timeline for {@code claimId} via {@code GET
-   * /api/v1/claims/{claimId}/history}. Returns the raw {@link JsonNode} so callers can distinguish
-   * an explicit JSON {@code null} in the metadata bag from a missing key — a critical distinction
-   * for the claim-history timeline scenarios (DSTEW-1811 / -1812 / -1813 / -1814 / -1815).
+   * /api/v1/claims/{claimId}/history} and returns the raw JSON response.
+   *
+   * <p>The raw {@link JsonNode} is intentionally retained so callers can distinguish an explicit
+   * JSON {@code null} in the metadata bag from a missing key — a critical distinction for the
+   * claim-history timeline scenarios (DSTEW-1811 / -1812 / -1813 / -1814 / -1815).
    */
-  public JsonNode getClaimHistory(UUID claimId) throws IOException {
+  public JsonNode getClaimHistoryJson(UUID claimId) throws IOException {
     HttpHeaders headers = new HttpHeaders();
     headers.add(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN);
     HttpEntity<Void> request = new HttpEntity<>(headers);

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddApiStepSupport.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddApiStepSupport.java
@@ -7,6 +7,7 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestCon
 import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.CREATE_CLAIM_PATH;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.CREATE_SUBMISSION_PATH;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.GET_BULK_SUBMISSION_BY_ID_PATH;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.GET_CLAIM_HISTORY_PATH;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.GET_SUBMISSIONS_PATH;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.GET_SUBMISSION_BY_ID_PATH;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.bdd.config.BddTestConstants.PATCH_BULK_SUBMISSION_PATH;
@@ -269,6 +270,29 @@ public class BddApiStepSupport {
             request,
             String.class,
             bulkSubmissionId);
+    return objectMapper.readTree(response.getBody());
+  }
+
+  /**
+   * Fetches the unified claim-history timeline for {@code claimId} via {@code GET
+   * /api/v1/claims/{claimId}/history}. Returns the raw {@link JsonNode} so callers can distinguish
+   * an explicit JSON {@code null} in the metadata bag from a missing key — a critical distinction
+   * for the claim-history timeline scenarios (DSTEW-1811 / -1812 / -1813 / -1814 / -1815).
+   */
+  public JsonNode getClaimHistory(UUID claimId) throws IOException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN);
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            serverInfo.baseUrl() + GET_CLAIM_HISTORY_PATH,
+            HttpMethod.GET,
+            request,
+            String.class,
+            claimId);
+    context.setLastStatusCode(response.getStatusCode().value());
+    context.setLastResponseBody(response.getBody());
     return objectMapper.readTree(response.getBody());
   }
 

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
@@ -42,7 +42,7 @@ public final class BddStepFailures {
   public static void step(String contextDescription, ThrowingRunnable body) {
     try {
       body.run();
-    } catch (Throwable cause) {
+    } catch (Exception | AssertionError cause) {
       throw rewrap(contextDescription, cause);
     }
   }
@@ -51,7 +51,7 @@ public final class BddStepFailures {
   public static <T> T step(String contextDescription, ThrowingSupplier<T> body) {
     try {
       return body.get();
-    } catch (Throwable cause) {
+    } catch (Exception | AssertionError cause) {
       throw rewrap(contextDescription, cause);
     }
   }

--- a/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
+++ b/claims-data/service/src/bddTest/java/uk/gov/justice/laa/dstew/payments/claimsdata/bdd/steps/support/BddStepFailures.java
@@ -1,0 +1,87 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.bdd.steps.support;
+
+/**
+ * Small failure-translation wrapper for BDD step methods.
+ *
+ * <p><b>Standing rule (2026-08-13, DSTEW-1813 onward):</b> every step-definition method wraps its
+ * body in {@link #step(String, ThrowingRunnable)} (or its supplier overload). The {@code
+ * contextDescription} is a plain-English sentence naming the verb + noun and any scenario-scoped
+ * identifiers (claim id, tag id, expected value) that make a failure diagnosable at a glance
+ * without opening the Java stack trace.
+ *
+ * <p>On failure the wrapper rethrows an {@link AssertionError} whose message is {@code [BDD step
+ * failed] <contextDescription> — <cause summary>} and chains the original throwable via {@link
+ * Throwable#initCause(Throwable)}, so the Cucumber HTML report and the JUnit XML both show the
+ * friendly line first and the deep stack second. AssertJ assertions inside the body still use
+ * {@code .as("…")} to describe the specific assertion; the wrapper prepends the outer step context
+ * so both show side by side.
+ */
+public final class BddStepFailures {
+
+  private BddStepFailures() {
+    // utility class
+  }
+
+  /** Body that returns nothing and may throw any checked/unchecked exception. */
+  @FunctionalInterface
+  public interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  /** Body that returns a value and may throw any checked/unchecked exception. */
+  @FunctionalInterface
+  public interface ThrowingSupplier<T> {
+    T get() throws Exception;
+  }
+
+  /**
+   * Runs {@code body} inside a friendly-failure envelope. On any thrown exception, rewraps as
+   * {@link AssertionError} with a prefixed, business-language message and preserves the original
+   * cause + stack via {@link Throwable#initCause(Throwable)}.
+   */
+  public static void step(String contextDescription, ThrowingRunnable body) {
+    try {
+      body.run();
+    } catch (Throwable cause) {
+      throw rewrap(contextDescription, cause);
+    }
+  }
+
+  /** Supplier overload — same behaviour as {@link #step(String, ThrowingRunnable)}. */
+  public static <T> T step(String contextDescription, ThrowingSupplier<T> body) {
+    try {
+      return body.get();
+    } catch (Throwable cause) {
+      throw rewrap(contextDescription, cause);
+    }
+  }
+
+  private static AssertionError rewrap(String contextDescription, Throwable cause) {
+    String summary = summarise(cause);
+    String prefix = "[BDD step failed] " + contextDescription;
+    String message = (summary == null || summary.isBlank()) ? prefix : (prefix + " — " + summary);
+    AssertionError rewrapped = new AssertionError(message);
+    // Preserve original stack + cause so the test report drills down into the real failure point.
+    rewrapped.initCause(cause);
+    return rewrapped;
+  }
+
+  /**
+   * Short human-readable summary of the failure. For AssertJ / AssertionError bodies (which already
+   * carry a friendly {@code .as("…")} description) we surface the message verbatim so the report
+   * shows both the outer step context and the specific assertion side by side. For other throwable
+   * types we prefix the simple class name so the reader can tell at a glance whether the failure
+   * came from an assertion, an I/O error, an HTTP status, etc.
+   */
+  private static String summarise(Throwable cause) {
+    if (cause == null) {
+      return null;
+    }
+    String raw = cause.getMessage();
+    String message = (raw == null || raw.isBlank()) ? cause.getClass().getSimpleName() : raw;
+    if (cause instanceof AssertionError) {
+      return message;
+    }
+    return cause.getClass().getSimpleName() + ": " + message;
+  }
+}

--- a/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryTimelineContract.feature
+++ b/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryTimelineContract.feature
@@ -47,22 +47,24 @@ Feature: Claim history timeline — contract skeleton & SUBMISSION event
   @smoke @DS1811_1
   Scenario: SUBMISSION event returned with the common envelope + submission metadata
     Given a claim exists that has been submitted but never amended, assessed or voided
+    And the claim has the following stored values
+      | field              | value                |
+      | id                 | claim-uuid-1         |
+      | created_on         | 2026-04-22T11:26:00Z |
+      | created_by_user_id | user-abc             |
     And the parent submission has the following stored values
-      | field                 | value                |
-      | id                    | sub-uuid-1           |
-      | created_on            | 2026-04-22T11:26:00Z |
-      | created_by_user_id    | user-abc             |
-      | submission_period     | APR-2026             |
-      | office_account_number | 0X123Y               |
-      | area_of_law           | CRIME_LOWER          |
+      | field                 | value       |
+      | submission_period     | APR-2026    |
+      | office_account_number | 0X123Y      |
+      | area_of_law           | CRIME_LOWER |
     When I request the claim history timeline
     Then the response contains exactly one event
     And that event matches the following common envelope
       | envelopeField    | value                |
       | event_type       | SUBMISSION           |
       | event_timestamp  | 2026-04-22T11:26:00Z |
-      | actor_user_id    | user-abc             |
-      | source_id        | sub-uuid-1           |
+      | actor_id         | user-abc             |
+      | source_id        | claim-uuid-1         |
     And that event's metadata contains
       | metadataField         | value       |
       | submission_period     | APR-2026    |

--- a/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryTimelineContract.feature
+++ b/claims-data/service/src/bddTest/resources/features/bdd/claimHistoryTimelineContract.feature
@@ -1,0 +1,102 @@
+@Regression
+@claimHistory
+@dstew-1811
+Feature: Claim history timeline — contract skeleton & SUBMISSION event
+
+  # Jira: DSTEW-1811 (1645-A) (parent: DSTEW-1645 → DSTEW-1999)
+  # Endpoint: GET /api/v1/claims/{claimId}/history  (indicative; final names
+  #                                                  agreed in this story)
+  #
+  # First child of the Claim History Timeline API. Ships the contract skeleton
+  # + working SUBMISSION event so the envelope is proven against real data
+  # before the richer event types land in DSTEW-1812/1813/1814/1815.
+  #
+  # Common event envelope (contract this story owns):
+  #   event_type              stable machine-readable, from
+  #                             {SUBMISSION, AMENDMENT, ASSESSMENT, VOID}
+  #   event_timestamp
+  #   actor_user_id           populated ALWAYS (fallback SYSTEM/UNAVAILABLE
+  #                             when source has no user id — never omitted)
+  #   source_id               submission | amendment | assessment UUID
+  #   metadata                extension container — child tickets add fields
+  #
+  # SUBMISSION source mapping (claims.submission):
+  #   event_timestamp             ← created_on
+  #   actor_user_id               ← created_by_user_id  (else fallback)
+  #   source_id                   ← id
+  #   metadata.submission_period  ← submission_period
+  #   metadata.office_account_number ← office_account_number
+  #   metadata.area_of_law        ← area_of_law
+  #
+  # Coverage review (2026-08-11): `ClaimHistoryControllerIntegrationTest`
+  # covers happy-path SUBMISSION response at controller level. Gaps this
+  # file closes: (a) actor fallback when `created_by_user_id` is null;
+  # (b) agreed not-found shape for unknown claim id; (c) metadata container
+  # is present + shape-stable even for a submission-only history so the
+  # extension point can't drift silently. All BDD-observable.
+  #
+  # OUT OF SCOPE (delegated to children — do NOT add here):
+  #   * AMENDMENT event content        → DSTEW-1813 (future file)
+  #   * ASSESSMENT / VOID event content → DSTEW-1812 (future file)
+  #   * Field-level diff detail        → DSTEW-1814 (future file)
+  #   * FSP / escape metadata          → claimHistoryAmendmentEvents.feature (DSTEW-1815)
+  #   * Cross-cutting parent guarantees → claimHistoryTimelineParent.feature (DSTEW-1645)
+  #   * Display-name lookup for user ids → AaBC UI concern
+  #   * New Matter Starts events       → excluded from claim timeline
+
+  @smoke @DS1811_1
+  Scenario: SUBMISSION event returned with the common envelope + submission metadata
+    Given a claim exists that has been submitted but never amended, assessed or voided
+    And the parent submission has the following stored values
+      | field                 | value                |
+      | id                    | sub-uuid-1           |
+      | created_on            | 2026-04-22T11:26:00Z |
+      | created_by_user_id    | user-abc             |
+      | submission_period     | APR-2026             |
+      | office_account_number | 0X123Y               |
+      | area_of_law           | CRIME_LOWER          |
+    When I request the claim history timeline
+    Then the response contains exactly one event
+    And that event matches the following common envelope
+      | envelopeField    | value                |
+      | event_type       | SUBMISSION           |
+      | event_timestamp  | 2026-04-22T11:26:00Z |
+      | actor_user_id    | user-abc             |
+      | source_id        | sub-uuid-1           |
+    And that event's metadata contains
+      | metadataField         | value       |
+      | submission_period     | APR-2026    |
+      | office_account_number | 0X123Y      |
+      | area_of_law           | CRIME_LOWER |
+
+  @DS1811_2
+  Scenario: Unknown claim id returns the agreed not-found response
+    Given no claim exists for claim id "00000000-0000-0000-0000-000000000000"
+    When I request the claim history timeline for that claim id
+    Then the endpoint returns the agreed not-found response
+    And the response shape matches the existing Claims API claim-not-found contract
+    And no history events are returned in the body
+
+  # De-scoped from BDD (2026-08-13) — audit trail carried in the reporting ledger:
+  #   * @DS1811_3 — actor fallback when `created_by_user_id` is null. The delivered
+  #     SUBMISSION event derives `actor_id` from `claim.created_by_user_id` via
+  #     `COALESCE(c.created_by_user_id, 'SYSTEM')` in `HISTORY_SQL`. However every
+  #     migration that has ever touched `claim.created_by_user_id` (V3 originally,
+  #     no later relaxation) declares the column `TEXT NOT NULL`, so a null value
+  #     cannot be inserted through any code path — Postgres blocks the write. The
+  #     COALESCE-to-`SYSTEM` branch is defensive dead code end-to-end and cannot be
+  #     exercised from the BDD tier. The scenario is removed until either (a) the
+  #     column is relaxed, or (b) product formally closes the fallback requirement
+  #     as unreachable.
+
+  @DS1811_4
+  Scenario: Metadata container is present and shape-stable — extension point for child tickets
+    # Guards the contract extension point: 1812/1813/1814/1815 add fields to
+    # metadata. The container must exist even on a submission-only history
+    # so downstream events extend the same shape rather than reshape it.
+    Given a claim exists that has been submitted but never amended, assessed or voided
+    When I request the claim history timeline
+    Then the SUBMISSION event contains a `metadata` object
+    And the `metadata` object is present as an object type, not null and not omitted
+    And no submission-only fields leak outside the `metadata` container onto the envelope
+


### PR DESCRIPTION
## What

Adds Cucumber BDD coverage for the **contract skeleton owner** of `GET /api/v1/claims/{claimId}/history` (DSTEW-1811 / 1645-A) — the common envelope shape (`event_type`, `event_timestamp`, `actor_id`, `source_id`, `metadata` container) that DSTEW-1812 / -1813 / -1814 / -1815 all defer to, plus the SUBMISSION-event source mapping.

## Scope

Read-side only. No production code changes — all additions live under `claims-data/service/src/bddTest`.

## ⚠️ De-scoped scenarios (audit)

**One scenario from the source branch could NOT be enabled against `main` because the underlying constraint blocks the data shape it asserts on.** Delivery gap, not a testing shortcut. Called out inline in the feature file's de-scope banner.

| Tag | One-line reason | Blocks |
|---|---|---|
| `@DS1811_3` | Actor fallback when `created_by_user_id` is null. `HISTORY_SQL` implements it via `COALESCE(c.created_by_user_id, 'SYSTEM') AS actor_id`, but `claim.created_by_user_id` has been `TEXT NOT NULL` since V3 (`V3__create_claim_table.sql`) with no later relaxation. Postgres blocks any null insert, so the fallback branch is **defensive dead code** end-to-end — cannot be exercised from the BDD tier. | Product decision: close as unreachable (recommended, since the branch only fires for data that cannot exist) OR relax the constraint to allow legacy nulls. |

## Scenarios (`@dstew-1811`)

| Tag | Purpose |
|---|---|
| `@DS1811_1` | SUBMISSION envelope + metadata assembled from a real claim + parent submission (`event_type=SUBMISSION`, `event_timestamp=claim.created_on`, `actor_id=claim.created_by_user_id`, `source_id=claim.id`; `metadata` carries `submission_period`, `office_account_number`, `area_of_law`). |
| `@DS1811_2` | Unknown claim id → 404 via `ClaimNotFoundException`; body carries the standard error contract and mentions the missing claim id; no `events[]` leaked in the body. |
| `@DS1811_4` | Metadata container is present, non-null, and shape-stable so 1812/1813/1814/1815 can extend it; no submission-only fields leak onto the top-level envelope. |

## Structural changes

- **Standing-rule helper — `BddStepFailures.step(context, body)`** (`…bdd/steps/support/BddStepFailures.java`). Every step body wraps its logic in `BddStepFailures.step("...", () -> { ... })` so on failure the Cucumber HTML report shows `[BDD step failed] <context> — <cause summary>` before the stack trace. Same file added by #428 / #430; will merge cleanly with either.
- **`BddApiStepSupport.getClaimHistory(UUID)`** — HTTP helper for `GET /api/v1/claims/{claimId}/history` returning `JsonNode`.
- **`BddTestConstants.GET_CLAIM_HISTORY_PATH`** — path constant.

### Design notes

- **SUBMISSION event `source_id` = claim.id** (not submission.id). Delivered SQL: `c.id AS source_id`. Feature-file labels like `"sub-uuid-1"` bind to the seeded claim's UUID so assertions match the emitted response. Called out in the steps-class Javadoc.
- **`AreaOfLaw` enum-storage**: Hibernate uses `@Enumerated(EnumType.STRING)` → DB stores `.name()` form (`CRIME_LOWER` with underscore). Jackson's `@JsonValue` (`"CRIME LOWER"` with space) is separate and only affects Java-object JSON serialization. The SUBMISSION-metadata `area_of_law` reads verbatim from the row via `jsonb_build_object`, so the underscore form surfaces at the HTTP boundary — matching the feature-file table.
- **`Claim.createdOn` immutability**: DSTEW-2051's fix made this `@Column(nullable = false, updatable = false)`. Pinning the timestamp for `@DS1811_1` uses a native SQL UPDATE to bypass Hibernate's immutability guard — same pattern used by 1812.
- **`OffsetDateTime` at the JDBC boundary**: PG driver rejects raw `java.time.Instant` (`Can't infer the SQL type...`); wrap in `OffsetDateTime.ofInstant(instant, ZoneOffset.UTC)`.

## Local vs UAT

Local-only. Seeded through JPA + native SQL in step logic; asserted against the live REST endpoint via `TestRestTemplate` (using the standard `AUTHORIZATION_TOKEN` from `ClaimsDataTestUtil` for the direct 4xx-observing path in `@DS1811_2`). No UAT hooks.

## Endpoints exercised

- `GET /api/v1/claims/{claimId}/history`

## Verification

- `./gradlew :claims-data:service:spotlessCheck` — clean.
- `./gradlew :claims-data:service:bddTest -Dcucumber.filter.tags=@dstew-1811` — **3/3 in-scope pass**.
- `./gradlew :claims-data:service:bddTest` — **79/79 pass** (full BDD suite, no regressions).

## Checklist

- [x] Story confirmed delivered on `main` (`f24734a7 feat(DSTEW-1645): claim-history read contract by claim ID (SUBMISSION timeline) (#386)` — 1811 is the 1645-A envelope split, delivered as part of the same commit).
- [x] Feature file copied 1:1 from `DSTEW-1999-amend-claims-bdd-scenarios` and adjusted only to remove undeliverable scenarios (banner + PR audit block document the reasons).
- [x] All step methods use the new `BddStepFailures.step(...)` wrapper.
- [x] No production code changed.
- [x] No unrelated files staged.

## Jira

- DSTEW-1811

