### PR TITLE
fix(logging): use deployed image tag as service version

### DIFF
--- a/.helm/data-claims-api/templates/deployment.yaml
+++ b/.helm/data-claims-api/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            - name: SERVICE_VERSION
+              value: {{ .Values.image.tag | quote }}
             - name: AUTHORIZED_CLIENTS
               valueFrom:
                 secretKeyRef:

--- a/claims-data/service/src/main/resources/application.yml
+++ b/claims-data/service/src/main/resources/application.yml
@@ -131,7 +131,7 @@ logging:
     ecs:
       service:
         name: ${spring.application.name:default}
-        version: ${spring.application.version:default}
+        version: ${SERVICE_VERSION:unknown}
         environment: ${spring.profiles.active:default}
         node_name: ${HOSTNAME:unknown}
 


### PR DESCRIPTION
## What

- Having migrated from the Gradle Release Plugin, the logged versions has been the static Gradle-derived application version `0.0.0-SNAPSHOT`
- This change replaces the static Gradle-derived application version in ECS structured logs
- Populate `service.version` from a `SERVICE_VERSION` environment variable
- Set `SERVICE_VERSION` from the Helm image tag, ensuring logs identify the deployed release image or preview commit

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
