### PR TITLE
infra(DSTEW-2144): make rolling deployments safer

### DIFF
--- a/.helm/data-claims-api/templates/deployment.yaml
+++ b/.helm/data-claims-api/templates/deployment.yaml
@@ -8,11 +8,12 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  minReadySeconds: 15
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
-      maxSurge: 100%
+      maxSurge: 1
   selector:
     matchLabels:
       {{- include "data-claims-api.selectorLabels" . | nindent 6 }}
@@ -20,9 +21,8 @@ spec:
     metadata:
       labels:
         {{- include "data-claims-api.selectorLabels" . | nindent 8 }}
-      annotations:
-        releaseTime: {{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC"| quote }}
     spec:
+      terminationGracePeriodSeconds: 60
       serviceAccountName: "{{ .Values.service_account.name }}"
       containers:
         - name: {{ .Chart.Name }}

--- a/claims-data/service/src/main/resources/application.yml
+++ b/claims-data/service/src/main/resources/application.yml
@@ -44,6 +44,11 @@ spring:
     properties:
       hibernate:
         default_schema: claims
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+
+server:
+  shutdown: graceful
 
 # Local connection details for dev, overridden in other envs
 aws:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2144)

Improve rollout safety in Kubernetes by reducing the chance of all pods recycling at once during a Helm upgrade.

- enable graceful shutdown in Spring Boot
- add a shutdown phase timeout
- require pods to remain ready before counting as available
- limit rollout surge to one pod at a time
- add a termination grace period for in-flight request handling
- stop forcing pod restarts on no-op Helm upgrades

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
