### PR TITLE
fix: Helm ServiceMonitor indentation

### DIFF
--- a/.helm/data-claims-api/templates/serviceMonitor.yaml
+++ b/.helm/data-claims-api/templates/serviceMonitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "data-claims-api.labels" . | nindent 4 }}
+      {{- include "data-claims-api.labels" . | nindent 6 }}
   endpoints:
     - port: {{ .Chart.Name }}-management
       interval: 15s


### PR DESCRIPTION
## What

CP s been noticing a lot of errors from prometheus, telling us it's scraping out of order timestamps.

The cause of that looks to be service monitors in the UAT namespace (due to the ephemeral environment) aren't selecting their corresponding service properly, so it's scraping much more than it should and ends up reporting duplicate metrics.

There was a missing indentation in the helm chart, as the labels aren't under `spec.selector.matchLabels`, they are inline.

Reference CP Issue: https://github.com/ministryofjustice/cloud-platform/issues/8452

## Checklist

Before you ask people to review this PR please ensure the following and mark as complete when done:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
- [ ] If applicable, you have executed the end-to-end (E2E) tests using the [bulk-submission-and-fee-scheme-tests-](https://github.com/ministryofjustice/bulk-submission-and-fee-scheme-tests-) repository and confirmed they pass.
